### PR TITLE
chore: Add and modify GitHub CODEOWNERS global owners list.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,10 @@
-# Global Owners
-* @porcuquine @huitseeker
+# Global Owners: @porcuquine, @huitseeker
+* @lurk-lab/lurk-noncircuit
 
 # Order is important; the last matching pattern takes the most
 # precedence. This excludes @huitseeker for /src/eval.rs
 /src/eval.rs @porcuquine
 
 # Circuit
-# And this excludes @huitseeker for /src/circuit/**
-/src/circuit/** @emmorais @porcuquine
+# And this excludes everyone but @emmorais for /src/circuit/**
+/src/circuit/** @lurk-lab/lurk-circuit


### PR DESCRIPTION
- Add new global owner @lurk-lab/noncircuit
- Modify global owners list to include @porcuquine and @huitseeker
- Include @emmorais only for the path /src/circuit/**