### PR TITLE
Speed up tag's to_field_bytes

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -402,9 +402,6 @@ pub mod tests {
       fn prop_vesta_repr_canonicity(f1 in any::<FWrap<pasta_curves::Fq>>()) {
           repr_canonicity(f1)
       }
-    }
-
-    proptest! {
       #[test]
       fn prop_tag_consistency(x in any::<ExprTag>()) {
           let f1 = Fr::from_expr_tag(x);
@@ -420,5 +417,38 @@ pub mod tests {
             let f2 = FWrap::de(&bytes).unwrap();
             assert_eq!(x, f2)
       }
+    }
+
+    // This checks that the field we're using have a representation
+    // such that forall x: u64, F::from(x).to_repr() == x.to_le_bytes()
+    // This enables a fast conversion for tags, and must be present for all fields
+    // we use this library with.
+    proptest! {
+        #[test]
+        fn prop_pallas_tag_roundtrip(x in any::<u64>()){
+            let f1 = pasta_curves::Fp::from(x);
+            let bytes = f1.to_repr().as_ref().to_vec();
+            let mut bytes_from_u64 = [0u8; 32];
+            bytes_from_u64[..8].copy_from_slice(&x.to_le_bytes());
+            assert_eq!(bytes, bytes_from_u64);
+        }
+
+        #[test]
+        fn prop_vesta_tag_roundtrip(x in any::<u64>()){
+            let f1 = pasta_curves::Fq::from(x);
+            let bytes = f1.to_repr().as_ref().to_vec();
+            let mut bytes_from_u64 = [0u8; 32];
+            bytes_from_u64[..8].copy_from_slice(&x.to_le_bytes());
+            assert_eq!(bytes, bytes_from_u64);
+        }
+
+        #[test]
+        fn prop_bls_tag_roundtrip(x in any::<u64>()){
+            let f1 = blstrs::Scalar::from(x);
+            let bytes = f1.to_repr().as_ref().to_vec();
+            let mut bytes_from_u64 = [0u8; 32];
+            bytes_from_u64[..8].copy_from_slice(&x.to_le_bytes());
+            assert_eq!(bytes, bytes_from_u64);
+        }
     }
 }

--- a/src/scalar_store.rs
+++ b/src/scalar_store.rs
@@ -15,7 +15,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 /// `ScalarStore` allows realization of a graph of `ScalarPtr`s suitable for serialization to IPLD. `ScalarExpression`s
-/// are composed only of `ScalarPtr`s, so `scalar_map` suffices to allow traverseing an arbitrary DAG.
+/// are composed only of `ScalarPtr`s, so `scalar_map` suffices to allow traversing an arbitrary DAG.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ScalarStore<F: LurkField> {
     scalar_map: BTreeMap<ScalarPtr<F>, Option<ScalarExpression<F>>>,

--- a/src/store.rs
+++ b/src/store.rs
@@ -341,11 +341,11 @@ impl<E: Tag, F: LurkField> Display for SPtr<E, F> {
 impl<E: Tag, F: LurkField> PartialOrd for SPtr<E, F> {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         (
-            self.0.to_field::<F>().to_repr().as_ref(),
+            self.0.to_field_bytes::<F>().as_ref(),
             self.1.to_repr().as_ref(),
         )
             .partial_cmp(&(
-                other.0.to_field::<F>().to_repr().as_ref(),
+                other.0.to_field_bytes::<F>().as_ref(),
                 other.1.to_repr().as_ref(),
             ))
     }
@@ -376,7 +376,7 @@ impl<E: Tag, F: LurkField> Encodable for SPtr<E, F> {
 #[allow(clippy::derive_hash_xor_eq)]
 impl<E: Tag, F: LurkField> Hash for SPtr<E, F> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.0.to_field::<F>().to_repr().as_ref().hash(state);
+        self.0.to_field_bytes::<F>().as_ref().hash(state);
         self.1.to_repr().as_ref().hash(state);
     }
 }

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -10,6 +10,13 @@ use crate::store::TypePredicates;
 pub trait Tag: Into<u16> + TryFrom<u16> + Copy + Sized + Eq + fmt::Debug {
     fn from_field<F: LurkField>(f: &F) -> Option<Self>;
     fn to_field<F: LurkField>(&self) -> F;
+
+    /// This explicitly defines a shortcut to access the canonical
+    /// byte representation of the field element associated to a
+    /// tag. We expect some tag types to be able to improve upon it.
+    fn to_field_bytes<F: LurkField>(&self) -> F::Repr {
+        self.to_field::<F>().to_repr()
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize_repr, Deserialize_repr)]
@@ -113,6 +120,13 @@ impl Tag for ExprTag {
     fn to_field<F: LurkField>(&self) -> F {
         F::from(*self as u64)
     }
+
+    fn to_field_bytes<F: LurkField>(&self) -> F::Repr {
+        let mut res = F::Repr::default();
+        let u: u16 = (*self).into();
+        res.as_mut()[..2].copy_from_slice(&u.to_le_bytes());
+        res
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -182,6 +196,13 @@ impl Tag for ContTag {
 
     fn to_field<F: LurkField>(&self) -> F {
         F::from(*self as u64)
+    }
+
+    fn to_field_bytes<F: LurkField>(&self) -> F::Repr {
+        let mut res = F::Repr::default();
+        let u: u16 = (*self).into();
+        res.as_mut()[..2].copy_from_slice(&u.to_le_bytes());
+        res
     }
 }
 
@@ -279,6 +300,13 @@ impl Tag for Op1 {
 
     fn to_field<F: LurkField>(&self) -> F {
         F::from(*self as u64)
+    }
+
+    fn to_field_bytes<F: LurkField>(&self) -> F::Repr {
+        let mut res = F::Repr::default();
+        let u: u16 = (*self).into();
+        res.as_mut()[..2].copy_from_slice(&u.to_le_bytes());
+        res
     }
 }
 
@@ -408,6 +436,13 @@ impl Tag for Op2 {
 
     fn to_field<F: From<u64> + ff::Field>(&self) -> F {
         F::from(*self as u64)
+    }
+
+    fn to_field_bytes<F: LurkField>(&self) -> F::Repr {
+        let mut res = F::Repr::default();
+        let u: u16 = (*self).into();
+        res.as_mut()[..2].copy_from_slice(&u.to_le_bytes());
+        res
     }
 }
 


### PR DESCRIPTION
Fixes #307.

```
go_base_10_16_bls12     time:   [3.1047 ms 3.1121 ms 3.1195 ms]
                        change: [-19.706% -19.469% -19.215%] (p = 0.00 < 0.05)
                        Performance has improved.

go_base_10_160_bls12    time:   [29.734 ms 29.819 ms 29.906 ms]
                        change: [-19.368% -19.070% -18.767%] (p = 0.00 < 0.05)
                        Performance has improved.

go_base_10_16_pasta_pallas
                        time:   [3.1728 ms 3.1768 ms 3.1808 ms]
                        change: [-18.493% -18.204% -17.952%] (p = 0.00 < 0.05)
                        Performance has improved.

go_base_10_160_pasta_pallas
                        time:   [30.472 ms 30.538 ms 30.610 ms]
                        change: [-18.865% -18.513% -18.159%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
  ```