### PR TITLE
Refactor Scalar(Cont)Ptr

### DIFF
--- a/clutch/src/lib.rs
+++ b/clutch/src/lib.rs
@@ -11,7 +11,7 @@ use lurk::field::LurkField;
 use lurk::package::Package;
 use lurk::proof::{nova::NovaProver, Prover};
 use lurk::repl::{ReplState, ReplTrait};
-use lurk::store::{Expression, Pointer, Ptr, ScalarPointer, Store};
+use lurk::store::{Expression, Pointer, Ptr, Store};
 use lurk::tag::ExprTag;
 use lurk::writer::Write;
 

--- a/fcomm/src/lib.rs
+++ b/fcomm/src/lib.rs
@@ -24,7 +24,7 @@ use lurk::{
     proof::nova::{self, NovaProver, PublicParams},
     proof::Prover,
     scalar_store::ScalarStore,
-    store::{Pointer, Ptr, ScalarPointer, ScalarPtr, Store},
+    store::{Pointer, Ptr, ScalarPtr, Store},
     tag::ExprTag,
     writer::Write,
 };

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -173,7 +173,7 @@ impl<'a, F: LurkField, T: Clone + Copy + std::cmp::PartialEq, W: Copy> MultiFram
                     // Ensure all intermediate allocated I/O values match the provided executation trace.
                     assert_eq!(
                         allocated_io.0.tag().get_value(),
-                        store.hash_expr(&next_input.expr).map(|x| *x.tag()),
+                        store.hash_expr(&next_input.expr).map(|x| x.tag()),
                         "expr tag mismatch"
                     );
                     assert_eq!(
@@ -183,7 +183,7 @@ impl<'a, F: LurkField, T: Clone + Copy + std::cmp::PartialEq, W: Copy> MultiFram
                     );
                     assert_eq!(
                         allocated_io.1.tag().get_value(),
-                        store.hash_expr(&next_input.env).map(|x| *x.tag()),
+                        store.hash_expr(&next_input.env).map(|x| x.tag()),
                         "env tag mismatch"
                     );
                     assert_eq!(
@@ -193,7 +193,7 @@ impl<'a, F: LurkField, T: Clone + Copy + std::cmp::PartialEq, W: Copy> MultiFram
                     );
                     assert_eq!(
                         allocated_io.2.tag().get_value(),
-                        store.hash_cont(&next_input.cont).map(|x| *x.tag()),
+                        store.hash_cont(&next_input.cont).map(|x| x.tag()),
                         "cont tag mismatch"
                     );
                     assert_eq!(

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     field::LurkField,
     hash_witness::{ConsName, ContName},
-    store::{NamedConstants, ScalarPointer},
+    store::NamedConstants,
     tag::Tag,
 };
 
@@ -173,7 +173,7 @@ impl<'a, F: LurkField, T: Clone + Copy + std::cmp::PartialEq, W: Copy> MultiFram
                     // Ensure all intermediate allocated I/O values match the provided executation trace.
                     assert_eq!(
                         allocated_io.0.tag().get_value(),
-                        store.hash_expr(&next_input.expr).map(|x| x.tag()),
+                        store.hash_expr(&next_input.expr).map(|x| x.tag_field()),
                         "expr tag mismatch"
                     );
                     assert_eq!(
@@ -183,7 +183,7 @@ impl<'a, F: LurkField, T: Clone + Copy + std::cmp::PartialEq, W: Copy> MultiFram
                     );
                     assert_eq!(
                         allocated_io.1.tag().get_value(),
-                        store.hash_expr(&next_input.env).map(|x| x.tag()),
+                        store.hash_expr(&next_input.env).map(|x| x.tag_field()),
                         "env tag mismatch"
                     );
                     assert_eq!(
@@ -193,7 +193,7 @@ impl<'a, F: LurkField, T: Clone + Copy + std::cmp::PartialEq, W: Copy> MultiFram
                     );
                     assert_eq!(
                         allocated_io.2.tag().get_value(),
-                        store.hash_cont(&next_input.cont).map(|x| x.tag()),
+                        store.hash_cont(&next_input.cont).map(|x| x.tag_field()),
                         "cont tag mismatch"
                     );
                     assert_eq!(

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -15,6 +15,7 @@ use crate::{
     field::LurkField,
     hash_witness::{ConsName, ContName},
     store::{NamedConstants, ScalarPointer},
+    tag::Tag,
 };
 
 use super::gadgets::constraints::{
@@ -451,7 +452,7 @@ impl<'a, F: LurkField> Results<'a, F> {
         result_cont: &'a AllocatedContPtr<F>,
         result_apply_continuation: &'a AllocatedNum<F>,
     ) {
-        let key = key.as_field();
+        let key = key.to_field();
         add_clause(
             &mut self.expr_tag_clauses,
             &mut self.expr_hash_clauses,
@@ -516,7 +517,7 @@ impl<'a, F: LurkField> Results<'a, F> {
         result_env: &'a AllocatedPtr<F>,
         result_cont: &'a AllocatedContPtr<F>,
     ) {
-        let key = key.as_field();
+        let key = key.to_field();
         add_clause(
             &mut self.expr_tag_clauses,
             &mut self.expr_hash_clauses,
@@ -546,7 +547,7 @@ impl<'a, F: LurkField> Results<'a, F> {
         make_thunk_num: &'a AllocatedNum<F>,
         newer_cont2_not_dummy: &'a AllocatedNum<F>,
     ) {
-        let key = key.as_field();
+        let key = key.to_field();
         add_clause(
             &mut self.expr_tag_clauses,
             &mut self.expr_hash_clauses,
@@ -690,11 +691,11 @@ fn reduce_expression<F: LurkField, CS: ConstraintSystem<F>>(
 
     let cont_is_terminal = cont.alloc_tag_equal(
         &mut cs.namespace(|| "cont_is_terminal"),
-        ContTag::Terminal.as_field(),
+        ContTag::Terminal.to_field(),
     )?;
     let cont_is_error = cont.alloc_tag_equal(
         &mut cs.namespace(|| "cont_is_error"),
-        ContTag::Error.as_field(),
+        ContTag::Error.to_field(),
     )?;
 
     // Enforce (expr.tag == thunk_tag) implies (expr_thunk_hash == expr.hash).
@@ -1117,7 +1118,7 @@ fn reduce_sym<F: LurkField, CS: ConstraintSystem<F>>(
 
     let cont_is_lookup = cont.alloc_tag_equal(
         &mut cs.namespace(|| "cons_is_lookup"),
-        ContTag::Lookup.as_field(),
+        ContTag::Lookup.to_field(),
     )?;
 
     let needed_env_missing = and!(cs, &sym_otherwise, &env_is_nil)?;
@@ -1757,14 +1758,14 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         let the_op = pick_const(
             &mut cs.namespace(|| "eval op"),
             &end_is_nil,
-            ContTag::Unop.as_field(),
-            ContTag::Binop.as_field(),
+            ContTag::Unop.to_field(),
+            ContTag::Binop.to_field(),
         )?;
         let op1_or_op2 = pick_const(
             &mut cs.namespace(|| "op1 or op2"),
             &end_is_nil,
-            Op1::Eval.as_field(),
-            Op2::Eval.as_field(),
+            Op1::Eval.to_field(),
+            Op2::Eval.to_field(),
         )?;
         let cont_or_env_tag = pick(
             &mut cs.namespace(|| "env or cont tag"),
@@ -2736,7 +2737,7 @@ fn make_thunk<F: LurkField, CS: ConstraintSystem<F>>(
 
     let cont_is_tail = cont.alloc_tag_equal(
         &mut cs.namespace(|| "cont_is_tail"),
-        ContTag::Tail.as_field(),
+        ContTag::Tail.to_field(),
     )?;
 
     let make_thunk_cont_not_dummy = and!(cs, &cont_is_tail, not_dummy)?;
@@ -2859,19 +2860,19 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
 
     let cont_is_terminal = cont.alloc_tag_equal(
         &mut cs.namespace(|| "cont_is_terminal"),
-        ContTag::Terminal.as_field(),
+        ContTag::Terminal.to_field(),
     )?;
     let cont_is_dummy = cont.alloc_tag_equal(
         &mut cs.namespace(|| "cont_is_dummy"),
-        ContTag::Dummy.as_field(),
+        ContTag::Dummy.to_field(),
     )?;
     let cont_is_error = cont.alloc_tag_equal(
         &mut cs.namespace(|| "cont_is_error"),
-        ContTag::Error.as_field(),
+        ContTag::Error.to_field(),
     )?;
     let cont_is_outermost = cont.alloc_tag_equal(
         &mut cs.namespace(|| "cont_is_outermost"),
-        ContTag::Outermost.as_field(),
+        ContTag::Outermost.to_field(),
     )?;
 
     let cont_is_trivial = or!(
@@ -2926,7 +2927,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         default_num_pair,
     ];
     hash_default_results.add_hash_input_clauses(
-        ContTag::Call0.as_field(),
+        ContTag::Call0.to_field(),
         &g.tail_cont_tag,
         call0_components,
     );
@@ -2943,7 +2944,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
     let call_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&saved_env, function, &continuation, default_num_pair];
     hash_default_results.add_hash_input_clauses(
-        ContTag::Call.as_field(),
+        ContTag::Call.to_field(),
         &g.call2_cont_tag,
         call_components,
     );
@@ -2963,7 +2964,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         default_num_pair,
     ];
     hash_default_results.add_hash_input_clauses(
-        ContTag::Call2.as_field(),
+        ContTag::Call2.to_field(),
         &g.tail_cont_tag,
         call2_components,
     );
@@ -2980,7 +2981,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         &[&saved_env, &let_cont, default_num_pair, default_num_pair];
 
     hash_default_results.add_hash_input_clauses(
-        ContTag::Let.as_field(),
+        ContTag::Let.to_field(),
         &g.tail_cont_tag,
         let_components,
     );
@@ -2996,7 +2997,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
     let letrec_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&saved_env, &letrec_cont, default_num_pair, default_num_pair];
     hash_default_results.add_hash_input_clauses(
-        ContTag::LetRec.as_field(),
+        ContTag::LetRec.to_field(),
         &g.tail_cont_tag,
         letrec_components,
     );
@@ -3007,12 +3008,12 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         let operator = AllocatedPtr::by_index(0, &continuation_components);
 
         let is_op2_hide =
-            operator.alloc_tag_equal(&mut cs.namespace(|| "is_op2_hide"), Op2::Hide.as_field())?;
+            operator.alloc_tag_equal(&mut cs.namespace(|| "is_op2_hide"), Op2::Hide.to_field())?;
         let is_op1_open =
-            operator.alloc_tag_equal(&mut cs.namespace(|| "is_op1_open"), Op1::Open.as_field())?;
+            operator.alloc_tag_equal(&mut cs.namespace(|| "is_op1_open"), Op1::Open.to_field())?;
         let is_op1_secret = operator.alloc_tag_equal(
             &mut cs.namespace(|| "is_op1_secret"),
-            Op1::Secret.as_field(),
+            Op1::Secret.to_field(),
         )?;
         let is_op1_open_or_secret = or!(cs, &is_op1_open, &is_op1_secret)?;
 
@@ -3056,13 +3057,13 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
 
         let cont_is_unop = cont.alloc_tag_equal(
             &mut cs.namespace(|| "cont_is_unop"),
-            ContTag::Unop.as_field(),
+            ContTag::Unop.to_field(),
         )?;
 
         let unop_op_is_car =
-            op1.alloc_tag_equal(&mut cs.namespace(|| "unop_op_is_car"), Op1::Car.as_field())?;
+            op1.alloc_tag_equal(&mut cs.namespace(|| "unop_op_is_car"), Op1::Car.to_field())?;
         let unop_op_is_cdr =
-            op1.alloc_tag_equal(&mut cs.namespace(|| "unop_op_is_cdr"), Op1::Cdr.as_field())?;
+            op1.alloc_tag_equal(&mut cs.namespace(|| "unop_op_is_cdr"), Op1::Cdr.to_field())?;
         let unop_op_is_car_or_cdr = or!(cs, &unop_op_is_car, &unop_op_is_cdr)?;
 
         let result_is_cons = result.is_cons(&mut cs.namespace(|| "result_is_cons"))?;
@@ -3114,101 +3115,101 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             &[
                 &[
                     CaseClause {
-                        key: Op1::Car.as_field(),
+                        key: Op1::Car.to_field(),
                         value: res_car.tag(),
                     },
                     CaseClause {
-                        key: Op1::Cdr.as_field(),
+                        key: Op1::Cdr.to_field(),
                         value: res_cdr.tag(),
                     },
                     CaseClause {
-                        key: Op1::Atom.as_field(),
+                        key: Op1::Atom.to_field(),
                         value: is_atom_ptr.tag(),
                     },
                     CaseClause {
-                        key: Op1::Emit.as_field(),
+                        key: Op1::Emit.to_field(),
                         value: result.tag(),
                     },
                     CaseClause {
-                        key: Op1::Commit.as_field(),
+                        key: Op1::Commit.to_field(),
                         value: commitment.tag(),
                     },
                     CaseClause {
-                        key: Op1::Open.as_field(),
+                        key: Op1::Open.to_field(),
                         value: committed_expr.tag(),
                     },
                     CaseClause {
-                        key: Op1::Secret.as_field(),
+                        key: Op1::Secret.to_field(),
                         value: &g.num_tag,
                     },
                     CaseClause {
-                        key: Op1::Num.as_field(),
+                        key: Op1::Num.to_field(),
                         value: num.tag(),
                     },
                     CaseClause {
-                        key: Op1::U64.as_field(),
+                        key: Op1::U64.to_field(),
                         value: &g.u64_tag,
                     },
                     CaseClause {
-                        key: Op1::Comm.as_field(),
+                        key: Op1::Comm.to_field(),
                         value: comm.tag(),
                     },
                     CaseClause {
-                        key: Op1::Char.as_field(),
+                        key: Op1::Char.to_field(),
                         value: &g.char_tag,
                     },
                     CaseClause {
-                        key: Op1::Eval.as_field(),
+                        key: Op1::Eval.to_field(),
                         value: result.tag(),
                     },
                 ],
                 &[
                     CaseClause {
-                        key: Op1::Car.as_field(),
+                        key: Op1::Car.to_field(),
                         value: allocated_car.hash(),
                     },
                     CaseClause {
-                        key: Op1::Cdr.as_field(),
+                        key: Op1::Cdr.to_field(),
                         value: allocated_cdr.hash(),
                     },
                     CaseClause {
-                        key: Op1::Atom.as_field(),
+                        key: Op1::Atom.to_field(),
                         value: is_atom_ptr.hash(),
                     },
                     CaseClause {
-                        key: Op1::Emit.as_field(),
+                        key: Op1::Emit.to_field(),
                         value: result.hash(),
                     },
                     CaseClause {
-                        key: Op1::Commit.as_field(),
+                        key: Op1::Commit.to_field(),
                         value: commitment.hash(),
                     },
                     CaseClause {
-                        key: Op1::Open.as_field(),
+                        key: Op1::Open.to_field(),
                         value: committed_expr.hash(),
                     },
                     CaseClause {
-                        key: Op1::Secret.as_field(),
+                        key: Op1::Secret.to_field(),
                         value: &commitment_secret,
                     },
                     CaseClause {
-                        key: Op1::Num.as_field(),
+                        key: Op1::Num.to_field(),
                         value: num.hash(),
                     },
                     CaseClause {
-                        key: Op1::U64.as_field(),
+                        key: Op1::U64.to_field(),
                         value: &u64_elem,
                     },
                     CaseClause {
-                        key: Op1::Comm.as_field(),
+                        key: Op1::Comm.to_field(),
                         value: comm.hash(),
                     },
                     CaseClause {
-                        key: Op1::Char.as_field(),
+                        key: Op1::Char.to_field(),
                         value: &u32_elem,
                     },
                     CaseClause {
-                        key: Op1::Eval.as_field(),
+                        key: Op1::Eval.to_field(),
                         value: result.hash(),
                     },
                 ],
@@ -3227,7 +3228,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         default_num_pair,
     ];
     hash_default_results.add_hash_input_clauses(
-        ContTag::Unop.as_field(),
+        ContTag::Unop.to_field(),
         &g.emit_cont_tag,
         emit_components,
     );
@@ -3247,7 +3248,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         default_num_pair,
     ];
     hash_default_results.add_hash_input_clauses(
-        ContTag::Binop.as_field(),
+        ContTag::Binop.to_field(),
         &g.binop2_cont_tag,
         binop_components,
     );
@@ -3310,7 +3311,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
 
         let cont_is_call0 = cont.alloc_tag_equal(
             &mut cs.namespace(|| "cont_is_call0"),
-            ContTag::Call0.as_field(),
+            ContTag::Call0.to_field(),
         )?;
         let call0_not_dummy = and!(cs, &cont_is_call0, &result_is_fun, not_dummy)?;
 
@@ -3347,7 +3348,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
 
         let continuation_is_tail = continuation.alloc_tag_equal(
             &mut cs.namespace(|| "continuation is tail"),
-            ContTag::Tail.as_field(),
+            ContTag::Tail.to_field(),
         )?;
 
         let tail_cont = AllocatedContPtr::pick(
@@ -3474,7 +3475,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         {
             let cont_is_call2_precomp = cont.alloc_tag_equal(
                 &mut cs.namespace(|| "cont_is_call2_precomp"),
-                ContTag::Call2.as_field(),
+                ContTag::Call2.to_field(),
             )?;
             let cont_is_call2_and_not_dummy = and!(cs, &cont_is_call2_precomp, not_dummy)?;
 
@@ -3531,7 +3532,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
 
             let continuation_is_tail = continuation.alloc_tag_equal(
                 &mut cs.namespace(|| "continuation is tail"),
-                ContTag::Tail.as_field(),
+                ContTag::Tail.to_field(),
             )?;
 
             let tail_cont = AllocatedContPtr::pick(
@@ -3582,7 +3583,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
 
         let cont_is_binop = cont.alloc_tag_equal(
             &mut cs.namespace(|| "cont_is_binop"),
-            ContTag::Binop.as_field(),
+            ContTag::Binop.to_field(),
         )?;
 
         let binop_not_dummy = Boolean::and(
@@ -3602,7 +3603,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         )?;
 
         let op_is_begin =
-            operator.alloc_tag_equal(&mut cs.namespace(|| "op_is_begin"), Op2::Begin.as_field())?;
+            operator.alloc_tag_equal(&mut cs.namespace(|| "op_is_begin"), Op2::Begin.to_field())?;
 
         let rest_is_nil = allocated_rest.is_nil(&mut cs.namespace(|| "rest_is_nil"), g)?;
         let rest_not_nil = rest_is_nil.not();
@@ -3752,7 +3753,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
 
         let not_dummy = cont.alloc_tag_equal(
             &mut cs.namespace(|| "Binop2 not dummy"),
-            ContTag::Binop2.as_field(),
+            ContTag::Binop2.to_field(),
         )?;
 
         let sum = add(&mut cs.namespace(|| "sum"), a, b)?;
@@ -3760,9 +3761,9 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         let product = mul(&mut cs.namespace(|| "product"), a, b)?;
 
         let op2_is_div =
-            op2.alloc_tag_equal(&mut cs.namespace(|| "op2_is_div"), Op2::Quotient.as_field())?;
+            op2.alloc_tag_equal(&mut cs.namespace(|| "op2_is_div"), Op2::Quotient.to_field())?;
         let op2_is_mod =
-            op2.alloc_tag_equal(&mut cs.namespace(|| "op2_is_mod"), Op2::Modulo.as_field())?;
+            op2.alloc_tag_equal(&mut cs.namespace(|| "op2_is_mod"), Op2::Modulo.to_field())?;
 
         let op2_is_div_or_mod = or(
             &mut cs.namespace(|| "op2 is div or mod"),
@@ -3782,10 +3783,10 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         let quotient = div(&mut cs.namespace(|| "quotient"), a, &divisor)?;
 
         let is_cons =
-            op2.alloc_tag_equal(&mut cs.namespace(|| "Op2 is Cons"), Op2::Cons.as_field())?;
+            op2.alloc_tag_equal(&mut cs.namespace(|| "Op2 is Cons"), Op2::Cons.to_field())?;
         let is_strcons = op2.alloc_tag_equal(
             &mut cs.namespace(|| "Op2 is StrCons"),
-            Op2::StrCons.as_field(),
+            Op2::StrCons.to_field(),
         )?;
 
         let is_cons_or_strcons = or(
@@ -3831,39 +3832,39 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             op2.tag(),
             &[
                 CaseClause {
-                    key: Op2::Sum.as_field(),
+                    key: Op2::Sum.to_field(),
                     value: &sum,
                 },
                 CaseClause {
-                    key: Op2::Diff.as_field(),
+                    key: Op2::Diff.to_field(),
                     value: &diff,
                 },
                 CaseClause {
-                    key: Op2::Product.as_field(),
+                    key: Op2::Product.to_field(),
                     value: &product,
                 },
                 CaseClause {
-                    key: Op2::Quotient.as_field(),
+                    key: Op2::Quotient.to_field(),
                     value: &quotient,
                 },
                 CaseClause {
-                    key: Op2::Equal.as_field(),
+                    key: Op2::Equal.to_field(),
                     value: args_equal_ptr.hash(),
                 },
                 CaseClause {
-                    key: Op2::NumEqual.as_field(),
+                    key: Op2::NumEqual.to_field(),
                     value: args_equal_ptr.hash(),
                 },
                 CaseClause {
-                    key: Op2::Cons.as_field(),
+                    key: Op2::Cons.to_field(),
                     value: cons.hash(),
                 },
                 CaseClause {
-                    key: Op2::StrCons.as_field(),
+                    key: Op2::StrCons.to_field(),
                     value: cons.hash(),
                 },
                 CaseClause {
-                    key: Op2::Hide.as_field(),
+                    key: Op2::Hide.to_field(),
                     value: commitment.hash(),
                 },
             ],
@@ -3872,11 +3873,11 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         )?;
 
         let is_equal =
-            op2.alloc_tag_equal(&mut cs.namespace(|| "Op2 is Equal"), Op2::Equal.as_field())?;
+            op2.alloc_tag_equal(&mut cs.namespace(|| "Op2 is Equal"), Op2::Equal.to_field())?;
 
         let is_num_equal = op2.alloc_tag_equal(
             &mut cs.namespace(|| "Op2 is NumEqual"),
-            Op2::NumEqual.as_field(),
+            Op2::NumEqual.to_field(),
         )?;
 
         let is_equal_or_num_equal = or(
@@ -3886,7 +3887,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         )?;
 
         let op2_is_hide =
-            op2.alloc_tag_equal(&mut cs.namespace(|| "Op2 is Hide"), Op2::Hide.as_field())?;
+            op2.alloc_tag_equal(&mut cs.namespace(|| "Op2 is Hide"), Op2::Hide.to_field())?;
 
         let commitment_tag_is_comm =
             commitment.is_comm(&mut cs.namespace(|| "commitment tag is comm"))?;
@@ -3907,15 +3908,15 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         let cons_tag = pick_const(
             &mut cs.namespace(|| "cons_tag"),
             &is_strcons,
-            ExprTag::Str.as_field(),
-            ExprTag::Cons.as_field(),
+            ExprTag::Str.to_field(),
+            ExprTag::Cons.to_field(),
         )?;
 
         let comm_or_num_tag = pick_const(
             &mut cs.namespace(|| "Op2 tag is comm or num"),
             &op2_is_hide,
-            ExprTag::Comm.as_field(),
-            ExprTag::Num.as_field(),
+            ExprTag::Comm.to_field(),
+            ExprTag::Num.to_field(),
         )?;
 
         let is_cons_or_hide = or!(cs, &is_cons, &op2_is_hide)?;
@@ -3971,7 +3972,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         )?;
 
         let op2_is_diff =
-            op2.alloc_tag_equal(&mut cs.namespace(|| "op2_is_diff"), Op2::Diff.as_field())?;
+            op2.alloc_tag_equal(&mut cs.namespace(|| "op2_is_diff"), Op2::Diff.to_field())?;
 
         let diff_is_negative_and_op2_is_diff = Boolean::and(
             &mut cs.namespace(|| "diff is negative and op2 is diff"),
@@ -4085,7 +4086,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         )?;
 
         let op2_is_eval =
-            op2.alloc_tag_equal(&mut cs.namespace(|| "op2_is_eval"), Op2::Eval.as_field())?;
+            op2.alloc_tag_equal(&mut cs.namespace(|| "op2_is_eval"), Op2::Eval.to_field())?;
 
         let the_cont_ = AllocatedContPtr::pick(
             &mut cs.namespace(|| "maybe type or div by zero error"),
@@ -4149,7 +4150,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         let condition = result;
 
         let cont_is_if =
-            cont.alloc_tag_equal(&mut cs.namespace(|| "cont_is_if"), ContTag::If.as_field())?;
+            cont.alloc_tag_equal(&mut cs.namespace(|| "cont_is_if"), ContTag::If.to_field())?;
 
         let if_not_dummy = and!(cs, &cont_is_if, not_dummy)?;
 
@@ -4246,10 +4247,10 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         let let_cont = AllocatedContPtr::by_index(3, &continuation_components);
 
         let cont_is_let =
-            cont.alloc_tag_equal(&mut cs.namespace(|| "cont_is_let"), ContTag::Let.as_field())?;
+            cont.alloc_tag_equal(&mut cs.namespace(|| "cont_is_let"), ContTag::Let.to_field())?;
         let let_cont_is_let = let_cont.alloc_tag_equal(
             &mut cs.namespace(|| "let_cont_is_let"),
-            ContTag::Let.as_field(),
+            ContTag::Let.to_field(),
         )?;
 
         let extended_env_not_dummy = and!(cs, &let_cont_is_let, not_dummy, &cont_is_let)?;
@@ -4267,7 +4268,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
 
         let continuation_is_tail = let_cont.alloc_tag_equal(
             &mut cs.namespace(|| "continuation is tail"),
-            ContTag::Tail.as_field(),
+            ContTag::Tail.to_field(),
         )?;
 
         let tail_cont = AllocatedContPtr::pick(
@@ -4303,7 +4304,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
 
         let letrec_cont_is_letrec_cont = letrec_cont.alloc_tag_equal(
             &mut cs.namespace(|| "letrec_cont_is_letrec_cont"),
-            ContTag::LetRec.as_field(),
+            ContTag::LetRec.to_field(),
         )?;
 
         let extend_rec_not_dummy = and!(cs, &letrec_cont_is_letrec_cont, not_dummy)?;
@@ -4323,7 +4324,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
 
         let continuation_is_tail = letrec_cont.alloc_tag_equal(
             &mut cs.namespace(|| "continuation is tail"),
-            ContTag::Tail.as_field(),
+            ContTag::Tail.to_field(),
         )?;
 
         let tail_cont = AllocatedContPtr::pick(
@@ -4360,9 +4361,9 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         let other_unop_continuation = AllocatedContPtr::by_index(1, &continuation_components);
 
         let op1_is_emit =
-            unop_op1.alloc_tag_equal(&mut cs.namespace(|| "op1_is_emit"), Op1::Emit.as_field())?;
+            unop_op1.alloc_tag_equal(&mut cs.namespace(|| "op1_is_emit"), Op1::Emit.to_field())?;
         let op1_is_eval =
-            unop_op1.alloc_tag_equal(&mut cs.namespace(|| "op1_is_eval"), Op1::Eval.as_field())?;
+            unop_op1.alloc_tag_equal(&mut cs.namespace(|| "op1_is_eval"), Op1::Eval.to_field())?;
 
         let unop_continuation0 = AllocatedContPtr::pick(
             &mut cs.namespace(|| "unop_continuation0"),
@@ -4386,42 +4387,42 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         let car_cdr_is_valid = or!(cs, &result_is_cons, &result_is_str, &result_is_nil)?;
 
         let op1_is_car =
-            unop_op1.alloc_tag_equal(&mut cs.namespace(|| "op1_is_car"), Op1::Car.as_field())?;
+            unop_op1.alloc_tag_equal(&mut cs.namespace(|| "op1_is_car"), Op1::Car.to_field())?;
         let op1_is_cdr =
-            unop_op1.alloc_tag_equal(&mut cs.namespace(|| "op1_is_cdr"), Op1::Cdr.as_field())?;
+            unop_op1.alloc_tag_equal(&mut cs.namespace(|| "op1_is_cdr"), Op1::Cdr.to_field())?;
         let op1_is_car_or_cdr = or!(cs, &op1_is_car, &op1_is_cdr)?;
         let car_cdr_is_invalid = and!(cs, &op1_is_car_or_cdr, &car_cdr_is_valid.not())?;
 
         let op1_is_comm =
-            unop_op1.alloc_tag_equal(&mut cs.namespace(|| "op1_is_comm"), Op1::Comm.as_field())?;
+            unop_op1.alloc_tag_equal(&mut cs.namespace(|| "op1_is_comm"), Op1::Comm.to_field())?;
         let op1_is_num =
-            unop_op1.alloc_tag_equal(&mut cs.namespace(|| "op1_is_num"), Op1::Num.as_field())?;
+            unop_op1.alloc_tag_equal(&mut cs.namespace(|| "op1_is_num"), Op1::Num.to_field())?;
         let op1_is_char =
-            unop_op1.alloc_tag_equal(&mut cs.namespace(|| "op1_is_char"), Op1::Char.as_field())?;
+            unop_op1.alloc_tag_equal(&mut cs.namespace(|| "op1_is_char"), Op1::Char.to_field())?;
         let op1_is_open =
-            unop_op1.alloc_tag_equal(&mut cs.namespace(|| "op1_is_open"), Op1::Open.as_field())?;
+            unop_op1.alloc_tag_equal(&mut cs.namespace(|| "op1_is_open"), Op1::Open.to_field())?;
         let op1_is_secret = unop_op1.alloc_tag_equal(
             &mut cs.namespace(|| "op1_is_secret"),
-            Op1::Secret.as_field(),
+            Op1::Secret.to_field(),
         )?;
         let op1_is_u64 =
-            unop_op1.alloc_tag_equal(&mut cs.namespace(|| "op1_is_u64"), Op1::U64.as_field())?;
+            unop_op1.alloc_tag_equal(&mut cs.namespace(|| "op1_is_u64"), Op1::U64.to_field())?;
 
         let tag_is_char = result.alloc_tag_equal(
             &mut cs.namespace(|| "result_is_char"),
-            ExprTag::Char.as_field(),
+            ExprTag::Char.to_field(),
         )?;
         let tag_is_num = result.alloc_tag_equal(
             &mut cs.namespace(|| "result_is_num"),
-            ExprTag::Num.as_field(),
+            ExprTag::Num.to_field(),
         )?;
         let tag_is_comm = result.alloc_tag_equal(
             &mut cs.namespace(|| "result_is_comm"),
-            ExprTag::Comm.as_field(),
+            ExprTag::Comm.to_field(),
         )?;
         let tag_is_u64 = result.alloc_tag_equal(
             &mut cs.namespace(|| "result_is_u64"),
-            ExprTag::U64.as_field(),
+            ExprTag::U64.to_field(),
         )?;
 
         let tag_is_num_or_comm = or!(cs, &tag_is_num, &tag_is_comm)?;
@@ -4647,25 +4648,25 @@ pub fn comparison_helper<F: LurkField, CS: ConstraintSystem<F>>(
 
     let mut comp_results = CompResults::default();
     comp_results.add_clauses_comp(
-        Op2::Less.as_field(),
+        Op2::Less.to_field(),
         &alloc_num_diff_is_negative,
         &g.true_num,
         &g.false_num,
     );
     comp_results.add_clauses_comp(
-        Op2::LessEqual.as_field(),
+        Op2::LessEqual.to_field(),
         &alloc_num_diff_is_not_positive,
         &g.true_num,
         &g.false_num,
     );
     comp_results.add_clauses_comp(
-        Op2::Greater.as_field(),
+        Op2::Greater.to_field(),
         &alloc_num_diff_is_positive,
         &g.false_num,
         &g.true_num,
     );
     comp_results.add_clauses_comp(
-        Op2::GreaterEqual.as_field(),
+        Op2::GreaterEqual.to_field(),
         &alloc_num_diff_is_not_negative,
         &g.false_num,
         &g.true_num,

--- a/src/circuit/gadgets/data.rs
+++ b/src/circuit/gadgets/data.rs
@@ -9,9 +9,9 @@ use neptune::{
 
 use super::pointer::AsAllocatedHashComponents;
 use crate::field::LurkField;
+use crate::store::ScalarContPtr;
 use crate::store::{Expression, Pointer, Ptr, Store, Thunk};
 use crate::store::{IntoHashComponents, ScalarPtr};
-use crate::store::{ScalarContPtr, ScalarPointer};
 use crate::tag::{ContTag, ExprTag, Op1, Op2, Tag};
 
 use super::pointer::{AllocatedContPtr, AllocatedPtr};

--- a/src/circuit/gadgets/data.rs
+++ b/src/circuit/gadgets/data.rs
@@ -474,7 +474,10 @@ impl<F: LurkField> Thunk<F> {
         let value = AllocatedPtr::alloc(&mut cs.namespace(|| "Thunk component: value"), || {
             component_frs
                 .as_ref()
-                .map(|frs| ScalarPtr::from_parts(frs[0], frs[1]))
+                .and_then(|frs| {
+                    let opt_tag = ExprTag::from_field(&frs[0]);
+                    opt_tag.map(|tag| ScalarPtr::from_parts(tag, frs[1]))
+                })
                 .ok_or(SynthesisError::AssignmentMissing)
         })?;
 
@@ -483,7 +486,10 @@ impl<F: LurkField> Thunk<F> {
             || {
                 component_frs
                     .as_ref()
-                    .map(|frs| ScalarContPtr::from_parts(frs[2], frs[3]))
+                    .and_then(|frs| {
+                        let opt_tag = ContTag::from_field(&frs[2]);
+                        opt_tag.map(|tag| ScalarContPtr::from_parts(tag, frs[3]))
+                    })
                     .ok_or(SynthesisError::AssignmentMissing)
             },
         )?;
@@ -498,12 +504,12 @@ impl<F: LurkField> Thunk<F> {
         store: &Store<F>,
     ) -> Result<(AllocatedNum<F>, AllocatedPtr<F>, AllocatedContPtr<F>), SynthesisError> {
         let value = AllocatedPtr::alloc(&mut cs.namespace(|| "Thunk component: value"), || {
-            Ok(ScalarPtr::from_parts(F::zero(), F::zero()))
+            Ok(ScalarPtr::from_parts(ExprTag::Nil, F::zero()))
         })?;
 
         let cont = AllocatedContPtr::alloc(
             &mut cs.namespace(|| "Thunk component: continuation"),
-            || Ok(ScalarContPtr::from_parts(F::zero(), F::zero())),
+            || Ok(ScalarContPtr::from_parts(ContTag::Dummy, F::zero())),
         )?;
 
         let dummy_hash = Self::hash_components(cs.namespace(|| "Thunk"), store, &value, &cont)?;

--- a/src/circuit/gadgets/data.rs
+++ b/src/circuit/gadgets/data.rs
@@ -12,7 +12,7 @@ use crate::field::LurkField;
 use crate::store::{Expression, Pointer, Ptr, Store, Thunk};
 use crate::store::{IntoHashComponents, ScalarPtr};
 use crate::store::{ScalarContPtr, ScalarPointer};
-use crate::tag::{ContTag, ExprTag, Op1, Op2};
+use crate::tag::{ContTag, ExprTag, Op1, Op2, Tag};
 
 use super::pointer::{AllocatedContPtr, AllocatedPtr};
 
@@ -178,7 +178,7 @@ impl<F: LurkField> GlobalAllocations<F> {
             Op2::Modulo.allocate_constant(&mut cs.namespace(|| "op2_modulo_tag"))?;
         let op2_numequal_tag =
             AllocatedNum::alloc(&mut cs.namespace(|| "op2_numequal_tag"), || {
-                Ok(Op2::NumEqual.as_field())
+                Ok(Op2::NumEqual.to_field())
             })?;
         let op2_less_tag = Op2::Less.allocate_constant(&mut cs.namespace(|| "op2_less_tag"))?;
         let op2_less_equal_tag =
@@ -188,7 +188,7 @@ impl<F: LurkField> GlobalAllocations<F> {
         let op2_greater_equal_tag =
             Op2::GreaterEqual.allocate_constant(&mut cs.namespace(|| "op2_greater_equal_tag"))?;
         let op2_equal_tag = AllocatedNum::alloc(&mut cs.namespace(|| "op2_equal_tag"), || {
-            Ok(Op2::Equal.as_field())
+            Ok(Op2::Equal.to_field())
         })?;
 
         let c = store.get_constants();
@@ -409,7 +409,7 @@ impl ExprTag {
     ) -> Result<AllocatedNum<F>, SynthesisError> {
         allocate_constant(
             &mut cs.namespace(|| format!("{self:?} tag")),
-            self.as_field(),
+            self.to_field(),
         )
     }
 }
@@ -421,7 +421,7 @@ impl ContTag {
     ) -> Result<AllocatedNum<F>, SynthesisError> {
         allocate_constant(
             &mut cs.namespace(|| format!("{self:?} base continuation tag")),
-            self.as_field(),
+            self.to_field(),
         )
     }
 }
@@ -433,7 +433,7 @@ impl Op1 {
     ) -> Result<AllocatedNum<F>, SynthesisError> {
         allocate_constant(
             &mut cs.namespace(|| format!("{self:?} tag")),
-            self.as_field(),
+            self.to_field(),
         )
     }
 }
@@ -445,7 +445,7 @@ impl Op2 {
     ) -> Result<AllocatedNum<F>, SynthesisError> {
         allocate_constant(
             &mut cs.namespace(|| format!("{self:?} tag")),
-            self.as_field(),
+            self.to_field(),
         )
     }
 }

--- a/src/circuit/gadgets/hashes.rs
+++ b/src/circuit/gadgets/hashes.rs
@@ -8,7 +8,7 @@ use crate::circuit::gadgets::pointer::{AllocatedPtr, AsAllocatedHashComponents};
 
 use crate::field::LurkField;
 use crate::hash_witness::{ConsName, ConsWitness, ContName, ContWitness, HashName, Stub};
-use crate::store::{HashConst, HashConstants, ScalarPointer, ScalarPtr, Store};
+use crate::store::{HashConst, HashConstants, ScalarPtr, Store};
 use crate::tag::ExprTag;
 
 #[derive(Clone)]

--- a/src/circuit/gadgets/hashes.rs
+++ b/src/circuit/gadgets/hashes.rs
@@ -9,6 +9,7 @@ use crate::circuit::gadgets::pointer::{AllocatedPtr, AsAllocatedHashComponents};
 use crate::field::LurkField;
 use crate::hash_witness::{ConsName, ConsWitness, ContName, ContWitness, HashName, Stub};
 use crate::store::{HashConst, HashConstants, ScalarPointer, ScalarPtr, Store};
+use crate::tag::ExprTag;
 
 #[derive(Clone)]
 pub struct AllocatedHash<F: LurkField, PreimageType> {
@@ -152,8 +153,8 @@ impl<'a, F: LurkField> AllocatedConsWitness<'a, F> {
 
             let (car_ptr, cdr_ptr, cons_hash) = match p {
                 Stub::Dummy => (
-                    Some(ScalarPtr::from_parts(F::zero(), F::zero())),
-                    Some(ScalarPtr::from_parts(F::zero(), F::zero())),
+                    Some(ScalarPtr::from_parts(ExprTag::Nil, F::zero())),
+                    Some(ScalarPtr::from_parts(ExprTag::Nil, F::zero())),
                     None,
                 ),
                 Stub::Blank => (None, None, None),

--- a/src/circuit/gadgets/pointer.rs
+++ b/src/circuit/gadgets/pointer.rs
@@ -64,7 +64,7 @@ impl<F: LurkField> AllocatedPtr<F> {
         let alloc_tag = AllocatedNum::alloc(&mut cs.namespace(|| "tag"), || {
             let ptr = value()?;
             hash = Some(*ptr.value());
-            Ok(*ptr.tag())
+            Ok(ptr.tag())
         })?;
 
         let alloc_hash = AllocatedNum::alloc(&mut cs.namespace(|| "hash"), || {
@@ -81,7 +81,7 @@ impl<F: LurkField> AllocatedPtr<F> {
         cs: &mut CS,
         value: ScalarPtr<F>,
     ) -> Result<Self, SynthesisError> {
-        let alloc_tag = allocate_constant(&mut cs.namespace(|| "tag"), *value.tag())?;
+        let alloc_tag = allocate_constant(&mut cs.namespace(|| "tag"), value.tag())?;
         let alloc_hash = allocate_constant(&mut cs.namespace(|| "hash"), *value.value())?;
 
         Ok(AllocatedPtr {
@@ -450,7 +450,7 @@ impl<F: LurkField> AllocatedPtr<F> {
     where
         CS: ConstraintSystem<F>,
     {
-        let tag = pick_const(cs.namespace(|| "tag"), condition, *a.tag(), *b.tag())?;
+        let tag = pick_const(cs.namespace(|| "tag"), condition, a.tag(), b.tag())?;
         let hash = pick_const(cs.namespace(|| "hash"), condition, *a.value(), *b.value())?;
 
         Ok(AllocatedPtr { tag, hash })
@@ -472,7 +472,7 @@ impl<F: LurkField> AllocatedPtr<F> {
 
         let tag = AllocatedNum::alloc(cs.namespace(|| "tag"), || {
             ptr.as_ref()
-                .map(|th| *th.tag())
+                .map(|th| th.tag())
                 .ok_or(SynthesisError::AssignmentMissing)
         })?;
         tag.inputize(cs.namespace(|| "tag input"))?;
@@ -526,7 +526,7 @@ impl<F: LurkField> AllocatedContPtr<F> {
         let alloc_tag = AllocatedNum::alloc(&mut cs.namespace(|| "tag"), || {
             let ptr = value()?;
             hash = Some(*ptr.value());
-            Ok(*ptr.tag())
+            Ok(ptr.tag())
         })?;
 
         let alloc_hash = AllocatedNum::alloc(&mut cs.namespace(|| "hash"), || {
@@ -543,7 +543,7 @@ impl<F: LurkField> AllocatedContPtr<F> {
         cs: &mut CS,
         value: ScalarContPtr<F>,
     ) -> Result<Self, SynthesisError> {
-        let alloc_tag = allocate_constant(&mut cs.namespace(|| "tag"), *value.tag())?;
+        let alloc_tag = allocate_constant(&mut cs.namespace(|| "tag"), value.tag())?;
         let alloc_hash = allocate_constant(&mut cs.namespace(|| "hash"), *value.value())?;
 
         Ok(AllocatedContPtr {
@@ -667,7 +667,7 @@ impl<F: LurkField> AllocatedContPtr<F> {
         let ptr = cont.and_then(|c| store.hash_cont(c));
 
         let tag = AllocatedNum::alloc(cs.namespace(|| "continuation tag"), || {
-            ptr.map(|c| *c.tag())
+            ptr.map(|c| c.tag())
                 .ok_or(SynthesisError::AssignmentMissing)
         })?;
         tag.inputize(cs.namespace(|| "continuation tag input"))?;

--- a/src/circuit/gadgets/pointer.rs
+++ b/src/circuit/gadgets/pointer.rs
@@ -13,7 +13,7 @@ use crate::{
         ContPtr, Continuation, Expression, IntoHashComponents, Ptr, ScalarContPtr, ScalarPointer,
         ScalarPtr, Store, Thunk,
     },
-    tag::ExprTag,
+    tag::{ExprTag, Tag},
     writer::Write,
 };
 
@@ -183,34 +183,34 @@ impl<F: LurkField> AllocatedPtr<F> {
         alloc_equal(cs, self.tag(), g.nil_ptr.tag())
     }
     pub fn is_cons<CS: ConstraintSystem<F>>(&self, cs: &mut CS) -> Result<Boolean, SynthesisError> {
-        self.alloc_tag_equal(&mut cs.namespace(|| "is_cons"), ExprTag::Cons.as_field())
+        self.alloc_tag_equal(&mut cs.namespace(|| "is_cons"), ExprTag::Cons.to_field())
     }
     pub fn is_str<CS: ConstraintSystem<F>>(&self, cs: &mut CS) -> Result<Boolean, SynthesisError> {
-        self.alloc_tag_equal(&mut cs.namespace(|| "is_str"), ExprTag::Str.as_field())
+        self.alloc_tag_equal(&mut cs.namespace(|| "is_str"), ExprTag::Str.to_field())
     }
     pub fn is_num<CS: ConstraintSystem<F>>(&self, cs: &mut CS) -> Result<Boolean, SynthesisError> {
-        self.alloc_tag_equal(&mut cs.namespace(|| "is_num"), ExprTag::Num.as_field())
+        self.alloc_tag_equal(&mut cs.namespace(|| "is_num"), ExprTag::Num.to_field())
     }
     pub fn is_u64<CS: ConstraintSystem<F>>(&self, cs: &mut CS) -> Result<Boolean, SynthesisError> {
-        self.alloc_tag_equal(&mut cs.namespace(|| "is_u64"), ExprTag::U64.as_field())
+        self.alloc_tag_equal(&mut cs.namespace(|| "is_u64"), ExprTag::U64.to_field())
     }
     pub fn is_char<CS: ConstraintSystem<F>>(&self, cs: &mut CS) -> Result<Boolean, SynthesisError> {
-        self.alloc_tag_equal(&mut cs.namespace(|| "is_char"), ExprTag::Char.as_field())
+        self.alloc_tag_equal(&mut cs.namespace(|| "is_char"), ExprTag::Char.to_field())
     }
     pub fn is_comm<CS: ConstraintSystem<F>>(&self, cs: &mut CS) -> Result<Boolean, SynthesisError> {
-        self.alloc_tag_equal(&mut cs.namespace(|| "is_comm"), ExprTag::Comm.as_field())
+        self.alloc_tag_equal(&mut cs.namespace(|| "is_comm"), ExprTag::Comm.to_field())
     }
     pub fn is_sym<CS: ConstraintSystem<F>>(&self, cs: &mut CS) -> Result<Boolean, SynthesisError> {
-        self.alloc_tag_equal(&mut cs.namespace(|| "is_sym"), ExprTag::Sym.as_field())
+        self.alloc_tag_equal(&mut cs.namespace(|| "is_sym"), ExprTag::Sym.to_field())
     }
     pub fn is_fun<CS: ConstraintSystem<F>>(&self, cs: &mut CS) -> Result<Boolean, SynthesisError> {
-        self.alloc_tag_equal(&mut cs.namespace(|| "is_fun"), ExprTag::Fun.as_field())
+        self.alloc_tag_equal(&mut cs.namespace(|| "is_fun"), ExprTag::Fun.to_field())
     }
     pub fn is_thunk<CS: ConstraintSystem<F>>(
         &self,
         cs: &mut CS,
     ) -> Result<Boolean, SynthesisError> {
-        self.alloc_tag_equal(&mut cs.namespace(|| "is_thunk"), ExprTag::Thunk.as_field())
+        self.alloc_tag_equal(&mut cs.namespace(|| "is_thunk"), ExprTag::Thunk.to_field())
     }
 
     pub fn ptr(&self, store: &Store<F>) -> Option<Ptr<F>> {

--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -2,7 +2,7 @@
 use crate::field::LurkField;
 
 use crate::eval::IO;
-use crate::store::{ScalarPointer, Store};
+use crate::store::Store;
 
 #[macro_use]
 pub(crate) mod gadgets;
@@ -33,11 +33,11 @@ impl<F: LurkField> ToInputs<F> for IO<F> {
         let env = store.get_expr_hash(&self.env).unwrap();
         let cont = store.hash_cont(&self.cont).unwrap();
         let public_inputs = vec![
-            expr.tag(),
+            expr.tag_field(),
             *expr.value(),
-            env.tag(),
+            env.tag_field(),
             *env.value(),
-            cont.tag(),
+            cont.tag_field(),
             *cont.value(),
         ];
 

--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -33,11 +33,11 @@ impl<F: LurkField> ToInputs<F> for IO<F> {
         let env = store.get_expr_hash(&self.env).unwrap();
         let cont = store.hash_cont(&self.cont).unwrap();
         let public_inputs = vec![
-            *expr.tag(),
+            expr.tag(),
             *expr.value(),
-            *env.tag(),
+            env.tag(),
             *env.value(),
-            *cont.tag(),
+            cont.tag(),
             *cont.value(),
         ];
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -216,11 +216,11 @@ impl<F: LurkField> IO<F> {
             .hash_cont(&self.cont)
             .ok_or_else(|| store::Error("expr hash missing".into()))?;
         Ok(vec![
-            *expr_scalar_ptr.tag(),
+            expr_scalar_ptr.tag(),
             *expr_scalar_ptr.value(),
-            *env_scalar_ptr.tag(),
+            env_scalar_ptr.tag(),
             *env_scalar_ptr.value(),
-            *cont_scalar_ptr.tag(),
+            cont_scalar_ptr.tag(),
             *cont_scalar_ptr.value(),
         ])
     }
@@ -4286,7 +4286,7 @@ mod test {
         let scalar_ptr = &s.get_expr_hash(&x).unwrap();
 
         assert_eq!(&Fr::zero(), scalar_ptr.value());
-        assert_eq!(&ExprTag::Sym.to_field::<Fr>(), scalar_ptr.tag());
+        assert_eq!(ExprTag::Sym.to_field::<Fr>(), scalar_ptr.tag());
     }
 
     #[test]
@@ -4339,8 +4339,8 @@ mod test {
         );
 
         // The tags differ though.
-        assert_eq!(&ExprTag::Sym.to_field::<Fr>(), sym_scalar_ptr.tag());
-        assert_eq!(&ExprTag::Key.to_field::<Fr>(), key_scalar_ptr.tag());
+        assert_eq!(ExprTag::Sym.to_field::<Fr>(), sym_scalar_ptr.tag());
+        assert_eq!(ExprTag::Key.to_field::<Fr>(), key_scalar_ptr.tag());
     }
 
     #[test]

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2273,7 +2273,7 @@ pub fn eval_to_ptr<F: LurkField>(s: &mut Store<F>, src: &str) -> Result<Ptr<F>, 
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::tag::Op;
+    use crate::tag::{Op, Tag};
     use crate::writer::Write;
     use blstrs::Scalar as Fr;
 
@@ -4286,7 +4286,7 @@ mod test {
         let scalar_ptr = &s.get_expr_hash(&x).unwrap();
 
         assert_eq!(&Fr::zero(), scalar_ptr.value());
-        assert_eq!(&ExprTag::Sym.as_field::<Fr>(), scalar_ptr.tag());
+        assert_eq!(&ExprTag::Sym.to_field::<Fr>(), scalar_ptr.tag());
     }
 
     #[test]
@@ -4339,8 +4339,8 @@ mod test {
         );
 
         // The tags differ though.
-        assert_eq!(&ExprTag::Sym.as_field::<Fr>(), sym_scalar_ptr.tag());
-        assert_eq!(&ExprTag::Key.as_field::<Fr>(), key_scalar_ptr.tag());
+        assert_eq!(&ExprTag::Sym.to_field::<Fr>(), sym_scalar_ptr.tag());
+        assert_eq!(&ExprTag::Key.to_field::<Fr>(), key_scalar_ptr.tag());
     }
 
     #[test]

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -4,8 +4,7 @@ use crate::hash_witness::{ConsName, ConsWitness, ContName, ContWitness};
 use crate::num::Num;
 use crate::store;
 use crate::store::{
-    ContPtr, Continuation, Expression, NamedConstants, Pointer, Ptr, ScalarPointer, Store, Thunk,
-    TypePredicates,
+    ContPtr, Continuation, Expression, NamedConstants, Pointer, Ptr, Store, Thunk, TypePredicates,
 };
 use crate::tag::{ContTag, ExprTag, Op1, Op2};
 use crate::writer::Write;
@@ -216,11 +215,11 @@ impl<F: LurkField> IO<F> {
             .hash_cont(&self.cont)
             .ok_or_else(|| store::Error("expr hash missing".into()))?;
         Ok(vec![
-            expr_scalar_ptr.tag(),
+            expr_scalar_ptr.tag_field(),
             *expr_scalar_ptr.value(),
-            env_scalar_ptr.tag(),
+            env_scalar_ptr.tag_field(),
             *env_scalar_ptr.value(),
-            cont_scalar_ptr.tag(),
+            cont_scalar_ptr.tag_field(),
             *cont_scalar_ptr.value(),
         ])
     }
@@ -2273,7 +2272,7 @@ pub fn eval_to_ptr<F: LurkField>(s: &mut Store<F>, src: &str) -> Result<Ptr<F>, 
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::tag::{Op, Tag};
+    use crate::tag::Op;
     use crate::writer::Write;
     use blstrs::Scalar as Fr;
 
@@ -3456,7 +3455,6 @@ mod test {
 
     #[test]
     fn hide_opaque_open_available() {
-        use crate::store::ScalarPointer;
         use crate::Num;
 
         let s = &mut Store::<Fr>::default();
@@ -3494,8 +3492,6 @@ mod test {
     #[test]
     #[should_panic]
     fn hide_opaque_open_unavailable() {
-        use crate::store::ScalarPointer;
-
         let s = &mut Store::<Fr>::default();
         let commitment = eval_to_ptr(s, "(hide 123 'x)").unwrap();
 
@@ -4286,12 +4282,11 @@ mod test {
         let scalar_ptr = &s.get_expr_hash(&x).unwrap();
 
         assert_eq!(&Fr::zero(), scalar_ptr.value());
-        assert_eq!(ExprTag::Sym.to_field::<Fr>(), scalar_ptr.tag());
+        assert_eq!(ExprTag::Sym, scalar_ptr.tag());
     }
 
     #[test]
     fn test_sym_hash_values() {
-        use crate::store::ScalarPointer;
         use crate::sym::Sym;
 
         let s = &mut Store::<Fr>::default();
@@ -4339,8 +4334,8 @@ mod test {
         );
 
         // The tags differ though.
-        assert_eq!(ExprTag::Sym.to_field::<Fr>(), sym_scalar_ptr.tag());
-        assert_eq!(ExprTag::Key.to_field::<Fr>(), key_scalar_ptr.tag());
+        assert_eq!(ExprTag::Sym, sym_scalar_ptr.tag());
+        assert_eq!(ExprTag::Key, key_scalar_ptr.tag());
     }
 
     #[test]

--- a/src/light_data/light_store.rs
+++ b/src/light_data/light_store.rs
@@ -17,7 +17,7 @@ use crate::scalar_store::ScalarStore;
 use crate::store::ScalarPointer;
 use crate::store::ScalarPtr;
 use crate::sym::Sym;
-use crate::tag::ExprTag;
+use crate::tag::{ExprTag, Tag};
 
 use crate::field::LurkField;
 
@@ -56,7 +56,7 @@ impl<F: LurkField> LightStore<F> {
         let mut s = String::new();
         let mut tail_ptrs = vec![];
         let mut ptr = ptr0;
-        let strnil_ptr = ScalarPtr::from_parts(ExprTag::Str.as_field(), F::zero());
+        let strnil_ptr = ScalarPtr::from_parts(ExprTag::Str.to_field(), F::zero());
 
         // TODO: this needs to bail on encountering an opaque pointer
         while let Some(LightExpr::StrCons(c, cs)) = self.get(&ptr).flatten() {
@@ -103,7 +103,7 @@ impl<F: LurkField> LightStore<F> {
         let mut path = Sym::root();
         let mut tail_ptrs = vec![ptr0];
         let mut ptr = ptr0;
-        let symnil_ptr = ScalarPtr::from_parts(ExprTag::Sym.as_field(), F::zero());
+        let symnil_ptr = ScalarPtr::from_parts(ExprTag::Sym.to_field(), F::zero());
 
         // TODO: this needs to bail on encountering an opaque pointer
         while let Some(LightExpr::SymCons(s, ss)) = self.get(&ptr).flatten() {
@@ -324,22 +324,22 @@ pub mod tests {
         fn test_convert_light_store_basic_strings((ptr3, ptr4, c1, c2) in any::<(ScalarPtr<Scalar>, ScalarPtr<Scalar>, char, char)>().prop_filter(
             "Avoids confusion with StrNil",
             |(ptr3, ptr4,_c1, _c2)| {
-                let strnil = ScalarPtr::from_parts(ExprTag::Str.as_field(), Scalar::zero());
+                let strnil = ScalarPtr::from_parts(ExprTag::Str.to_field(), Scalar::zero());
                 *ptr3 != strnil && *ptr4 != strnil
             })
         ) {
-            let ptr1 = ScalarPtr::from_parts(ExprTag::Char.as_field(), Scalar::from_char(c1));
-            let ptr2 = ScalarPtr::from_parts(ExprTag::Char.as_field(), Scalar::from_char(c2));
+            let ptr1 = ScalarPtr::from_parts(ExprTag::Char.to_field(), Scalar::from_char(c1));
+            let ptr2 = ScalarPtr::from_parts(ExprTag::Char.to_field(), Scalar::from_char(c2));
 
             let mut store = BTreeMap::new();
-            let strnil = ScalarPtr::from_parts(ExprTag::Str.as_field(), Scalar::zero());
+            let strnil = ScalarPtr::from_parts(ExprTag::Str.to_field(), Scalar::zero());
             store.insert(ptr3, Some(LightExpr::StrCons(ptr1, strnil)));
             store.insert(ptr4, Some(LightExpr::StrCons(ptr2, ptr3)));
 
             let expected_output = {
                 let mut output = ScalarStore::default();
                 output.insert_scalar_expression(
-                    ScalarPtr::from_parts(ExprTag::Str.as_field(), Scalar::zero()),
+                    ScalarPtr::from_parts(ExprTag::Str.to_field(), Scalar::zero()),
                     Some(ScalarExpression::Str(String::from(""))),
                 );
                 output.insert_scalar_expression(ptr1, Some(ScalarExpression::Char(c1)));
@@ -357,19 +357,19 @@ pub mod tests {
         fn test_convert_light_store_basic_symbols((ptr3, ptr4, ptr5, ptr6, c1, c2) in any::<(ScalarPtr<Scalar>, ScalarPtr<Scalar>, ScalarPtr<Scalar>, ScalarPtr<Scalar>, char, char)>().prop_filter(
             "Avoids confusion with StrNil, Symnil",
             |(ptr3, ptr4, ptr5, ptr6, c1, c2)| {
-                let symnil = ScalarPtr::from_parts(ExprTag::Sym.as_field(), Scalar::zero());
-                let strnil = ScalarPtr::from_parts(ExprTag::Str.as_field(), Scalar::zero());
+                let symnil = ScalarPtr::from_parts(ExprTag::Sym.to_field(), Scalar::zero());
+                let strnil = ScalarPtr::from_parts(ExprTag::Str.to_field(), Scalar::zero());
                 *ptr3 != strnil && *ptr4 != strnil && *ptr5 != strnil && *ptr6 != strnil &&
                 *ptr3 != symnil && *ptr4 != symnil && *ptr5 != symnil && *ptr6 != symnil &&
                 c2.to_string() != parser::SYM_SEPARATOR && c1.to_string() != parser::SYM_SEPARATOR
             })
         ) {
-            let ptr1 = ScalarPtr::from_parts(ExprTag::Char.as_field(), Scalar::from_char(c1));
-            let ptr2 = ScalarPtr::from_parts(ExprTag::Char.as_field(), Scalar::from_char(c2));
+            let ptr1 = ScalarPtr::from_parts(ExprTag::Char.to_field(), Scalar::from_char(c1));
+            let ptr2 = ScalarPtr::from_parts(ExprTag::Char.to_field(), Scalar::from_char(c2));
 
             let mut store = BTreeMap::new();
-            let strnil = ScalarPtr::from_parts(ExprTag::Str.as_field(), Scalar::zero());
-            let symnil = ScalarPtr::from_parts(ExprTag::Sym.as_field(), Scalar::zero());
+            let strnil = ScalarPtr::from_parts(ExprTag::Str.to_field(), Scalar::zero());
+            let symnil = ScalarPtr::from_parts(ExprTag::Sym.to_field(), Scalar::zero());
             store.insert(ptr3, Some(LightExpr::StrCons(ptr1, strnil)));
             store.insert(ptr4, Some(LightExpr::StrCons(ptr2, ptr3)));
             store.insert(ptr5, Some(LightExpr::SymCons(ptr3, symnil)));

--- a/src/light_data/light_store.rs
+++ b/src/light_data/light_store.rs
@@ -17,7 +17,7 @@ use crate::scalar_store::ScalarStore;
 use crate::store::ScalarPointer;
 use crate::store::ScalarPtr;
 use crate::sym::Sym;
-use crate::tag::{ExprTag, Tag};
+use crate::tag::ExprTag;
 
 use crate::field::LurkField;
 
@@ -56,7 +56,7 @@ impl<F: LurkField> LightStore<F> {
         let mut s = String::new();
         let mut tail_ptrs = vec![];
         let mut ptr = ptr0;
-        let strnil_ptr = ScalarPtr::from_parts(ExprTag::Str.to_field(), F::zero());
+        let strnil_ptr = ScalarPtr::from_parts(ExprTag::Str, F::zero());
 
         // TODO: this needs to bail on encountering an opaque pointer
         while let Some(LightExpr::StrCons(c, cs)) = self.get(&ptr).flatten() {
@@ -103,7 +103,7 @@ impl<F: LurkField> LightStore<F> {
         let mut path = Sym::root();
         let mut tail_ptrs = vec![ptr0];
         let mut ptr = ptr0;
-        let symnil_ptr = ScalarPtr::from_parts(ExprTag::Sym.to_field(), F::zero());
+        let symnil_ptr = ScalarPtr::from_parts(ExprTag::Sym, F::zero());
 
         // TODO: this needs to bail on encountering an opaque pointer
         while let Some(LightExpr::SymCons(s, ss)) = self.get(&ptr).flatten() {
@@ -324,22 +324,22 @@ pub mod tests {
         fn test_convert_light_store_basic_strings((ptr3, ptr4, c1, c2) in any::<(ScalarPtr<Scalar>, ScalarPtr<Scalar>, char, char)>().prop_filter(
             "Avoids confusion with StrNil",
             |(ptr3, ptr4,_c1, _c2)| {
-                let strnil = ScalarPtr::from_parts(ExprTag::Str.to_field(), Scalar::zero());
+                let strnil = ScalarPtr::from_parts(ExprTag::Str, Scalar::zero());
                 *ptr3 != strnil && *ptr4 != strnil
             })
         ) {
-            let ptr1 = ScalarPtr::from_parts(ExprTag::Char.to_field(), Scalar::from_char(c1));
-            let ptr2 = ScalarPtr::from_parts(ExprTag::Char.to_field(), Scalar::from_char(c2));
+            let ptr1 = ScalarPtr::from_parts(ExprTag::Char, Scalar::from_char(c1));
+            let ptr2 = ScalarPtr::from_parts(ExprTag::Char, Scalar::from_char(c2));
 
             let mut store = BTreeMap::new();
-            let strnil = ScalarPtr::from_parts(ExprTag::Str.to_field(), Scalar::zero());
+            let strnil = ScalarPtr::from_parts(ExprTag::Str, Scalar::zero());
             store.insert(ptr3, Some(LightExpr::StrCons(ptr1, strnil)));
             store.insert(ptr4, Some(LightExpr::StrCons(ptr2, ptr3)));
 
             let expected_output = {
                 let mut output = ScalarStore::default();
                 output.insert_scalar_expression(
-                    ScalarPtr::from_parts(ExprTag::Str.to_field(), Scalar::zero()),
+                    ScalarPtr::from_parts(ExprTag::Str, Scalar::zero()),
                     Some(ScalarExpression::Str(String::from(""))),
                 );
                 output.insert_scalar_expression(ptr1, Some(ScalarExpression::Char(c1)));
@@ -357,19 +357,19 @@ pub mod tests {
         fn test_convert_light_store_basic_symbols((ptr3, ptr4, ptr5, ptr6, c1, c2) in any::<(ScalarPtr<Scalar>, ScalarPtr<Scalar>, ScalarPtr<Scalar>, ScalarPtr<Scalar>, char, char)>().prop_filter(
             "Avoids confusion with StrNil, Symnil",
             |(ptr3, ptr4, ptr5, ptr6, c1, c2)| {
-                let symnil = ScalarPtr::from_parts(ExprTag::Sym.to_field(), Scalar::zero());
-                let strnil = ScalarPtr::from_parts(ExprTag::Str.to_field(), Scalar::zero());
+                let symnil = ScalarPtr::from_parts(ExprTag::Sym, Scalar::zero());
+                let strnil = ScalarPtr::from_parts(ExprTag::Str, Scalar::zero());
                 *ptr3 != strnil && *ptr4 != strnil && *ptr5 != strnil && *ptr6 != strnil &&
                 *ptr3 != symnil && *ptr4 != symnil && *ptr5 != symnil && *ptr6 != symnil &&
                 c2.to_string() != parser::SYM_SEPARATOR && c1.to_string() != parser::SYM_SEPARATOR
             })
         ) {
-            let ptr1 = ScalarPtr::from_parts(ExprTag::Char.to_field(), Scalar::from_char(c1));
-            let ptr2 = ScalarPtr::from_parts(ExprTag::Char.to_field(), Scalar::from_char(c2));
+            let ptr1 = ScalarPtr::from_parts(ExprTag::Char, Scalar::from_char(c1));
+            let ptr2 = ScalarPtr::from_parts(ExprTag::Char, Scalar::from_char(c2));
 
             let mut store = BTreeMap::new();
-            let strnil = ScalarPtr::from_parts(ExprTag::Str.to_field(), Scalar::zero());
-            let symnil = ScalarPtr::from_parts(ExprTag::Sym.to_field(), Scalar::zero());
+            let strnil = ScalarPtr::from_parts(ExprTag::Str, Scalar::zero());
+            let symnil = ScalarPtr::from_parts(ExprTag::Sym, Scalar::zero());
             store.insert(ptr3, Some(LightExpr::StrCons(ptr1, strnil)));
             store.insert(ptr4, Some(LightExpr::StrCons(ptr2, ptr3)));
             store.insert(ptr5, Some(LightExpr::SymCons(ptr3, symnil)));

--- a/src/light_data/light_store.rs
+++ b/src/light_data/light_store.rs
@@ -14,7 +14,6 @@ use crate::light_data::Encodable;
 use crate::light_data::LightData;
 use crate::scalar_store::ScalarExpression;
 use crate::scalar_store::ScalarStore;
-use crate::store::ScalarPointer;
 use crate::store::ScalarPtr;
 use crate::sym::Sym;
 use crate::tag::ExprTag;

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -3051,8 +3051,6 @@ mod tests {
     }
     #[test]
     fn test_prove_head_with_sym_mimicking_value() {
-        use crate::store::ScalarPointer;
-
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
 

--- a/src/scalar_store.rs
+++ b/src/scalar_store.rs
@@ -326,8 +326,6 @@ mod test {
     use super::*;
     use crate::eval::empty_sym_env;
 
-    use crate::store::ScalarPointer;
-
     use blstrs::Scalar as Fr;
 
     use tap::TapFallible;

--- a/src/scalar_store.rs
+++ b/src/scalar_store.rs
@@ -342,30 +342,40 @@ mod test {
             let y = from_ipld(to_ipld).unwrap();
             assert_eq!(x, y);
         }
-    }
 
-    proptest! {
         #[test]
-        fn prop_scalar_expression_ipld(x: ScalarExpression<Fr>) {
-            let to_ipld = to_ipld(x.clone()).tap_err(|e| {
+        fn prop_scalar_expression_ipld(x in any::<ScalarExpression<Fr>>()) {
+            let to_ipld = to_ipld(x.clone())
+            .tap_err(|e| {
                 println!("ser x: {x:?}");
                 println!("err e: {e:?}");
-            }).unwrap();
+            })
+            .unwrap();
 
-            let y = from_ipld(to_ipld.clone()).tap_err(|e| {
+            let y = from_ipld(to_ipld.clone())
+            .tap_err(|e| {
                 println!("ser x: {x:?}");
                 println!("de ipld: {to_ipld:?}");
                 println!("err e: {e:?}");
-            }).unwrap();
+            })
+            .unwrap();
 
             println!("x: {x:?}");
             println!("y: {y:?}");
 
             assert_eq!(x, y);
-
         }
 
-        fn prop_scalar_continuation_ipld(x: ScalarExpression<Fr>) {
+
+        #[test]
+        fn prop_scalar_expr_ipld(x in any::< ScalarExpression<Fr>>()) {
+            let to_ipld = to_ipld(x.clone()).unwrap();
+            let from_ipld = from_ipld(to_ipld).unwrap();
+            assert_eq!(x, from_ipld);
+        }
+
+        #[test]
+        fn prop_scalar_cont_ipld(x in any::<ScalarContinuation<Fr>>()) {
             let to_ipld = to_ipld(x.clone()).unwrap();
             let from_ipld = from_ipld(to_ipld).unwrap();
             assert_eq!(x, from_ipld);
@@ -380,12 +390,12 @@ mod test {
             prop::collection::btree_map(
                 any::<ScalarPtr<Fr>>(),
                 any::<Option<ScalarExpression<Fr>>>(),
-                0..100,
+                0..1,
             ),
             prop::collection::btree_map(
                 any::<ScalarContPtr<Fr>>(),
                 any::<Option<ScalarContinuation<Fr>>>(),
-                0..100,
+                0..1,
             ),
         )
             .prop_map(|(scalar_map, scalar_cont_map)| ScalarStore {

--- a/src/store.rs
+++ b/src/store.rs
@@ -316,6 +316,11 @@ impl<F: LurkField> Pointer<F> for Ptr<F> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(not(target_arch = "wasm32"), derive(Arbitrary))]
 // Note: the trait bound E: Tag is not necessary in the struct, but it makes the proptest strategy more efficient.
+/// A struct representing a scalar pointer with a tag and a value.
+///
+/// The `SPtr` struct is used to store a tagged scalar pointer, where `E` is its tag, and `F` the field for its values.
+/// It has two important aliases, `ScalarPtr` and `ScalarContPtr`, which are used respectively with `ExprTag` and `ContTag`,
+/// i.e. the type of expressions and the type of continuations.
 pub struct SPtr<E: Tag, F: LurkField>(
     E,
     #[cfg_attr(

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,5 +1,8 @@
+use anyhow::anyhow;
 use generic_array::typenum::{U3, U4, U6, U8};
 use neptune::Poseidon;
+#[cfg(not(target_arch = "wasm32"))]
+use proptest_derive::Arbitrary;
 use rayon::prelude::*;
 use std::collections::VecDeque;
 use std::fmt::{Display, Formatter};
@@ -236,8 +239,8 @@ pub trait Object<F: LurkField>: fmt::Debug + Clone + PartialEq {
 }
 
 pub trait Pointer<F: LurkField + From<u64>>: fmt::Debug + Copy + Clone + PartialEq + Hash {
-    type Tag: Into<u64>;
-    type ScalarPointer: ScalarPointer<F>;
+    type Tag: Into<u64> + Tag;
+    type ScalarPointer: ScalarPointer<Self::Tag, F>;
 
     fn tag(&self) -> Self::Tag;
     fn tag_field(&self) -> F {
@@ -245,9 +248,11 @@ pub trait Pointer<F: LurkField + From<u64>>: fmt::Debug + Copy + Clone + Partial
     }
 }
 
-pub trait ScalarPointer<F: LurkField>: fmt::Debug + Copy + Clone + PartialEq + Hash {
-    fn from_parts(tag: F, value: F) -> Self;
-    fn tag(&self) -> &F;
+pub trait ScalarPointer<E: Tag, F: LurkField>:
+    fmt::Debug + Copy + Clone + PartialEq + Hash
+{
+    fn from_parts(tag: E, value: F) -> Self;
+    fn tag(&self) -> F;
     fn value(&self) -> &F;
 }
 
@@ -318,57 +323,79 @@ impl<F: LurkField> Pointer<F> for Ptr<F> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ScalarPtr<F: LurkField>(F, F);
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Arbitrary))]
+pub struct SPtr<E, F: LurkField>(
+    E,
+    #[proptest(strategy = "any::<FWrap<F>>().prop_map(|x| x.0)")] F,
+);
 
-impl<F: LurkField> Copy for ScalarPtr<F> {}
-
-impl<F: LurkField> Display for ScalarPtr<F> {
+impl<E: Tag, F: LurkField> Display for SPtr<E, F> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let trimmed_f1 = self.0.trimmed_hex_digits();
+        let trimmed_f1 = self.0.to_field::<F>().trimmed_hex_digits();
         let trimmed_f2 = self.1.trimmed_hex_digits();
         write!(f, "(ptr->{trimmed_f1}, {trimmed_f2})",)
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
-impl<Fr: LurkField> Arbitrary for ScalarPtr<Fr> {
-    type Parameters = ();
-    type Strategy = BoxedStrategy<Self>;
-
-    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        any::<(ExprTag, FWrap<Fr>)>()
-            .prop_map(|(tag, val)| ScalarPtr::from_parts(Fr::from(tag as u64), val.0))
-            .boxed()
-    }
-}
-
-impl<F: LurkField> PartialOrd for ScalarPtr<F> {
+impl<E: Tag, F: LurkField> PartialOrd for SPtr<E, F> {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        (self.0.to_repr().as_ref(), self.1.to_repr().as_ref())
-            .partial_cmp(&(other.0.to_repr().as_ref(), other.1.to_repr().as_ref()))
+        (
+            self.0.to_field::<F>().to_repr().as_ref(),
+            self.1.to_repr().as_ref(),
+        )
+            .partial_cmp(&(
+                other.0.to_field::<F>().to_repr().as_ref(),
+                other.1.to_repr().as_ref(),
+            ))
     }
 }
 
-impl<F: LurkField> Ord for ScalarPtr<F> {
+impl<E: Tag, F: LurkField> Ord for SPtr<E, F> {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        (self.0.to_repr().as_ref(), self.1.to_repr().as_ref())
-            .cmp(&(other.0.to_repr().as_ref(), other.1.to_repr().as_ref()))
+        self.partial_cmp(other)
+            .expect("SPtr::cmp: partial_cmp domain invariant violation")
     }
 }
 
-impl<F: LurkField> Encodable for ScalarPtr<F> {
+impl<E: Tag, F: LurkField> Encodable for SPtr<E, F> {
     fn ser(&self) -> LightData {
-        let (x, y): (FWrap<F>, FWrap<F>) = (FWrap(self.0), FWrap(self.1));
+        let (x, y): (FWrap<F>, FWrap<F>) = (FWrap(self.0.to_field()), FWrap(self.1));
         (x, y).ser()
     }
     fn de(ld: &LightData) -> anyhow::Result<Self> {
         let (x, y): (FWrap<F>, FWrap<F>) = Encodable::de(ld)?;
-        Ok(ScalarPtr::from_parts(x.0, y.0))
+        let tag_as_u16 =
+            x.0.to_u16()
+                .ok_or_else(|| anyhow!("invalid range for field element representing a tag"))?;
+        let tag = E::try_from(tag_as_u16).map_err(|_| anyhow!("invalid tag"))?;
+        Ok(SPtr(tag, y.0))
     }
 }
 
-impl<F: LurkField> Serialize for ScalarPtr<F> {
+#[allow(clippy::derive_hash_xor_eq)]
+impl<E: Tag, F: LurkField> Hash for SPtr<E, F> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.to_field::<F>().to_repr().as_ref().hash(state);
+        self.1.to_repr().as_ref().hash(state);
+    }
+}
+
+impl<E: Tag, F: LurkField> ScalarPointer<E, F> for SPtr<E, F> {
+    fn from_parts(tag: E, value: F) -> Self {
+        SPtr(tag, value)
+    }
+
+    fn tag(&self) -> F {
+        self.0.to_field::<F>()
+    }
+
+    fn value(&self) -> &F {
+        &self.1
+    }
+}
+
+impl<E: Tag, F: LurkField> Serialize for SPtr<E, F> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -386,7 +413,7 @@ impl<F: LurkField> Serialize for ScalarPtr<F> {
     }
 }
 
-impl<'de, F: LurkField> Deserialize<'de> for ScalarPtr<F> {
+impl<'de, E: Tag, F: LurkField> Deserialize<'de> for SPtr<E, F> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -396,31 +423,13 @@ impl<'de, F: LurkField> Deserialize<'de> for ScalarPtr<F> {
         let tag = F::from_u64(cid.codec() & 0x0000_0000_ffff_ffff);
         let val = F::from_bytes(cid.hash().digest())
             .ok_or_else(|| D::Error::custom("expected ScalarContPtr value".to_string()))?;
-        Ok(ScalarPtr::from_parts(tag, val))
+        // TODO(fga): eliminate this round-trip through the field
+        let e_tag = E::from_field(&tag).ok_or_else(|| D::Error::custom("invalid Tag"))?;
+        Ok(SPtr::from_parts(e_tag, val))
     }
 }
 
-#[allow(clippy::derive_hash_xor_eq)]
-impl<F: LurkField> Hash for ScalarPtr<F> {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.0.to_repr().as_ref().hash(state);
-        self.1.to_repr().as_ref().hash(state);
-    }
-}
-
-impl<F: LurkField> ScalarPointer<F> for ScalarPtr<F> {
-    fn from_parts(tag: F, value: F) -> Self {
-        ScalarPtr(tag, value)
-    }
-
-    fn tag(&self) -> &F {
-        &self.0
-    }
-
-    fn value(&self) -> &F {
-        &self.1
-    }
-}
+pub type ScalarPtr<F> = SPtr<ExprTag, F>;
 
 pub trait IntoHashComponents<F: LurkField> {
     fn into_hash_components(self) -> [F; 2];
@@ -434,7 +443,7 @@ impl<F: LurkField> IntoHashComponents<F> for [F; 2] {
 
 impl<F: LurkField> IntoHashComponents<F> for ScalarPtr<F> {
     fn into_hash_components(self) -> [F; 2] {
-        [self.0, self.1]
+        [self.0.to_field::<F>(), self.1]
     }
 }
 
@@ -450,7 +459,7 @@ impl<Fr: LurkField> Arbitrary for ScalarContPtr<Fr> {
 
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
         any::<(ContTag, FWrap<Fr>)>()
-            .prop_map(|(tag, val)| ScalarContPtr::from_parts(Fr::from(tag as u64), val.0))
+            .prop_map(|(tag, val)| ScalarContPtr::from_parts(tag, val.0))
             .boxed()
     }
 }
@@ -497,7 +506,10 @@ impl<'de, F: LurkField> Deserialize<'de> for ScalarContPtr<F> {
         let tag = F::from_u64(cid.codec() & 0x0000_0000_ffff_ffff);
         let val = F::from_bytes(cid.hash().digest())
             .ok_or_else(|| D::Error::custom("expected ScalarContPtr value".to_string()))?;
-        Ok(ScalarContPtr::from_parts(tag, val))
+        // TODO(fga): eliminate this round-trip through the field
+        let cont_tag =
+            ContTag::from_field(&tag).ok_or_else(|| D::Error::custom("invalid ContTag"))?;
+        Ok(ScalarContPtr::from_parts(cont_tag, val))
     }
 }
 
@@ -509,12 +521,12 @@ impl<F: LurkField> Hash for ScalarContPtr<F> {
     }
 }
 
-impl<F: LurkField> ScalarPointer<F> for ScalarContPtr<F> {
-    fn from_parts(tag: F, value: F) -> Self {
-        ScalarContPtr(tag, value)
+impl<F: LurkField> ScalarPointer<ContTag, F> for ScalarContPtr<F> {
+    fn from_parts(tag: ContTag, value: F) -> Self {
+        ScalarContPtr(tag.to_field(), value)
     }
-    fn tag(&self) -> &F {
-        &self.0
+    fn tag(&self) -> F {
+        self.0
     }
 
     fn value(&self) -> &F {
@@ -1173,7 +1185,7 @@ impl<F: LurkField> Store<F> {
     }
 
     pub fn get_maybe_opaque(&self, tag: ExprTag, hash: F) -> Option<Ptr<F>> {
-        let scalar_ptr = ScalarPtr::from_parts(tag.to_field(), hash);
+        let scalar_ptr = ScalarPtr::from_parts(tag, hash);
 
         let ptr = self.scalar_ptr_map.get(&scalar_ptr);
         if let Some(p) = ptr {
@@ -1191,7 +1203,7 @@ impl<F: LurkField> Store<F> {
         return_non_opaque_if_existing: bool,
     ) -> Ptr<F> {
         self.hydrate_scalar_cache();
-        let scalar_ptr = ScalarPtr::from_parts(tag.to_field(), hash);
+        let scalar_ptr = ScalarPtr::from_parts(tag, hash);
 
         // Scope the first immutable borrow.
         {
@@ -1215,7 +1227,7 @@ impl<F: LurkField> Store<F> {
         scalar_store: &ScalarStore<F>,
     ) -> Option<ContPtr<F>> {
         use ScalarContinuation::*;
-        let tag: ContTag = ContTag::from_field(ptr.tag())?;
+        let tag: ContTag = ContTag::from_field(&ptr.tag())?;
 
         if let Some(cont) = scalar_store.get_cont(&ptr) {
             let continuation = match cont {
@@ -1332,7 +1344,7 @@ impl<F: LurkField> Store<F> {
         ptr: ScalarPtr<F>,
         scalar_store: &ScalarStore<F>,
     ) -> Option<Ptr<F>> {
-        let tag: ExprTag = ExprTag::from_field(ptr.tag())?;
+        let tag: ExprTag = ptr.0;
         let expr = scalar_store.get_expr(&ptr);
         use ScalarExpression::*;
         match (tag, expr) {
@@ -1632,12 +1644,11 @@ impl<F: LurkField> Store<F> {
     }
 
     pub fn scalar_from_parts(&self, tag: F, value: F) -> Option<ScalarPtr<F>> {
-        let scalar_ptr = ScalarPtr(tag, value);
-        if self.scalar_ptr_map.contains_key(&scalar_ptr) {
-            return Some(scalar_ptr);
-        }
-
-        None
+        let Some(e_tag) = ExprTag::from_field(&tag) else { return None };
+        let scalar_ptr = ScalarPtr::from_parts(e_tag, value);
+        self.scalar_ptr_map
+            .contains_key(&scalar_ptr)
+            .then_some(scalar_ptr)
     }
 
     pub fn scalar_from_parts_cont(&self, tag: F, value: F) -> Option<ScalarContPtr<F>> {
@@ -1978,14 +1989,14 @@ impl<F: LurkField> Store<F> {
     /// The only places that `ScalarPtr`s for `Ptr`s should be created, to
     /// ensure that they are cached properly
     fn create_scalar_ptr(&self, ptr: Ptr<F>, hash: F) -> ScalarPtr<F> {
-        let scalar_ptr = ScalarPtr(ptr.tag_field(), hash);
+        let scalar_ptr = ScalarPtr::from_parts(ptr.0, hash);
         let entry = self.scalar_ptr_map.entry(scalar_ptr);
         entry.or_insert(ptr);
         scalar_ptr
     }
 
     fn get_scalar_ptr(&self, ptr: Ptr<F>, hash: F) -> ScalarPtr<F> {
-        ScalarPtr(ptr.tag_field(), hash)
+        ScalarPtr::from_parts(ptr.0, hash)
     }
 
     /// The only places that `ScalarContPtr`s for `ContPtr`s should be created, to
@@ -2122,7 +2133,7 @@ impl<F: LurkField> Store<F> {
         cont: &ContPtr<F>,
     ) -> Option<[[F; 2]; 4]> {
         let def = [F::zero(), F::zero()];
-        let op = self.hash_op2(op).into_hash_components();
+        let op = [op.to_field(), F::zero()];
         let arg1 = self.get_expr_hash(arg1)?.into_hash_components();
         let cont = self.hash_cont(cont)?.into_hash_components();
         Some([op, arg1, cont, def])
@@ -2135,7 +2146,7 @@ impl<F: LurkField> Store<F> {
         unevaled_args: &Ptr<F>,
         cont: &ContPtr<F>,
     ) -> Option<[[F; 2]; 4]> {
-        let op = self.hash_op2(op).into_hash_components();
+        let op = [op.to_field(), F::zero()];
         let saved_env = self.get_expr_hash(saved_env)?.into_hash_components();
         let unevaled_args = self.get_expr_hash(unevaled_args)?.into_hash_components();
         let cont = self.hash_cont(cont)?.into_hash_components();
@@ -2144,7 +2155,7 @@ impl<F: LurkField> Store<F> {
 
     fn get_hash_components_unop(&self, op: &Op1, cont: &ContPtr<F>) -> Option<[[F; 2]; 4]> {
         let def = [F::zero(), F::zero()];
-        let op = self.hash_op1(op).into_hash_components();
+        let op = [op.to_field(), F::zero()];
         let cont = self.hash_cont(cont)?.into_hash_components();
         Some([op, cont, def, def])
     }
@@ -2301,7 +2312,7 @@ impl<F: LurkField> Store<F> {
     }
 
     pub(crate) fn commitment_hash(&self, secret_scalar: F, payload: ScalarPtr<F>) -> F {
-        let preimage = [secret_scalar, payload.0, payload.1];
+        let preimage = [secret_scalar, payload.0.to_field(), payload.1];
         self.poseidon_cache.hash3(&preimage)
     }
 
@@ -2424,11 +2435,11 @@ impl<F: LurkField> Store<F> {
         chars.fold(initial_scalar_ptr, |acc, char| {
             let c_scalar: F = (u32::from(char) as u64).into();
             // This bypasses create_scalar_ptr but is okay because Chars are immediate and don't need to be indexed.
-            let c = ScalarPtr(ExprTag::Char.to_field(), c_scalar);
+            let c = ScalarPtr::from_parts(ExprTag::Char, c_scalar);
             let hash = self.hash_scalar_ptrs_2(&[c, acc]);
             // This bypasses create_scalar_ptr but is okay because we will call it to correctly create each of these
             // ScalarPtrs below, in hash_string_mut_aux.
-            let new_scalar_ptr = ScalarPtr(ExprTag::Str.to_field(), hash);
+            let new_scalar_ptr = ScalarPtr::from_parts(ExprTag::Str, hash);
             hashes.push(hash);
             new_scalar_ptr
         });
@@ -2469,13 +2480,23 @@ impl<F: LurkField> Store<F> {
     }
 
     fn hash_scalar_ptrs_2(&self, ptrs: &[ScalarPtr<F>; 2]) -> F {
-        let preimage = [ptrs[0].0, ptrs[0].1, ptrs[1].0, ptrs[1].1];
+        let preimage = [
+            ptrs[0].0.to_field::<F>(),
+            ptrs[0].1,
+            ptrs[1].0.to_field::<F>(),
+            ptrs[1].1,
+        ];
         self.poseidon_cache.hash4(&preimage)
     }
 
     fn hash_scalar_ptrs_3(&self, ptrs: &[ScalarPtr<F>; 3]) -> F {
         let preimage = [
-            ptrs[0].0, ptrs[0].1, ptrs[1].0, ptrs[1].1, ptrs[2].0, ptrs[2].1,
+            ptrs[0].0.to_field::<F>(),
+            ptrs[0].1,
+            ptrs[1].0.to_field::<F>(),
+            ptrs[1].1,
+            ptrs[2].0.to_field::<F>(),
+            ptrs[2].1,
         ];
         self.poseidon_cache.hash6(&preimage)
     }
@@ -2484,14 +2505,6 @@ impl<F: LurkField> Store<F> {
         let nil = self.get_nil();
 
         self.hash_sym(nil, mode)
-    }
-
-    fn hash_op1(&self, op: &Op1) -> ScalarPtr<F> {
-        ScalarPtr(op.to_field(), F::zero())
-    }
-
-    fn hash_op2(&self, op: &Op2) -> ScalarPtr<F> {
-        ScalarPtr(op.to_field(), F::zero())
     }
 
     // An opaque Ptr is one for which we have the hash, but not the preimages.
@@ -3257,7 +3270,7 @@ pub mod test {
         let sym_tag = s.get_expr_hash(&sym).unwrap().0;
         // let sym_hash = s.get_expr_hash(&sym).unwrap().1;
 
-        assert_eq!(ExprTag::Sym.to_field::<Fr>(), sym_tag);
+        assert_eq!(ExprTag::Sym, sym_tag);
 
         // FIXME: What should this be? Should this even be allowed?
         // assert_eq!(Fr::from(0), sym_hash)

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -1,3 +1,4 @@
+use anyhow::anyhow;
 #[cfg(not(target_arch = "wasm32"))]
 use proptest_derive::Arbitrary;
 use serde_repr::{Deserialize_repr, Serialize_repr};
@@ -36,7 +37,7 @@ impl From<ExprTag> for u64 {
 }
 
 impl TryFrom<u16> for ExprTag {
-    type Error = String;
+    type Error = anyhow::Error;
 
     fn try_from(x: u16) -> Result<Self, <ExprTag as TryFrom<u16>>::Error> {
         match x {
@@ -51,7 +52,7 @@ impl TryFrom<u16> for ExprTag {
             f if f == ExprTag::Comm as u16 => Ok(ExprTag::Comm),
             f if f == ExprTag::U64 as u16 => Ok(ExprTag::U64),
             f if f == ExprTag::Key as u16 => Ok(ExprTag::Key),
-            f => Err(format!("Invalid ExprTag value: {}", f)),
+            f => Err(anyhow!("Invalid ExprTag value: {}", f)),
         }
     }
 }
@@ -144,7 +145,7 @@ impl From<ContTag> for u64 {
 }
 
 impl TryFrom<u16> for ContTag {
-    type Error = String;
+    type Error = anyhow::Error;
 
     fn try_from(x: u16) -> Result<Self, <ContTag as TryFrom<u16>>::Error> {
         match x {
@@ -164,7 +165,7 @@ impl TryFrom<u16> for ContTag {
             f if f == ContTag::Dummy as u16 => Ok(ContTag::Dummy),
             f if f == ContTag::Terminal as u16 => Ok(ContTag::Terminal),
             f if f == ContTag::Emit as u16 => Ok(ContTag::Emit),
-            f => Err(format!("Invalid ContTag value: {}", f)),
+            f => Err(anyhow!("Invalid ContTag value: {}", f)),
         }
     }
 }
@@ -233,7 +234,7 @@ impl From<Op1> for u64 {
 }
 
 impl TryFrom<u16> for Op1 {
-    type Error = String;
+    type Error = anyhow::Error;
 
     fn try_from(x: u16) -> Result<Self, <Op1 as TryFrom<u16>>::Error> {
         match x {
@@ -249,7 +250,7 @@ impl TryFrom<u16> for Op1 {
             f if f == Op1::Char as u16 => Ok(Op1::Char),
             f if f == Op1::Eval as u16 => Ok(Op1::Eval),
             f if f == Op1::U64 as u16 => Ok(Op1::U64),
-            f => Err(format!("Invalid Op1 value: {}", f)),
+            f => Err(anyhow!("Invalid Op1 value: {}", f)),
         }
     }
 }
@@ -370,7 +371,7 @@ impl From<Op2> for u64 {
 }
 
 impl TryFrom<u16> for Op2 {
-    type Error = String;
+    type Error = anyhow::Error;
 
     fn try_from(x: u16) -> Result<Self, <Op2 as TryFrom<u16>>::Error> {
         match x {
@@ -390,7 +391,7 @@ impl TryFrom<u16> for Op2 {
             f if f == Op2::Hide as u16 => Ok(Op2::Hide),
             f if f == Op2::Modulo as u16 => Ok(Op2::Modulo),
             f if f == Op2::Eval as u16 => Ok(Op2::Eval),
-            f => Err(format!("Invalid Op2 value: {}", f)),
+            f => Err(anyhow!("Invalid Op2 value: {}", f)),
         }
     }
 }

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -7,7 +7,7 @@ use std::{convert::TryFrom, fmt};
 use crate::field::LurkField;
 use crate::store::TypePredicates;
 
-pub trait Tag: Into<u16> + TryFrom<u16> + Copy + Sized {
+pub trait Tag: Into<u16> + TryFrom<u16> + Copy + Sized + Eq + fmt::Debug {
     fn from_field<F: LurkField>(f: &F) -> Option<Self>;
     fn to_field<F: LurkField>(&self) -> F;
 }

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -7,6 +7,11 @@ use std::{convert::TryFrom, fmt};
 use crate::field::LurkField;
 use crate::store::TypePredicates;
 
+pub trait Tag: Into<u16> + TryFrom<u16> + Copy + Sized {
+    fn from_field<F: LurkField>(f: &F) -> Option<Self>;
+    fn to_field<F: LurkField>(&self) -> F;
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize_repr, Deserialize_repr)]
 #[cfg_attr(not(target_arch = "wasm32"), derive(Arbitrary))]
 #[repr(u16)]
@@ -100,12 +105,12 @@ impl TypePredicates for ExprTag {
     }
 }
 
-impl ExprTag {
-    pub fn from_field<F: LurkField>(f: &F) -> Option<Self> {
+impl Tag for ExprTag {
+    fn from_field<F: LurkField>(f: &F) -> Option<Self> {
         Self::try_from(f.to_u16()?).ok()
     }
 
-    pub fn as_field<F: LurkField>(&self) -> F {
+    fn to_field<F: LurkField>(&self) -> F {
         F::from(*self as u64)
     }
 }
@@ -170,12 +175,12 @@ impl TryFrom<u16> for ContTag {
     }
 }
 
-impl ContTag {
-    pub fn from_field<F: LurkField>(f: &F) -> Option<Self> {
+impl Tag for ContTag {
+    fn from_field<F: LurkField>(f: &F) -> Option<Self> {
         Self::try_from(f.to_u16()?).ok()
     }
 
-    pub fn as_field<F: LurkField>(&self) -> F {
+    fn to_field<F: LurkField>(&self) -> F {
         F::from(*self as u64)
     }
 }
@@ -267,12 +272,12 @@ where
     }
 }
 
-impl Op1 {
-    pub fn from_field<F: LurkField>(f: &F) -> Option<Self> {
+impl Tag for Op1 {
+    fn from_field<F: LurkField>(f: &F) -> Option<Self> {
         Self::try_from(f.to_u16()?).ok()
     }
 
-    pub fn as_field<F: LurkField>(&self) -> F {
+    fn to_field<F: LurkField>(&self) -> F {
         F::from(*self as u64)
     }
 }
@@ -396,15 +401,17 @@ impl TryFrom<u16> for Op2 {
     }
 }
 
-impl Op2 {
-    pub fn from_field<F: LurkField>(f: &F) -> Option<Self> {
+impl Tag for Op2 {
+    fn from_field<F: LurkField>(f: &F) -> Option<Self> {
         Self::try_from(f.to_u16()?).ok()
     }
 
-    pub fn as_field<F: From<u64> + ff::Field>(&self) -> F {
+    fn to_field<F: From<u64> + ff::Field>(&self) -> F {
         F::from(*self as u64)
     }
+}
 
+impl Op2 {
     pub fn is_numeric(&self) -> bool {
         matches!(
             self,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -14,7 +14,7 @@ pub trait Write<F: LurkField> {
 
 impl<F: LurkField> Write<F> for Ptr<F> {
     fn fmt<W: io::Write>(&self, store: &Store<F>, w: &mut W) -> io::Result<()> {
-        use crate::store::{Pointer, ScalarPointer};
+        use crate::store::Pointer;
         if self.is_opaque() {
             // This should never fail.
             write!(w, "<Opaque ")?;


### PR DESCRIPTION
This is the non-controversial fragment of #307, which does not change the byte-level representation of `Scalar(Cont)Ptr` tags. This just saves a bit of code (but brings no meaningful performance change).

This simply refactors the definition of `Scalar(Cont)Ptr` to carry in tag position the type they are meant to represent, and adjusts the definitions in function. The implementation of those definitions is shared in a generic type `SPtr`, of which `ScalarContPtr` and `ScalarPtr` are just particular instantiations.

The `Tag` trait appears in `scalar.rs` to constrain the acceptable tags for a `SPtr`, but the `ScalarPointer` trait becomes obsolete and is replaced in this implementation, which means the total number of traits in the repo is kept constant.

Note: the commits each compile and pass tests, and their commit messages are meant to help review.

Side-effects: 
- fixes a few ill-defined (non-firing) proptests,
- uses `anyhow` rather than `String` in `TryFrom<u16> for Tag`,
- uses [C-CASE](https://rust-lang.github.io/api-guidelines/naming.html#ad-hoc-conversions-follow-as_-to_-into_-conventions-c-conv) to prompt some method renamings.