### PR TITLE
Maintenance PR: update rustyline, neptune

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,17 +881,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fd-lock"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef1a30ae415c3a691a4f41afddc2dbcd6d70baf338368d85ebc1e8ed92cedb9"
-dependencies = [
- "cfg-if",
- "rustix",
- "windows-sys 0.45.0",
-]
-
-[[package]]
 name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,6 +1279,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rand_xorshift",
  "rayon",
+ "rustyline",
  "rustyline-derive",
  "serde",
  "serde_repr",
@@ -1297,7 +1287,6 @@ dependencies = [
  "structopt",
  "tap",
  "thiserror",
- "yatima-rustyline",
 ]
 
 [[package]]
@@ -1494,13 +1483,14 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.24.3"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
+ "static_assertions",
 ]
 
 [[package]]
@@ -2071,11 +2061,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustyline-derive"
-version = "0.5.0"
+name = "rustyline"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688599bdab9f42105d0ae1494335a9ffafdeb7d36325e6b10fd4abc5829d6284"
+checksum = "5dfc8644681285d1fb67a467fb3021bfea306b99b4146b166a1fe3ada965eece"
 dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "clipboard-win",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "rustyline-derive",
+ "scopeguard",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "winapi",
+]
+
+[[package]]
+name = "rustyline-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8218eaf5d960e3c478a1b0f129fa888dd3d8d22eb3de097e9af14c1ab4438024"
+dependencies = [
+ "proc-macro2 1.0.53",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -2760,27 +2772,6 @@ checksum = "8ca6c5a4d66c1a9ea261811cf4773c27343de7e5033e1b75ea3f297dc7db3c1a"
 dependencies = [
  "flume",
  "scopeguard",
-]
-
-[[package]]
-name = "yatima-rustyline"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e615482fe136189e4de6ec92ba867341eb1a32e42a217b6e03d80ad1bcb8df6b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "clipboard-win",
- "fd-lock",
- "libc",
- "log",
- "memchr",
- "nix",
- "scopeguard",
- "unicode-segmentation",
- "unicode-width",
- "utf8parse",
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,9 +1461,9 @@ dependencies = [
 
 [[package]]
 name = "neptune"
-version = "8.1.0"
+version = "8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed43f3b001f2ee59069972e445d03df46206b0badcd87f67075b2eb1bdceefaf"
+checksum = "0d47b29bc49c7d957eb446e298f96cd7088829e2d7a549ab04b36bc82434e27b"
 dependencies = [
  "bellperson",
  "blake2s_simd 0.5.11",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ peekmore = "1.1.0"
 pretty_env_logger = "0.4"
 rand_core = { version = "0.6.4", default-features = false }
 rayon = "1.7.0"
-rustyline = { package = "yatima-rustyline", version = "0.1", default-features = false }
-rustyline-derive = "0.5.0"
+rustyline = { version="11.0", features = ["derive"], default-features = false }
+rustyline-derive = "0.8.0"
 rand_xorshift = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_repr = "0.1.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ ff = "0.12.1"
 generic-array = "0.14.6"
 itertools = "0.9"
 log = "0.4.17"
-neptune = { version = "8.1.0", features = ["arity2","arity4","arity8","arity16","pasta","bls"] }
+neptune = { version = "8.1.1", features = ["arity2","arity4","arity8","arity16","pasta","bls"] }
 nova = { package = "nova-snark", version = "0.19.0", default-features = false }
 once_cell = "1.17.1"
 pairing_lib = { version = "0.22", package = "pairing" }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -12,6 +12,7 @@ use anyhow::{Context, Result};
 use clap::{Arg, ArgAction, Command};
 use peekmore::PeekMore;
 use rustyline::error::ReadlineError;
+use rustyline::history::DefaultHistory;
 use rustyline::validate::{
     MatchingBracketValidator, ValidationContext, ValidationResult, Validator,
 };
@@ -42,7 +43,7 @@ pub struct ReplState<F: LurkField> {
 
 pub struct Repl<F: LurkField, T: ReplTrait<F>> {
     state: T,
-    rl: Editor<InputValidator>,
+    rl: Editor<InputValidator, DefaultHistory>,
     history_path: PathBuf,
     _phantom: F,
 }
@@ -104,7 +105,7 @@ impl<F: LurkField, T: ReplTrait<F>> Repl<F, T> {
             .color_mode(rustyline::ColorMode::Enabled)
             .auto_add_history(true)
             .build();
-        let mut rl = Editor::with_config(config);
+        let mut rl = Editor::with_config(config)?;
         rl.set_helper(Some(h));
         if history_path.exists() {
             rl.load_history(&history_path)?;


### PR DESCRIPTION
- the update of neptune allows us to upgrade to @emmorais fixes re: neptune padding,
- the rustyline fork seems no longer needed to compile to wasm