### PR TITLE
Correctly report errors in REPL.

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -108,13 +108,16 @@ pub fn repl<P: AsRef<Path>>(lurk_file: Option<P>) -> Result<()> {
                 if let Some(expr) = s.read(&line) {
                     let (result, _next_env, iterations, next_cont) =
                         Evaluator::new(expr, repl.state.env, &mut s, limit).eval();
+
                     print!("[{} iterations] => ", iterations);
-                    let mut handle = stdout.lock();
-                    result.fmt(&s, &mut handle)?;
-                    println!();
 
                     match next_cont.tag() {
-                        ContTag::Outermost | ContTag::Terminal => (),
+                        ContTag::Outermost | ContTag::Terminal => {
+                            let mut handle = stdout.lock();
+                            result.fmt(&s, &mut handle)?;
+                            println!();
+                        }
+                        ContTag::Error => println!("ERROR!"),
                         _ => println!("Computation incomplete after limit: {}", limit),
                     }
                 }


### PR DESCRIPTION
Although actually evaluating correctly, the REPL was wrongly reporting errors. Therefore, what should have (and secretly was) resulted in an error *appeared* (as reported) to be an 'incomplete computation'.

This is because the response-handling code fell through to the default without a clause to handle the possibility that the final continuation returned was in fact an error.

As an aside, it is suboptimal that we collapse all errors into a single `Continuation::Error`. We should add the ability to attach arbitrary user data, and either use that to label built-in errors — or possibly also create more specific error cases for those. I currently lean toward just allowing arbitrary error data, along with a convention that will allow for extensible error-handling. From that perspective, some structure is likely preferable.


Before:
```
➜  lurk-rs git:(repl-bugs) ✗ bin/lurkrs
    Finished release [optimized] target(s) in 6.26s
     Running `target/release/examples/lurk`
Lurk REPL welcomes you.
> a
[1 iterations] => A
Computation incomplete after limit: 1000000000
>
```

After:
```
➜  lurk-rs git:(repl-bugs) ✗ bin/lurkrs
    Finished release [optimized] target(s) in 0.05s
     Running `target/release/examples/lurk`
Lurk REPL welcomes you.
> a
[1 iterations] => ERROR!
>
```