### PR TITLE
Apply cont refactor

### DIFF
--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -2963,7 +2963,7 @@ mod tests {
         let env = empty_sym_env(&store);
 
         // Input is not self-evaluating.
-        let expr = store.read("(+1 2)").unwrap();
+        let expr = store.read("(+ 1 2)").unwrap();
         let input = IO {
             expr: expr.clone(),
             env: env.clone(),


### PR DESCRIPTION
In apply_continuation() we need to construct a hash for the following continuation tags: call, call2, , let, letrec, binop, relop. In those cases, we modified the code to avoid computing many hashes. Instead, we use a multicase to select the hash input, and obtain the desired hash only once. Finally we compute the main multicase as before.