### PR TITLE
ci: Add huitseeker as secondary owner and update CODEOWNERS exclusion.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,10 @@
 # Global Owners
-* @porcuquine
+* @porcuquine @huitseeker
+
+# Order is important; the last matching pattern takes the most
+# precedence. This excludes @huitseeker for /src/eval.rs
+/src/eval.rs @porcuquine
 
 # Circuit
-/src/circuit/* @emmorais
+# And this excludes @huitseeker for /src/circuit/**
+/src/circuit/** @emmorais @porcuquine


### PR DESCRIPTION
- Implement GitHub action to validate CODEOWNERS file
- Add @huitseeker as a secondary owner in .github/CODEOWNERS
- Exclude @huitseeker from selected directories in .github/CODEOWNERS