### PR TITLE
Make fewer thunks again

### DIFF
--- a/src/proof.rs
+++ b/src/proof.rs
@@ -323,7 +323,7 @@ mod tests {
                      (c 2))
                 (/ (+ a b) c))",
             Expression::num(3),
-            24,
+            18,
             true, // Always check Groth16 in at least one test.
             true,
             100,
@@ -336,7 +336,7 @@ mod tests {
         outer_prove_aux(
             &"(+ 1 2)",
             Expression::num(3),
-            5,
+            3,
             DEFAULT_CHECK_GROTH16,
             true,
             100,
@@ -349,7 +349,7 @@ mod tests {
         outer_prove_aux(
             &"(eq 5 5)",
             Expression::Sym("T".to_string()),
-            5,
+            3,
             DEFAULT_CHECK_GROTH16,
             true,
             100,
@@ -364,7 +364,7 @@ mod tests {
         outer_prove_aux(
             &"(= 5 5)",
             Expression::Sym("T".to_string()),
-            5,
+            3,
             DEFAULT_CHECK_GROTH16,
             true,
             100,
@@ -373,7 +373,7 @@ mod tests {
         outer_prove_aux(
             &"(= 5 6)",
             Expression::Nil,
-            5,
+            3,
             DEFAULT_CHECK_GROTH16,
             true,
             100,
@@ -386,7 +386,7 @@ mod tests {
         outer_prove_aux(
             &"(if t 5 6)",
             Expression::num(5),
-            4,
+            3,
             DEFAULT_CHECK_GROTH16,
             true,
             100,
@@ -396,7 +396,7 @@ mod tests {
         outer_prove_aux(
             &"(if t 5 6)",
             Expression::num(5),
-            4,
+            3,
             DEFAULT_CHECK_GROTH16,
             true,
             100,
@@ -408,7 +408,7 @@ mod tests {
         outer_prove_aux(
             &"(if t (+ 5 5) 6)",
             Expression::num(10),
-            8,
+            5,
             DEFAULT_CHECK_GROTH16,
             true,
             100,


### PR DESCRIPTION
NOTE: the diff shown here will be noisy until #23 merges, since this PR builds off that one.

This is a reapplication of #22 applied on top of the changes in #23. The latter help make clearer why the former is indeed safe. For more detail, see comment here: https://github.com/lurk-lang/lurk-rs/pull/23#issuecomment-1013647858

To verify that this is safe, trace all code paths (depending on the `Continuation` variant passed) through `make_thunk` and observe that in all cases but `Tail`, exactly the same result is obtained as if we had instead called `invoke_continuation` — except with one fewer iteration. In the case of `Tail`, we see that calling `invoke_continuation` leads to a branch which ends up calling `make_thunk` anyway. So in that case, we reach the exact same code path after a brief detour.

So, after a long day's journey talking to myself, I now believe the hefty performance improvement via iteration count reduction is valid. Hooray.
