### PR TITLE
[RETRACTED] Don't make thunk in eval pass.

### DIFF
--- a/src/proof.rs
+++ b/src/proof.rs
@@ -323,7 +323,7 @@ mod tests {
                      (c 2))
                 (/ (+ a b) c))",
             Expression::num(3),
-            23,
+            17,
             true, // Always check Groth16 in at least one test.
             true,
             100,
@@ -336,7 +336,7 @@ mod tests {
         outer_prove_aux(
             &"(+ 1 2)",
             Expression::num(3),
-            5,
+            3,
             DEFAULT_CHECK_GROTH16,
             true,
             100,
@@ -349,7 +349,7 @@ mod tests {
         outer_prove_aux(
             &"(eq 5 5)",
             Expression::Sym("T".to_string()),
-            5,
+            3,
             DEFAULT_CHECK_GROTH16,
             true,
             100,
@@ -364,7 +364,7 @@ mod tests {
         outer_prove_aux(
             &"(= 5 5)",
             Expression::Sym("T".to_string()),
-            5,
+            3,
             DEFAULT_CHECK_GROTH16,
             true,
             100,
@@ -373,7 +373,7 @@ mod tests {
         outer_prove_aux(
             &"(= 5 6)",
             Expression::Nil,
-            5,
+            3,
             DEFAULT_CHECK_GROTH16,
             true,
             100,
@@ -386,7 +386,7 @@ mod tests {
         outer_prove_aux(
             &"(if t 5 6)",
             Expression::num(5),
-            4,
+            3,
             DEFAULT_CHECK_GROTH16,
             true,
             100,
@@ -396,7 +396,7 @@ mod tests {
         outer_prove_aux(
             &"(if t 5 6)",
             Expression::num(5),
-            4,
+            3,
             DEFAULT_CHECK_GROTH16,
             true,
             100,
@@ -408,7 +408,7 @@ mod tests {
         outer_prove_aux(
             &"(if t (+ 5 5) 6)",
             Expression::num(10),
-            8,
+            5,
             DEFAULT_CHECK_GROTH16,
             true,
             100,
@@ -427,7 +427,7 @@ mod tests {
                                      (* base ((exp base) (- exponent 1))))))))
                 ((exp 5) 3))",
             Expression::num(125),
-            117,
+            90,
             DEFAULT_CHECK_GROTH16,
             true,
             200,
@@ -447,7 +447,7 @@ mod tests {
                                           (((exp base) (- exponent 1)) (* acc base))))))))
                 (((exp 5) 5) 1))",
             Expression::num(3125),
-            248,
+            201,
             DEFAULT_CHECK_GROTH16,
             true,
             300,


### PR DESCRIPTION
~~We never actually need to return a thunk from the eval phase. Any time that happens, it is always immediately invoked in the next iteration. Therefore, we can always just invoke the continuation immediately from the eval phase, saving one iteration in every such case.~~

~~We still need the thunks when they are produced when invoking continuations (in `invoke_continuation`). Otherwise we would have recursive loops — which cannot be flattened into a circuit.~~

~~The point of this PR is that this trampolining mechanism for implementing continuations-invoking-continuations is the *only* reason we need the thunks. The previous flow was a historical artifact which had not yet been fully cleaned up.~~

~~I had always planned to make this optimization but had previously believed it depended on assumptions which would exist when iterating the inner circuit (future work). After explaining this idea to @emmorais today, I realized we might be able to do better. So the explanatory conversation was useful: it made me rethink an old assumption.~~

~~If you look at the tests, you'll see a significant (looks like 20-30%) reduction in iterations. This is great, since reducing iteration count translates into a *direct* performance improvement for any program.~~
