### PR TITLE
Only pad with trivial Terminal proofs.

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -63,7 +63,7 @@ impl<F: PrimeField> Evaluable<F, Witness<F>> for IO<F> {
 }
 
 impl<F: PrimeField, T: Evaluable<F, Witness<F>> + Clone + PartialEq> Frame<T, Witness<F>> {
-    fn next(&self, store: &mut Store<F>) -> Self {
+    pub(crate) fn next(&self, store: &mut Store<F>) -> Self {
         let input = self.output.clone();
         let (output, witness) = input.reduce(store);
 
@@ -573,7 +573,7 @@ fn apply_continuation<F: PrimeField>(
     witness.apply_continuation_cont = Some(*cont);
 
     let control = match cont.tag() {
-        ContTag::Terminal => unreachable!("Terminal Continuation should never be applied."),
+        ContTag::Terminal | ContTag::Error => Control::Return(*result, *env, *cont),
         ContTag::Dummy => unreachable!("Dummy Continuation should never be applied."),
         ContTag::Outermost => Control::Return(*result, *env, store.intern_cont_terminal()),
         ContTag::Call => match result.tag() {
@@ -789,7 +789,7 @@ fn apply_continuation<F: PrimeField>(
                 unreachable!();
             }
         },
-        ContTag::Simple | ContTag::Error => unreachable!(),
+        ContTag::Simple => unreachable!(),
     };
 
     if control.is_apply_continuation() {

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -239,7 +239,7 @@ mod tests {
         }
 
         let constraint_systems = if check_constraint_systems {
-            Some(CircuitFrame::outer_synthesize(expr, e, &mut s, limit).unwrap())
+            Some(CircuitFrame::outer_synthesize(expr, e, &mut s, limit, false).unwrap())
         } else {
             None
         };


### PR DESCRIPTION
This PR fixes input aggregation. The latest work on instance aggregation in bellperson now has tests passing there (https://github.com/filecoin-project/bellperson/pull/257). However, the previous code here was still failing verification with instance aggregation.

I will write out the problem and fix here, since it is somewhat subtle, worth recording, and relates to a number of convergent characteristics of the system.

- Recall that the SnarkPack Groth16 aggregation (based on the inner-product argument) requires that the number of proofs to be aggregated be a power of two.
- When only aggregating inputs, as previously, we can pad to that number by repeating any valid proof the appropriate number of times.
- This was previously working.
- Input aggregation enforces the constraint that each instance's output is equal to the next instance's input.

Based on this, in the initial implementation, I chose to use the *last* proof as the padding. This is because I know that:
- Terminal output is a fixed-point of reduction. That is, attempts to further reduce an expression which was returned by a Terminal continuation should not change the result.

However, the previous implementation failed because — although any further reduction attempts after a Terminal continuation has been returned should indeed repeat the same results, we were not actually producing a final repetitive post-Terminal reduction. (Absent this need for padding purposes, producing this proof would be wasteful.)

The main substance of this PR is to indeed produce such an extra proof if it will be needed for padding purposes. Although the previous padding mechanism (of simply repeating the final proof) was retained for efficiency, this is conceptually equivalent to simply continuing to extract repeated `next()` results from the evaluator even after the natural 'end' of the sequence. Logically, we could in fact do that. If we did, then the `i` field (which counts iterations of the reduction step) should also be incremented. (In point of fact, we will likely remove this field: it's function should be moved into whatever mechanism manages the iteration — as this mild residual inconsistency makes clear.)

For the sake of consistency, this PR also makes the following changes:
- The circuit did not actually produce valid proofs of the case in question, and that had not yet been exercised. This fixes that.
- The `limit` parameter of evaluation must be a power of 2. Otherwise, since a computation truncated because the limit was reached would not end on a 'repeating' result, the necessary padding would fail to fulfill the constraints of instance aggregation.
- Errors must also be repeated. (This behavior is not tested, and it possible that further work is required to handle correctly. In general, the subtleties of how Error conditions can be proved deterministically are not yet entirely well-defined by the current system. The circuit is a mixture of incomplete and inconsistent with a notional abstract definition of correct behavior.)

As of this work, Lurk is now capable of generating a succinct proof of an arbitrary (terminating) Turing-complete computation!

I left in all the redundant frames, proofs, aggregation, checks, etc. for now — in order to focus this PR on just the relevant fix. Those can be removed in future work, but ideally not until after https://github.com/filecoin-project/bellperson/pull/257 has been accepted. Until then, we should keep the more robust examples in case they are needed to help debug/validate instance aggregation upstream.
