### PR TITLE
Fix non-exact division in Num::U64/Num::U64 case.

### DIFF
--- a/src/num.rs
+++ b/src/num.rs
@@ -119,8 +119,9 @@ impl<F: PrimeField> DivAssign for Num<F> {
         assert!(!rhs.is_zero(), "can not divide by 0");
         match (*self, rhs) {
             (Num::U64(ref mut a), Num::U64(b)) => {
-                if let Some(res) = a.checked_div(b) {
-                    *self = Num::U64(res);
+                // The result will only be Num::U64 if b divides a.
+                if *a % b == 0 {
+                    *self = Num::U64(*a / b);
                 } else {
                     *self = Num::Scalar(F::from(*a) * F::from(b).invert().unwrap());
                 }
@@ -272,7 +273,12 @@ mod tests {
 
         let mut a = Num::<Scalar>::U64(10);
         a /= Num::U64(3);
-        assert_eq!(a, Num::U64(10 / 3));
+
+        // The result is not a Num::U64.
+        assert!(matches!(a, Num::<Scalar>::Scalar(_)));
+
+        a *= Num::U64(3);
+        assert_eq!(a, Num::<Scalar>::Scalar(Scalar::from(10)));
 
         // scalar - scalar - no overflow
         let mut a = Num::Scalar(Scalar::from(10));


### PR DESCRIPTION
There was a bug in the division implementation. Specifically, the previous code used `checked_div` on the assumption that this would catch cases in which we need to promote to Scalar / Scalar division. Presumably, this was an extrapolation from the similar uses of `checked_mul`, `checked_add`, and `checked_sub`. Those are all actually correct, but since U64 is not a field, normal division only gives correct results when exact. We never want, truncating integer division, so `checked_div` is not a strong enough check.

This PR fixes that, with a minimal change to the test to demonstrate the need.

We should create much more thorough tests over ranges of values in combinations which will exercise this behavior. In particular, we should include algebraic identities which must always hold. (This will be useful for later property checking and/or fuzz testing.) I will create a separate issue for that. [Update: #52]