### PR TITLE
Simplify make_thunk.

### DIFF
--- a/src/gadgets/constraints.rs
+++ b/src/gadgets/constraints.rs
@@ -163,12 +163,12 @@ pub fn div<F: PrimeField, CS: ConstraintSystem<F>>(
         let mut tmp = a.get_value().ok_or(SynthesisError::AssignmentMissing)?;
         let inv = (&b.get_value().ok_or(SynthesisError::AssignmentMissing)?).invert();
 
-        Ok(if inv.is_some().into() {
+        if inv.is_some().into() {
             inv.map(|i| tmp.mul_assign(i));
             Ok(tmp)
         } else {
             Err(SynthesisError::DivisionByZero)
-        }?)
+        }
     })?;
 
     // a = b * res

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -323,7 +323,7 @@ mod tests {
                      (c 2))
                 (/ (+ a b) c))",
             Expression::num(3),
-            23,
+            24,
             true, // Always check Groth16 in at least one test.
             true,
             100,


### PR DESCRIPTION
This PR provides some refactoring to simplify, adds some documentation (in comments). It's primarily motivated by #22. Now that `make_thunk` is much simpler, it should be easier to get to the bottom of the issue.

Note that constraint count did go up by one in many places because we were wrongly omitting creation of tail continuation's when the previous continuation was outermost. The problem is that the wrong environment was then returned. In addition being technically incorrect, it also means internal lexical information could be leaked — which is definitely a problem in a zero-knowledge context where the expectation is that only the final result will appear in the public inputs.

Note that the one added constraint won't affect performance generally. It's just a (truly) minimally increased constant overhead.