### PR TITLE
Multicase helper refactor

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -2312,10 +2312,10 @@ mod tests {
             let delta = cs.delta(&cs_blank, false);
             assert!(delta == Delta::Equal);
 
-            // println!("{}", print_cs(&cs));
-            assert_eq!(32499, cs.num_constraints());
+            //println!("{}", print_cs(&cs));
+            assert_eq!(31921, cs.num_constraints());
             assert_eq!(20, cs.num_inputs());
-            assert_eq!(32455, cs.aux().len());
+            assert_eq!(31901, cs.aux().len());
 
             let public_inputs = frame.public_inputs(store);
             let mut rng = rand::thread_rng();


### PR DESCRIPTION
Multicase gadget was refactored to avoid repeated constraints. In particular, constraints involving the selected element and the keys were repeated. Hence we included it only once, for the first clause, and reused the selectors in next clauses. 

* For first clause we do the same as in a regular case gadget
* For next clauses we reuse the selectors to get the corresponding values
* Verifies that key were passed in the same ordering for all clauses
* Added unit tests for negative cases
* Added comments