### PR TITLE
Add ScalarStore.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod eval;
 pub mod parser;
 pub mod proof;
 pub mod repl;
+pub mod scalar_store;
 pub mod store;
 pub mod writer;
 

--- a/src/scalar_store.rs
+++ b/src/scalar_store.rs
@@ -1,0 +1,343 @@
+use std::collections::HashMap;
+
+use ff::PrimeField;
+
+use crate::num::Num;
+use crate::store::{Op1, Op2, Pointer, Ptr, Rel2, ScalarContPtr, ScalarPtr, Store, Tag};
+
+/// `ScalarStore` allows realization of a graph of `ScalarPtr`s suitable for serialization to IPLD. `ScalarExpression`s
+/// are composed only of `ScalarPtr`s, so `scalar_map` suffices to allow traverseing an arbitrary DAG.
+#[derive(Default)]
+pub struct ScalarStore<F: PrimeField> {
+    scalar_map: HashMap<ScalarPtr<F>, ScalarExpression<F>>,
+    pending_scalar_ptrs: Vec<ScalarPtr<F>>,
+}
+
+impl<'a, F: PrimeField> ScalarStore<F> {
+    /// Create a new `ScalarStore` and add all `ScalarPtr`s reachable in the scalar representation of `expr`.
+    pub fn new_with_expr(store: &Store<F>, expr: &Ptr<F>) -> Self {
+        let mut new = Self::default();
+        new.add_one_ptr(store, expr);
+        new
+    }
+
+    /// Add all ScalarPtrs representing and reachable from expr.
+    pub fn add_one_ptr(&mut self, store: &Store<F>, expr: &Ptr<F>) {
+        self.add_ptr(store, expr);
+        self.finalize(store);
+    }
+
+    /// Add the `ScalarPtr` representing `expr`, and queue it for proceessing.
+    pub fn add_ptr(&mut self, store: &Store<F>, expr: &Ptr<F>) {
+        // Find the scalar_ptr representing ptr.
+        if let Some(scalar_ptr) = store.get_expr_hash(expr) {
+            self.add(store, expr, scalar_ptr);
+        };
+    }
+
+    /// Add a single `ScalarPtr` and queue it for processing.
+    /// NOTE: This requires that `store.scalar_cache` has been hydrated.
+    fn add_scalar_ptr(&mut self, store: &Store<F>, scalar_ptr: ScalarPtr<F>) {
+        // Find the ptr corresponding to scalar_ptr.
+        if let Some(ptr) = store.scalar_ptr_map.get(&scalar_ptr) {
+            self.add(store, &*ptr, scalar_ptr);
+        }
+    }
+
+    /// Add the `ScalarPtr` and `ScalarExpression` associated with `ptr`. The relationship between `ptr` and
+    /// `scalar_ptr` is not checked here, so `add` should only be called by `add_ptr` and `add_scalar_ptr`, which
+    /// enforce this relationship.
+    fn add(&mut self, store: &Store<F>, ptr: &Ptr<F>, scalar_ptr: ScalarPtr<F>) {
+        let mut new_pending_scalar_ptrs: Vec<ScalarPtr<F>> = Default::default();
+
+        // If `scalar_ptr` is not already in the map, queue its children for processing.
+        self.scalar_map.entry(scalar_ptr).or_insert_with(|| {
+            let scalar_expression =
+                ScalarExpression::from_ptr(store, ptr).expect("ScalarExpression missing for ptr");
+            if let Some(more_scalar_ptrs) = Self::child_scalar_ptrs(&scalar_expression) {
+                new_pending_scalar_ptrs.extend(more_scalar_ptrs);
+            };
+            scalar_expression
+        });
+
+        self.pending_scalar_ptrs.extend(new_pending_scalar_ptrs);
+    }
+
+    /// All the `ScalarPtr`s directly reachable from `scalar_expression`, if any.
+    fn child_scalar_ptrs(scalar_expression: &ScalarExpression<F>) -> Option<Vec<ScalarPtr<F>>> {
+        match scalar_expression {
+            ScalarExpression::Nil => None,
+            ScalarExpression::Cons(car, cdr) => Some(vec![*car, *cdr]),
+            ScalarExpression::Sym(_str) => None,
+            ScalarExpression::Fun {
+                arg,
+                body,
+                closed_env,
+            } => Some(vec![*arg, *body, *closed_env]),
+            ScalarExpression::Num(_) => None,
+            ScalarExpression::Str(_) => None,
+            ScalarExpression::Thunk(_) => None,
+            ScalarExpression::OpaqueCons
+            | ScalarExpression::OpaqueFun
+            | ScalarExpression::OpaqueSym
+            | ScalarExpression::OpaqueStr => None,
+        }
+    }
+
+    /// Unqueue all the pending `ScalarPtr`s and add them, queueing all of their children, then repeat until the queue
+    /// is pending queue is empty.
+    fn add_pending_scalar_ptrs(&mut self, store: &Store<F>) {
+        while let Some(scalar_ptr) = self.pending_scalar_ptrs.pop() {
+            self.add_scalar_ptr(store, scalar_ptr);
+        }
+        assert!(self.pending_scalar_ptrs.is_empty());
+    }
+
+    /// Method which finalizes the `ScalarStore`, ensuring that all reachable `ScalarPtr`s have been added.
+    pub fn finalize(&mut self, store: &Store<F>) {
+        self.add_pending_scalar_ptrs(store);
+    }
+}
+
+impl<'a, F: PrimeField> ScalarExpression<F> {
+    fn from_ptr(store: &Store<F>, ptr: &Ptr<F>) -> Option<Self> {
+        match ptr.tag() {
+            Tag::Nil => Some(ScalarExpression::Nil),
+            Tag::Cons => store
+                .fetch_cons(ptr)
+                .and_then(|(car, cdr)| {
+                    store.get_expr_hash(car).and_then(|car| {
+                        store
+                            .get_expr_hash(cdr)
+                            .map(|cdr| ScalarExpression::Cons(car, cdr))
+                    })
+                })
+                .or(Some(ScalarExpression::OpaqueCons)),
+            Tag::Sym => store
+                .fetch_sym(ptr)
+                .map(|str| ScalarExpression::Sym(str.into()))
+                .or(Some(ScalarExpression::OpaqueSym)),
+            Tag::Fun => store
+                .fetch_fun(ptr)
+                .and_then(|(arg, body, closed_env)| {
+                    store.get_expr_hash(arg).and_then(|arg| {
+                        store.get_expr_hash(body).and_then(|body| {
+                            store.get_expr_hash(closed_env).map(|closed_env| {
+                                ScalarExpression::Fun {
+                                    arg,
+                                    body,
+                                    closed_env,
+                                }
+                            })
+                        })
+                    })
+                })
+                .or(Some(ScalarExpression::OpaqueFun)),
+            Tag::Num => store.fetch_num(ptr).map(|num| ScalarExpression::Num(*num)),
+            Tag::Str => store
+                .fetch_str(ptr)
+                .map(|str| ScalarExpression::Str(str.into()))
+                .or(Some(ScalarExpression::OpaqueSym)),
+
+            Tag::Thunk => unimplemented!(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScalarExpression<F: PrimeField> {
+    Nil,
+    Cons(ScalarPtr<F>, ScalarPtr<F>),
+    Sym(String),
+    Fun {
+        arg: ScalarPtr<F>,
+        body: ScalarPtr<F>,
+        closed_env: ScalarPtr<F>,
+    },
+    Num(Num<F>),
+    Str(String),
+    Thunk(ScalarThunk<F>),
+    /// The `Opaque` variants represent potentially private data which has been added to the store for use in a proof or
+    /// computation, but for which no corresponding `Expression` is known. opaque `ScalarExpressions` therefore have no
+    /// children for the purpose of graph creation or traversal.
+    OpaqueCons,
+    OpaqueFun,
+    OpaqueSym,
+    OpaqueStr,
+}
+
+impl<'a, F: PrimeField> Default for ScalarExpression<F> {
+    fn default() -> Self {
+        Self::Nil
+    }
+}
+
+// Unused for now, but will be needed when we serialize Thunks to IPLD.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScalarThunk<F: PrimeField> {
+    pub(crate) value: ScalarPtr<F>,
+    pub(crate) continuation: ScalarContPtr<F>,
+}
+
+// Unused for now, but will be needed when we serialize Continuations to IPLD.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum ScalarContinuation<F: PrimeField> {
+    Outermost,
+    Call {
+        unevaled_arg: ScalarPtr<F>,
+        saved_env: ScalarPtr<F>,
+        continuation: ScalarContPtr<F>,
+    },
+    Call2 {
+        function: ScalarPtr<F>,
+        saved_env: ScalarPtr<F>,
+        continuation: ScalarContPtr<F>,
+    },
+    Tail {
+        saved_env: ScalarPtr<F>,
+        continuation: ScalarContPtr<F>,
+    },
+    Error,
+    Lookup {
+        saved_env: ScalarPtr<F>,
+        continuation: ScalarContPtr<F>,
+    },
+    Unop {
+        operator: Op1,
+        continuation: ScalarContPtr<F>,
+    },
+    Binop {
+        operator: Op2,
+        saved_env: ScalarPtr<F>,
+        unevaled_args: ScalarPtr<F>,
+        continuation: ScalarContPtr<F>,
+    },
+    Binop2 {
+        operator: Op2,
+        evaled_arg: ScalarPtr<F>,
+        continuation: ScalarContPtr<F>,
+    },
+    Relop {
+        operator: Rel2,
+        saved_env: ScalarPtr<F>,
+        unevaled_args: ScalarPtr<F>,
+        continuation: ScalarContPtr<F>,
+    },
+    Relop2 {
+        operator: Rel2,
+        evaled_arg: ScalarPtr<F>,
+        continuation: ScalarContPtr<F>,
+    },
+    If {
+        unevaled_args: ScalarPtr<F>,
+        continuation: ScalarContPtr<F>,
+    },
+    Let {
+        var: ScalarPtr<F>,
+        body: ScalarPtr<F>,
+        saved_env: ScalarPtr<F>,
+        continuation: ScalarContPtr<F>,
+    },
+    LetRec {
+        var: ScalarPtr<F>,
+        saved_env: ScalarPtr<F>,
+        body: ScalarPtr<F>,
+        continuation: ScalarContPtr<F>,
+    },
+    Emit {
+        continuation: ScalarContPtr<F>,
+    },
+    Dummy,
+    Terminal,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::eval::empty_sym_env;
+    use crate::store::ScalarPointer;
+    use blstrs::Scalar as Fr;
+
+    #[test]
+    fn test_scalar_store() {
+        let test = |src, expected| {
+            let mut s = Store::<Fr>::default();
+            let expr = s.read(src).unwrap();
+            s.hydrate_scalar_cache();
+
+            let scalar_store = ScalarStore::new_with_expr(&s, &expr);
+            assert_eq!(expected, scalar_store.scalar_map.len());
+        };
+
+        // Four atoms, four conses (four-element list), and NIL.
+        test("symbol", 1);
+        test("(1 . 2)", 3);
+        test("(+ 1 2 3)", 9);
+        test("(+ 1 2 (* 3 4))", 14);
+        // String are handled.
+        test("(+ 1 2 (* 3 4) \"asdf\" )", 16);
+        // Duplicate strings or symbols appear only once.
+        test("(+ 1 2 2 (* 3 4) \"asdf\" \"asdf\")", 18);
+    }
+
+    #[test]
+    fn test_scalar_store_opaque_cons() {
+        let mut store = Store::<Fr>::default();
+
+        let num1 = store.num(123);
+        let num2 = store.num(987);
+        let cons = store.intern_cons(num1, num2);
+        let cons_hash = store.hash_expr(&cons).unwrap();
+        let opaque_cons = store.intern_opaque_cons(*cons_hash.value());
+
+        store.hydrate_scalar_cache();
+
+        let scalar_store = ScalarStore::new_with_expr(&store, &opaque_cons);
+
+        assert_eq!(1, scalar_store.scalar_map.len());
+    }
+    #[test]
+    fn test_scalar_store_opaque_fun() {
+        let mut store = Store::<Fr>::default();
+
+        let arg = store.sym("A");
+        let body = store.num(123);
+        let empty_env = empty_sym_env(&store);
+        let fun = store.intern_fun(arg, body, empty_env);
+        let fun_hash = store.hash_expr(&fun).unwrap();
+        let opaque_fun = store.intern_opaque_fun(*fun_hash.value());
+        store.hydrate_scalar_cache();
+
+        let scalar_store = ScalarStore::new_with_expr(&store, &opaque_fun);
+
+        assert_eq!(1, scalar_store.scalar_map.len());
+    }
+    #[test]
+    fn test_scalar_store_opaque_sym() {
+        let mut store = Store::<Fr>::default();
+
+        let sym = store.sym(&"sym");
+        let sym_hash = store.hash_expr(&sym).unwrap();
+        let opaque_sym = store.intern_opaque_sym(*sym_hash.value());
+
+        store.hydrate_scalar_cache();
+
+        let scalar_store = ScalarStore::new_with_expr(&store, &opaque_sym);
+
+        assert_eq!(1, scalar_store.scalar_map.len());
+    }
+    #[test]
+    fn test_scalar_store_opaque_str() {
+        let mut store = Store::<Fr>::default();
+
+        let str = store.str(&"str");
+        let str_hash = store.hash_expr(&str).unwrap();
+        let opaque_str = store.intern_opaque_sym(*str_hash.value());
+
+        store.hydrate_scalar_cache();
+
+        let scalar_store = ScalarStore::new_with_expr(&store, &opaque_str);
+
+        assert_eq!(1, scalar_store.scalar_map.len());
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -62,16 +62,14 @@ impl Default for StringSet {
 
 #[derive(Debug)]
 pub struct Store<F: PrimeField> {
-    cons_store: IndexSet<(Ptr<F>, Ptr<F>)>,
-    pub(crate) opaque_cons: (Ptr<F>, Ptr<F>),
+    pub(crate) cons_store: IndexSet<(Ptr<F>, Ptr<F>)>,
 
     fun_store: IndexSet<(Ptr<F>, Ptr<F>, Ptr<F>)>,
-    pub(crate) opaque_fun: (Ptr<F>, Ptr<F>, Ptr<F>),
 
     sym_store: StringSet,
 
     // Other sparse storage format without hashing is likely more efficient
-    num_store: IndexSet<Num<F>>,
+    pub(crate) num_store: IndexSet<Num<F>>,
 
     str_store: StringSet,
     thunk_store: IndexSet<Thunk<F>>,
@@ -91,7 +89,7 @@ pub struct Store<F: PrimeField> {
 
     opaque_map: dashmap::DashMap<Ptr<F>, ScalarPtr<F>>,
     /// Holds a mapping of ScalarPtr -> Ptr for reverse lookups
-    scalar_ptr_map: dashmap::DashMap<ScalarPtr<F>, Ptr<F>, ahash::RandomState>,
+    pub(crate) scalar_ptr_map: dashmap::DashMap<ScalarPtr<F>, Ptr<F>, ahash::RandomState>,
     /// Holds a mapping of ScalarPtr -> ContPtr<F> for reverse lookups
     scalar_ptr_cont_map: dashmap::DashMap<ScalarContPtr<F>, ContPtr<F>, ahash::RandomState>,
 
@@ -204,8 +202,14 @@ impl<F: PrimeField> Pointer<F> for Ptr<F> {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd)]
 pub struct ScalarPtr<F: PrimeField>(F, F);
+
+// impl<F: PrimeField> Ord for ScalarPtr<F> {
+//     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+//         (self.0.to_repr(), self.1.to_repr()).cmp((other.0.to_repr(), other.1.to_repr()))
+//     }
+// }
 
 #[allow(clippy::derive_hash_xor_eq)]
 impl<F: PrimeField> Hash for ScalarPtr<F> {
@@ -353,6 +357,7 @@ pub enum Expression<'a, F: PrimeField> {
     Num(Num<F>),
     Str(&'a str),
     Thunk(Thunk<F>),
+    Opaque(Ptr<F>),
 }
 
 impl<F: PrimeField> Object<F> for Expression<'_, F> {
@@ -584,8 +589,6 @@ impl ContTag {
 
 impl<F: PrimeField> Default for Store<F> {
     fn default() -> Self {
-        let dummy_ptr = Ptr(Tag::Nil, RawPtr::new(0));
-
         let mut store = Store {
             cons_store: Default::default(),
             sym_store: Default::default(),
@@ -613,17 +616,7 @@ impl<F: PrimeField> Default for Store<F> {
             dehydrated: Default::default(),
             dehydrated_cont: Default::default(),
             opaque_raw_ptr_count: 0,
-            opaque_cons: (dummy_ptr, dummy_ptr),
-            opaque_fun: (dummy_ptr, dummy_ptr, dummy_ptr),
         };
-
-        let p = store.new_opaque_ptr();
-        store.opaque_cons = (p, p);
-        store.opaque_fun = (
-            store.new_opaque_ptr(),
-            store.new_opaque_ptr(),
-            store.new_opaque_ptr(),
-        );
 
         // insert some well known symbols
         for sym in &[
@@ -655,11 +648,6 @@ impl<F: PrimeField> Default for Store<F> {
             store.sym(sym);
         }
 
-        // This is a hack to at least mark printed opaque conses clearly.
-        let a = store.sym("<OPAQUE-CAR>");
-        let b = store.sym("<OPAQUE-CDR>");
-        store.opaque_cons = (a, b);
-
         store
     }
 }
@@ -687,6 +675,10 @@ impl<F: PrimeField> Store<F> {
 
     pub fn num<T: Into<Num<F>>>(&mut self, num: T) -> Ptr<F> {
         self.intern_num(num)
+    }
+
+    pub fn str<T: AsRef<str>>(&mut self, name: T) -> Ptr<F> {
+        self.intern_str(name)
     }
 
     pub fn sym<T: AsRef<str>>(&mut self, name: T) -> Ptr<F> {
@@ -754,7 +746,6 @@ impl<F: PrimeField> Store<F> {
         let ptr = Ptr(tag, self.new_opaque_raw_ptr());
         // Always insert. Key is unique because of newly allocated opaque raw_ptr.
         self.opaque_map.insert(ptr, scalar_ptr);
-
         ptr
     }
 
@@ -811,7 +802,6 @@ impl<F: PrimeField> Store<F> {
         if convert_case {
             Self::convert_sym_case(&mut name);
         }
-
         let tag = if name == "NIL" { Tag::Nil } else { Tag::Sym };
         self.sym_store
             .0
@@ -864,6 +854,7 @@ impl<F: PrimeField> Store<F> {
         self.dehydrated_cont.push(p);
         p
     }
+
     pub fn intern_cont_outermost(&mut self) -> ContPtr<F> {
         self.mark_dehydrated_cont(self.get_cont_outermost())
     }
@@ -1090,31 +1081,32 @@ impl<F: PrimeField> Store<F> {
             .resolve(SymbolUsize::try_from_usize(ptr.1.idx()).unwrap())
     }
 
-    fn fetch_str(&self, ptr: &Ptr<F>) -> Option<&str> {
+    pub(crate) fn fetch_str(&self, ptr: &Ptr<F>) -> Option<&str> {
         debug_assert!(matches!(ptr.0, Tag::Str));
         let symbol = SymbolUsize::try_from_usize(ptr.1.idx()).expect("invalid pointer");
         self.str_store.0.resolve(symbol)
     }
 
-    fn fetch_fun(&self, ptr: &Ptr<F>) -> Option<&(Ptr<F>, Ptr<F>, Ptr<F>)> {
+    pub(crate) fn fetch_fun(&self, ptr: &Ptr<F>) -> Option<&(Ptr<F>, Ptr<F>, Ptr<F>)> {
         debug_assert!(matches!(ptr.0, Tag::Fun));
         if ptr.1.is_opaque() {
-            Some(&self.opaque_fun)
+            None
+            // Some(&self.opaque_fun)
         } else {
             self.fun_store.get_index(ptr.1.idx())
         }
     }
 
-    fn fetch_cons(&self, ptr: &Ptr<F>) -> Option<&(Ptr<F>, Ptr<F>)> {
+    pub(crate) fn fetch_cons(&self, ptr: &Ptr<F>) -> Option<&(Ptr<F>, Ptr<F>)> {
         debug_assert!(matches!(ptr.0, Tag::Cons));
         if ptr.1.is_opaque() {
-            Some(&self.opaque_cons)
+            None
         } else {
             self.cons_store.get_index(ptr.1.idx())
         }
     }
 
-    fn fetch_num(&self, ptr: &Ptr<F>) -> Option<&Num<F>> {
+    pub(crate) fn fetch_num(&self, ptr: &Ptr<F>) -> Option<&Num<F>> {
         debug_assert!(matches!(ptr.0, Tag::Num));
         self.num_store.get_index(ptr.1.idx())
     }
@@ -1125,6 +1117,9 @@ impl<F: PrimeField> Store<F> {
     }
 
     pub fn fetch(&self, ptr: &Ptr<F>) -> Option<Expression<F>> {
+        if ptr.is_opaque() {
+            return Some(Expression::Opaque(*ptr));
+        }
         match ptr.0 {
             Tag::Nil => Some(Expression::Nil),
             Tag::Cons => self.fetch_cons(ptr).map(|(a, b)| Expression::Cons(*a, *b)),
@@ -1262,8 +1257,6 @@ impl<F: PrimeField> Store<F> {
                 _ => unreachable!(),
             },
             _ => {
-                use crate::writer::Write;
-                dbg!(ptr.fmt_to_string(self));
                 panic!("Can only extract car_cdr from Cons")
             }
         }
@@ -1282,6 +1275,23 @@ impl<F: PrimeField> Store<F> {
         }
     }
 
+    // Get hash for expr, but only if it already exists. This should never cause create_scalar_ptr to be called. Use
+    // this after the cache has been hydrated. NOTE: because dashmap::entry can deadlock, it is important not to call
+    // hash_expr in nested call graphs which might trigger that behavior. This discovery is what led to get_expr_hash
+    // and the 'get' versions of hash_cons, hash_sym, etc.
+    pub fn get_expr_hash(&self, ptr: &Ptr<F>) -> Option<ScalarPtr<F>> {
+        use Tag::*;
+        match ptr.tag() {
+            Nil => self.get_hash_nil(),
+            Cons => self.get_hash_cons(*ptr),
+            Sym => self.get_hash_sym(*ptr),
+            Fun => self.get_hash_fun(*ptr),
+            Num => self.get_hash_num(*ptr),
+            Str => self.get_hash_str(*ptr),
+            Thunk => self.get_hash_thunk(*ptr),
+        }
+    }
+
     pub fn hash_cont(&self, ptr: &ContPtr<F>) -> Option<ScalarContPtr<F>> {
         let components = self.get_hash_components_cont(ptr)?;
         let hash = self.poseidon_cache.hash8(&components);
@@ -1293,8 +1303,13 @@ impl<F: PrimeField> Store<F> {
     /// ensure that they are cached properly
     fn create_scalar_ptr(&self, ptr: Ptr<F>, hash: F) -> ScalarPtr<F> {
         let scalar_ptr = ScalarPtr(ptr.tag_field(), hash);
-        self.scalar_ptr_map.entry(scalar_ptr).or_insert(ptr);
+        let entry = self.scalar_ptr_map.entry(scalar_ptr);
+        entry.or_insert(ptr);
         scalar_ptr
+    }
+
+    fn get_scalar_ptr(&self, ptr: Ptr<F>, hash: F) -> ScalarPtr<F> {
+        ScalarPtr(ptr.tag_field(), hash)
     }
 
     /// The only places that `ScalarContPtr`s for `ContPtr`s should be created, to
@@ -1533,7 +1548,6 @@ impl<F: PrimeField> Store<F> {
         cont: &ContPtr<F>,
     ) -> Option<[[F; 2]; 4]> {
         let def = [F::zero(), F::zero()];
-
         let arg = self.hash_expr(arg)?.into_hash_components();
         let saved_env = self.hash_expr(saved_env)?.into_hash_components();
         let cont = self.hash_cont(cont)?.into_hash_components();
@@ -1566,12 +1580,25 @@ impl<F: PrimeField> Store<F> {
             return self.opaque_map.get(&sym).map(|s| *s);
         }
         let s = self.fetch_sym(&sym)?;
+
         Some(self.create_scalar_ptr(sym, self.hash_string(s)))
+    }
+
+    pub fn get_hash_sym(&self, sym: Ptr<F>) -> Option<ScalarPtr<F>> {
+        if sym.is_opaque() {
+            return self.opaque_map.get(&sym).map(|s| *s);
+        }
+        let s = self.fetch_sym(&sym)?;
+        Some(self.get_scalar_ptr(sym, self.hash_string(s)))
     }
 
     fn hash_str(&self, sym: Ptr<F>) -> Option<ScalarPtr<F>> {
         let s = self.fetch_str(&sym)?;
         Some(self.create_scalar_ptr(sym, self.hash_string(s)))
+    }
+    fn get_hash_str(&self, sym: Ptr<F>) -> Option<ScalarPtr<F>> {
+        let s = self.fetch_str(&sym)?;
+        Some(self.get_scalar_ptr(sym, self.hash_string(s)))
     }
 
     fn hash_fun(&self, fun: Ptr<F>) -> Option<ScalarPtr<F>> {
@@ -1585,6 +1612,19 @@ impl<F: PrimeField> Store<F> {
         } else {
             let (arg, body, closed_env) = self.fetch_fun(&fun)?;
             Some(self.create_scalar_ptr(fun, self.hash_ptrs_3(&[*arg, *body, *closed_env])?))
+        }
+    }
+    fn get_hash_fun(&self, fun: Ptr<F>) -> Option<ScalarPtr<F>> {
+        if fun.is_opaque() {
+            Some(
+                *self
+                    .opaque_map
+                    .get(&fun)
+                    .expect("ScalarPtr for opaque Fun missing"),
+            )
+        } else {
+            let (arg, body, closed_env) = self.fetch_fun(&fun)?;
+            Some(self.get_scalar_ptr(fun, self.get_hash_ptrs_3(&[*arg, *body, *closed_env])?))
         }
     }
 
@@ -1602,6 +1642,19 @@ impl<F: PrimeField> Store<F> {
 
         Some(self.create_scalar_ptr(cons, self.hash_ptrs_2(&[*car, *cdr])?))
     }
+    fn get_hash_cons(&self, cons: Ptr<F>) -> Option<ScalarPtr<F>> {
+        if cons.is_opaque() {
+            return Some(
+                *self
+                    .opaque_map
+                    .get(&cons)
+                    .expect("ScalarPtr for opaque Cons missing"),
+            );
+        }
+
+        let (car, cdr) = self.fetch_cons(&cons)?;
+        Some(self.get_scalar_ptr(cons, self.get_hash_ptrs_2(&[*car, *cdr])?))
+    }
 
     fn hash_thunk(&self, ptr: Ptr<F>) -> Option<ScalarPtr<F>> {
         let thunk = self.fetch_thunk(&ptr)?;
@@ -1609,9 +1662,21 @@ impl<F: PrimeField> Store<F> {
         Some(self.create_scalar_ptr(ptr, self.poseidon_cache.hash4(&components)))
     }
 
+    fn get_hash_thunk(&self, ptr: Ptr<F>) -> Option<ScalarPtr<F>> {
+        let thunk = self.fetch_thunk(&ptr)?;
+        let components = self.get_hash_components_thunk(thunk)?;
+        Some(self.get_scalar_ptr(ptr, self.poseidon_cache.hash4(&components)))
+    }
+
     fn hash_num(&self, ptr: Ptr<F>) -> Option<ScalarPtr<F>> {
         let n = self.fetch_num(&ptr)?;
+
         Some(self.create_scalar_ptr(ptr, n.into_scalar()))
+    }
+    fn get_hash_num(&self, ptr: Ptr<F>) -> Option<ScalarPtr<F>> {
+        let n = self.fetch_num(&ptr)?;
+
+        Some(self.get_scalar_ptr(ptr, n.into_scalar()))
     }
 
     fn hash_string(&self, s: &str) -> F {
@@ -1639,12 +1704,25 @@ impl<F: PrimeField> Store<F> {
         let scalar_ptrs = [self.hash_expr(&ptrs[0])?, self.hash_expr(&ptrs[1])?];
         Some(self.hash_scalar_ptrs_2(&scalar_ptrs))
     }
+    fn get_hash_ptrs_2(&self, ptrs: &[Ptr<F>; 2]) -> Option<F> {
+        let scalar_ptrs = [self.get_expr_hash(&ptrs[0])?, self.get_expr_hash(&ptrs[1])?];
+        Some(self.hash_scalar_ptrs_2(&scalar_ptrs))
+    }
 
     fn hash_ptrs_3(&self, ptrs: &[Ptr<F>; 3]) -> Option<F> {
         let scalar_ptrs = [
             self.hash_expr(&ptrs[0])?,
             self.hash_expr(&ptrs[1])?,
             self.hash_expr(&ptrs[2])?,
+        ];
+        Some(self.hash_scalar_ptrs_3(&scalar_ptrs))
+    }
+
+    fn get_hash_ptrs_3(&self, ptrs: &[Ptr<F>; 3]) -> Option<F> {
+        let scalar_ptrs = [
+            self.get_expr_hash(&ptrs[0])?,
+            self.get_expr_hash(&ptrs[1])?,
+            self.get_expr_hash(&ptrs[2])?,
         ];
         Some(self.hash_scalar_ptrs_3(&scalar_ptrs))
     }
@@ -1663,7 +1741,14 @@ impl<F: PrimeField> Store<F> {
 
     pub fn hash_nil(&self) -> Option<ScalarPtr<F>> {
         let nil = self.get_nil();
+
         self.hash_sym(nil)
+    }
+
+    pub fn get_hash_nil(&self) -> Option<ScalarPtr<F>> {
+        let nil = self.get_nil();
+
+        self.get_hash_sym(nil)
     }
 
     fn hash_op1(&self, op: &Op1) -> ScalarPtr<F> {
@@ -1701,7 +1786,7 @@ impl<F: PrimeField> Store<F> {
     pub fn ptr_eq(&self, a: &Ptr<F>, b: &Ptr<F>) -> bool {
         // In order to compare Ptrs, we *must* resolve the hashes. Otherwise, we risk failing to recognize equality of
         // compound data with opaque data in either element's transitive closure.
-        self.hash_expr(a) == self.hash_expr(b)
+        self.get_expr_hash(a) == self.get_expr_hash(b)
     }
 
     pub fn cons_eq(&self, a: &Ptr<F>, b: &Ptr<F>) -> bool {
@@ -1714,7 +1799,7 @@ impl<F: PrimeField> Store<F> {
         if !a_opaque && !b_opaque {
             return a == b;
         }
-        self.hash_expr(a) == self.hash_expr(b)
+        self.get_expr_hash(a) == self.get_expr_hash(b)
     }
 
     /// Fill the cache for Scalars. Only Ptrs which have been interned since last hydration will be hashed, so it is
@@ -2003,14 +2088,7 @@ mod test {
         let qcons_opaque2 = store.list(&[quote, opaque_cons2]);
 
         assert_eq!("<Opaque Cons>", opaque_cons.fmt_to_string(&store));
-        assert_eq!(
-            "<OPAQUE-CAR>",
-            store.car(&opaque_cons).fmt_to_string(&store)
-        );
-        assert_eq!(
-            "<OPAQUE-CDR>",
-            store.cdr(&opaque_cons).fmt_to_string(&store)
-        );
+
         {
             let comparison_expr = store.list(&[eq, qcons, qcons_opaque]);
             // FIXME: need to implement Write for opaque data.
@@ -2032,13 +2110,49 @@ mod test {
             // without this affecting equality semantics.
 
             let n = store.num(123);
+            let n2 = store.num(321);
             let cons_sym = store.sym("cons");
             let cons_expr1 = store.list(&[cons_sym, qcons, n]);
             let cons_expr2 = store.list(&[cons_sym, qcons_opaque, n]);
+            let cons_expr3 = store.list(&[cons_sym, qcons_opaque, n2]);
 
             let comparison_expr = store.list(&[eq, cons_expr1, cons_expr2]);
-            let (result, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
-            assert_eq!(t, result.expr);
+            let comparison_expr2 = store.list(&[eq, cons_expr1, cons_expr3]);
+            {
+                let (result, _) =
+                    Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
+                assert_eq!(t, result.expr);
+            }
+            {
+                let (result, _) =
+                    Evaluator::new(comparison_expr2, empty_env, &mut store, limit).eval();
+                assert_eq!(nil, result.expr);
+            }
         }
+    }
+
+    fn make_opaque_cons(store: &mut Store<Fr>) -> Ptr<Fr> {
+        let num1 = store.num(123);
+        let num2 = store.num(987);
+        let cons = store.intern_cons(num1, num2);
+        let cons_hash = store.hash_expr(&cons).unwrap();
+
+        store.intern_opaque_cons(*cons_hash.value())
+    }
+    #[test]
+    #[should_panic]
+    fn opaque_cons_car() {
+        let mut store = Store::<Fr>::default();
+
+        let opaque_cons = make_opaque_cons(&mut store);
+        store.car(&opaque_cons);
+    }
+    #[test]
+    #[should_panic]
+    fn opaque_cons_cdr() {
+        let mut store = Store::<Fr>::default();
+
+        let opaque_cons = make_opaque_cons(&mut store);
+        store.cdr(&opaque_cons);
     }
 }


### PR DESCRIPTION
This PR adds ScalarStore, to serve as the basis for IPLD embedding. The intention is that the IPLD code can avoid the complexity of the Store by relying on ScalarStore to walk the graph of ScalarPtrs. This process is fairly obscure, and there is no direct or convenient handle on it without some abstraction. ScalarStore provides that.

TODO [future work]:
- [ ] Support Continuations
- [ ] Support Thunks
- [ ] Support conversion from ScalarStore to Expression and/or Store.
   In particular, we should be able to dump the output of an evaluation (a Ptr expr) to a ScalarStore, serialize it to IPLD, write it to disk or send it across the wire, then reconstitute the ScalarStore and use it to populate a Store. The end result should be that it is possible to use the resulting expr as the input to a new evaluation.

We should make sure the IPLD work gets us everything need up to the ScalarStore -> Store conversion.