### PR TITLE
Implement zero-arg functions. Closes #5.

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -308,6 +308,8 @@ fn eval_expr_with_witness(
             if head == lambda {
                 let (args, body) = store.car_cdr(&rest);
                 let (arg, _rest) = if args == Expression::Nil {
+                    // (LAMBDA () STUFF)
+                    // becomes (LAMBDA (DUMMY) STUFF)
                     (dummy_arg, Expression::Nil)
                 } else {
                     store.car_cdr(&args)


### PR DESCRIPTION
The implementation simply desugars each zero-arg function into
a one-argument function taking nil.