### PR TITLE
Pre-release fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,12 +115,15 @@ jobs:
       - set_env_path
       - run: rustup target add wasm32-unknown-unknown
       - run:
-          name: Wasm Build
+          name: Wasm compiles sucessfully, 
           command: cargo build --target wasm32-unknown-unknown
       - run:
           name: Linux Tests
           command: cargo nextest run --profile ci --workspace
           no_output_timeout: 120m
+      - run:
+          name: Linux Gadget Tests w/o debug assertions
+          command: cargo nextest run --profile ci --workspace --cargo-profile dev-no-assertions -E 'test(circuit::gadgets)'
 
   linux_release:
     executor: default
@@ -133,11 +136,11 @@ jobs:
       - set_env_path
       - install_gpu_deps
       - run:
-          name: Linux Tests
-          command: cargo nextest run --profile ci --release --workspace --run-ignored all -E 'all() - test(groth16::tests::outer_prove_recursion)'
+          name: Linux compiles successfully, incl. benchmarks
+          command: cargo build --benches
       - run:
-          name: Linux benchmarks compile successfully
-          command: cargo bench --no-run
+          name: Linux Tests
+          command: cargo nextest run --profile ci --workspace --run-ignored all -E 'all() - test(groth16::tests::outer_prove_recursion)'
       - run:
           name: Linux Doc Tests
           command: cargo test --doc --workspace
@@ -157,12 +160,12 @@ jobs:
       - set_env_path
       - install_gpu_deps
       - run:
-          name: Arm64 Tests
-          command: cargo nextest run --profile ci --release --workspace
-          no_output_timeout: 120m
+          name: Arm64 compiles successfully, incl. benchmarks
+          command: cargo build --benches
       - run:
-          name: Arm64 benchmarks compile successfully
-          command: cargo bench --no-run
+          name: Arm64 Tests
+          command: cargo nextest run --profile ci --workspace
+          no_output_timeout: 120m
       - run:
           name: Arm64 Doc Tests
           command: cargo test --doc --workspace
@@ -180,12 +183,12 @@ jobs:
       - set_versions_n_runners
       - set_env_path
       - run:
-          name: MacOS Tests
-          command: cargo nextest run --profile ci --release --workspace
-          no_output_timeout: 120m
+          name: MacOS compiles successfully, incl. benchmarks
+          command: cargo build --benches
       - run:
-          name: MacOS benchmarks compile successfully
-          command: cargo bench --no-run
+          name: MacOS Tests
+          command: cargo nextest run --profile ci --workspace
+          no_output_timeout: 120m
       - run:
           name: MacOS Doc Tests
           command: cargo test --doc --workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,11 +170,11 @@ jobs:
       - install_gpu_deps
       - restore-sccache-cache
       - run:
-          name: Linux compiles successfully, incl. benchmarks
-          command: cargo build --benches
-      - run:
           name: Linux Tests
           command: cargo nextest run --profile ci --workspace --run-ignored all -E 'all() - test(groth16::tests::outer_prove_recursion)'
+      - run:
+          name: Benches build successfully
+          command: cargo bench --no-run --profile dev
       - run:
           name: Linux Doc Tests
           command: cargo test --doc --workspace
@@ -206,12 +206,12 @@ jobs:
             sccache --version
       - restore-sccache-cache
       - run:
-          name: Arm64 compiles successfully, incl. benchmarks
-          command: cargo build --benches
-      - run:
           name: Arm64 Tests
           command: cargo nextest run --profile ci --workspace
           no_output_timeout: 120m
+      - run:
+          name: Benches build successfully
+          command: cargo bench --no-run --profile dev
       - run:
           name: Arm64 Doc Tests
           command: cargo test --doc --workspace
@@ -241,12 +241,12 @@ jobs:
             sccache --version
       - restore-sccache-cache
       - run:
-          name: MacOS compiles successfully, incl. benchmarks
-          command: cargo build --benches
-      - run:
           name: MacOS Tests
           command: cargo nextest run --profile ci --workspace
           no_output_timeout: 120m
+      - run:
+          name: Benches build successfully
+          command: cargo bench --no-run --profile dev
       - run:
           name: MacOS Doc Tests
           command: cargo test --doc --workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ jobs:
           command: cargo build --target wasm32-unknown-unknown
       - run:
           name: Linux Tests
-          command: cargo nextest run --profile ci --workspace
+          command: cargo nextest run --profile ci --workspace --cargo-profile dev-ci
           no_output_timeout: 120m
       - run:
           name: Linux Gadget Tests w/o debug assertions
@@ -171,13 +171,13 @@ jobs:
       - restore-sccache-cache
       - run:
           name: Linux Tests
-          command: cargo nextest run --profile ci --workspace --run-ignored all -E 'all() - test(groth16::tests::outer_prove_recursion)'
+          command: cargo nextest run --profile ci --workspace --cargo-profile dev-ci --run-ignored all -E 'all() - test(groth16::tests::outer_prove_recursion)'
       - run:
           name: Benches build successfully
-          command: cargo bench --no-run --profile dev
+          command: cargo bench --no-run --profile dev-ci
       - run:
           name: Linux Doc Tests
-          command: cargo test --doc --workspace
+          command: cargo test --doc --workspace --profile dev-ci
       - save-sccache-cache
 
   arm64:
@@ -207,14 +207,14 @@ jobs:
       - restore-sccache-cache
       - run:
           name: Arm64 Tests
-          command: cargo nextest run --profile ci --workspace
+          command: cargo nextest run --profile ci --workspace --cargo-profile dev-ci
           no_output_timeout: 120m
       - run:
           name: Benches build successfully
-          command: cargo bench --no-run --profile dev
+          command: cargo bench --no-run --profile dev-ci
       - run:
           name: Arm64 Doc Tests
-          command: cargo test --doc --workspace
+          command: cargo test --doc --workspace --profile dev-ci
       - save-sccache-cache
 
   mac:
@@ -242,14 +242,14 @@ jobs:
       - restore-sccache-cache
       - run:
           name: MacOS Tests
-          command: cargo nextest run --profile ci --workspace
+          command: cargo nextest run --profile ci --workspace --cargo-profile dev-ci
           no_output_timeout: 120m
       - run:
           name: Benches build successfully
-          command: cargo bench --no-run --profile dev
+          command: cargo bench --no-run --profile dev-ci
       - run:
           name: MacOS Doc Tests
-          command: cargo test --doc --workspace
+          command: cargo test --doc --workspace --profile dev-ci
       - save-sccache-cache
 
   clippy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,35 @@ commands:
             echo "export PATH=$HOME:~/.cargo/bin:$(dirname $(find $(rustc --print sysroot) -name 'rust-lld')):$PATH" | tee -a $BASH_ENV
             source $BASH_ENV
 
+  setup-sccache:
+    steps:
+      - run:
+          name: Install sccache
+          command: |
+            cargo install sccache
+            # This configures Rust to use sccache.
+            echo 'export "RUSTC_WRAPPER"="sccache"' >> $BASH_ENV
+            # This is the maximum space sccache cache will use on disk.
+            echo 'export "SCCACHE_CACHE_SIZE"="1G"' >> $BASH_ENV
+            sccache --version
+
+  restore-sccache-cache:
+    steps:
+      - restore_cache:
+          name: Restore sccache cache
+          key: sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
+  save-sccache-cache:
+    steps:
+      - save_cache:
+          name: Save sccache cache
+          # We use {{ epoch }} to always upload a fresh cache:
+          # Of course, restore_cache will not find this exact key,
+          # but it will fall back to the closest key (aka the most recent).
+          # See https://discuss.circleci.com/t/add-mechanism-to-update-existing-cache-key/9014/13
+          key: sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
+          paths:
+            - "~/.cache/sccache"
+
   set_versions_n_runners:
     steps:
       - run:
@@ -94,6 +123,7 @@ jobs:
       - restore_rustup_cache
       - set_env_path
       - set_versions_n_runners
+      - setup-sccache
       - run: cargo fetch
       - run: rm -rf .git
       - persist_to_workspace:
@@ -114,6 +144,7 @@ jobs:
       - run: sudo apt install clang
       - set_env_path
       - run: rustup target add wasm32-unknown-unknown
+      - restore-sccache-cache
       - run:
           name: Wasm compiles sucessfully, 
           command: cargo build --target wasm32-unknown-unknown
@@ -124,6 +155,7 @@ jobs:
       - run:
           name: Linux Gadget Tests w/o debug assertions
           command: cargo nextest run --profile ci --workspace --cargo-profile dev-no-assertions -E 'test(circuit::gadgets)'
+      - save-sccache-cache
 
   linux_release:
     executor: default
@@ -135,6 +167,7 @@ jobs:
       - restore_rustup_cache
       - set_env_path
       - install_gpu_deps
+      - restore-sccache-cache
       - run:
           name: Linux compiles successfully, incl. benchmarks
           command: cargo build --benches
@@ -144,6 +177,7 @@ jobs:
       - run:
           name: Linux Doc Tests
           command: cargo test --doc --workspace
+      - save-sccache-cache
 
   arm64:
     executor: arm64
@@ -159,6 +193,8 @@ jobs:
       - set_versions_n_runners
       - set_env_path
       - install_gpu_deps
+      - setup-sccache
+      - restore-sccache-cache
       - run:
           name: Arm64 compiles successfully, incl. benchmarks
           command: cargo build --benches
@@ -169,6 +205,7 @@ jobs:
       - run:
           name: Arm64 Doc Tests
           command: cargo test --doc --workspace
+      - save-sccache-cache
 
   mac:
     executor: darwin
@@ -182,6 +219,8 @@ jobs:
            at: "~/"
       - set_versions_n_runners
       - set_env_path
+      - setup-sccache
+      - restore-sccache-cache
       - run:
           name: MacOS compiles successfully, incl. benchmarks
           command: cargo build --benches
@@ -192,6 +231,7 @@ jobs:
       - run:
           name: MacOS Doc Tests
           command: cargo test --doc --workspace
+      - save-sccache-cache
 
   clippy:
     executor: default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,8 @@ commands:
       - run:
           name: Install sccache
           command: |
-            cargo install sccache
+            curl -LsSf "https://github.com/mozilla/sccache/releases/download/v0.4.1/sccache-v0.4.1-x86_64-unknown-linux-musl.tar.gz" | tar xzf -
+            mv sccache-v0.4.1-x86_64-unknown-linux-musl/sccache $HOME/.cargo/bin
             # This configures Rust to use sccache.
             echo 'export "RUSTC_WRAPPER"="sccache"' >> $BASH_ENV
             # This is the maximum space sccache cache will use on disk.
@@ -193,7 +194,16 @@ jobs:
       - set_versions_n_runners
       - set_env_path
       - install_gpu_deps
-      - setup-sccache
+      - run:
+          name: Install sccache binary
+          command: |
+            curl -LsSf "https://github.com/mozilla/sccache/releases/download/v0.4.1/sccache-v0.4.1-aarch64-unknown-linux-musl.tar.gz" | tar xzf -
+            mv sccache-v0.4.1-aarch64-unknown-linux-musl/sccache $HOME/.cargo/bin
+            # This configures Rust to use sccache.
+            echo 'export "RUSTC_WRAPPER"="sccache"' >> $BASH_ENV
+            # This is the maximum space sccache cache will use on disk.                                                                               
+            echo 'export "SCCACHE_CACHE_SIZE"="1G"' >> $BASH_ENV
+            sccache --version
       - restore-sccache-cache
       - run:
           name: Arm64 compiles successfully, incl. benchmarks
@@ -219,7 +229,16 @@ jobs:
            at: "~/"
       - set_versions_n_runners
       - set_env_path
-      - setup-sccache
+      - run:
+          name: Install sccache binary
+          command: |
+            curl -LsSf "https://github.com/mozilla/sccache/releases/download/v0.4.1/sccache-v0.4.1-x86_64-apple-darwin.tar.gz" | tar xzf -
+            mv sccache-v0.4.1-x86_64-apple-darwin/sccache $HOME/.cargo/bin
+            # This configures Rust to use sccache.
+            echo 'export "RUSTC_WRAPPER"="sccache"' >> $BASH_ENV
+            # This is the maximum space sccache cache will use on disk.                                                                               
+            echo 'export "SCCACHE_CACHE_SIZE"="1G"' >> $BASH_ENV
+            sccache --version
       - restore-sccache-cache
       - run:
           name: MacOS compiles successfully, incl. benchmarks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,8 +132,8 @@ dependencies = [
  "log",
  "memmap2",
  "pairing",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand",
+ "rand_core",
  "rayon",
  "rustversion",
  "serde",
@@ -290,7 +290,7 @@ dependencies = [
  "ff",
  "group",
  "pairing",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "subtle",
 ]
@@ -788,6 +788,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "errno-dragonfly"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,10 +884,10 @@ dependencies = [
  "pairing",
  "predicates 2.1.5",
  "pretty_env_logger",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_json",
- "tempdir",
+ "tempfile",
  "thiserror",
 ]
 
@@ -889,7 +900,7 @@ dependencies = [
  "bitvec",
  "byteorder",
  "ff_derive",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -921,7 +932,7 @@ dependencies = [
  "group",
  "hex",
  "lazy_static",
- "rand 0.8.5",
+ "rand",
  "serde",
  "static_assertions",
  "subtle",
@@ -960,12 +971,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
@@ -1018,8 +1023,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand",
+ "rand_core",
  "rand_xorshift",
  "subtle",
 ]
@@ -1130,7 +1135,7 @@ checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1141,8 +1146,8 @@ checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
- "rustix",
- "windows-sys 0.45.0",
+ "rustix 0.36.11",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1221,6 +1226,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd550e73688e6d578f0ac2119e32b797a327631a42f9433e59d02e139c8df60d"
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,8 +1286,8 @@ dependencies = [
  "pretty_env_logger",
  "proptest",
  "proptest-derive",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand",
+ "rand_core",
  "rand_xorshift",
  "rayon",
  "rustyline",
@@ -1531,7 +1542,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
  "rayon",
  "serde",
  "sha3 0.8.2",
@@ -1559,7 +1570,7 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "serde",
 ]
 
@@ -1644,9 +1655,9 @@ checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1805,7 +1816,7 @@ dependencies = [
  "lazy_static",
  "num-traits",
  "quick-error 2.0.1",
- "rand 0.8.5",
+ "rand",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -1863,26 +1874,13 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1892,23 +1890,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1925,7 +1908,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1951,19 +1934,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
 ]
@@ -1975,7 +1958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "thiserror",
 ]
 
@@ -2003,15 +1986,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "rust-gpu-tools"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2035,11 +2009,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
 dependencies = [
  "bitflags 1.3.2",
- "errno",
+ "errno 0.2.8",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
- "windows-sys 0.45.0",
+ "linux-raw-sys 0.1.4",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c348b5dc624ecee40108aa2922fed8bad89d7fcc2b9f8cb18f632898ac4a37f9"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno 0.3.0",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2372,26 +2360,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
-]
-
-[[package]]
 name = "tempfile"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
- "rustix",
- "windows-sys 0.42.0",
+ "redox_syscall 0.3.5",
+ "rustix 0.37.4",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2673,21 +2651,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,13 +79,16 @@ members = [
 name = "lurkrs"
 path = "src/main.rs"
 
-[profile.dev]
+[profile.dev-ci]
+inherits = "dev"
 # By compiling dependencies with optimizations, performing tests gets much faster.
 opt-level = 3
-lto = true
+lto = "thin"
+incremental = false
+codegen-units = 16
 
 [profile.dev-no-assertions]
 # Some tests in the case gadget depend on debug assertions
 # being off (they test release behavior in case of duplicate clauses).
-inherits = "dev"
+inherits = "dev-ci"
 debug-assertions = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,3 +83,9 @@ path = "src/main.rs"
 # By compiling dependencies with optimizations, performing tests gets much faster.
 opt-level = 3
 lto = true
+
+[profile.dev-no-assertions]
+# Some tests in the case gadget depend on debug assertions
+# being off (they test release behavior in case of duplicate clauses).
+inherits = "dev"
+debug-assertions = false

--- a/fcomm/Cargo.toml
+++ b/fcomm/Cargo.toml
@@ -34,4 +34,4 @@ pasta_curves = { version = "0.5.2", features = ["serde"], package = "fil_pasta_c
 [dev-dependencies]
 assert_cmd = "2.0.8"
 predicates = "2.1.5"
-tempdir = "0.3.7"
+tempfile = "3.5.0"

--- a/fcomm/tests/proof_tests.rs
+++ b/fcomm/tests/proof_tests.rs
@@ -4,7 +4,7 @@ use std::ffi::OsStr;
 use std::fs::File;
 use std::io::Write;
 use std::process::Command;
-use tempdir::TempDir;
+use tempfile::{Builder, TempDir};
 
 use pasta_curves::pallas;
 
@@ -33,7 +33,7 @@ fn test_eval_expression() {
 
     let expression = "((LAMBDA (A B) (+ (* A 3) B)) 9 7)";
 
-    let tmp_dir = TempDir::new("tmp").unwrap();
+    let tmp_dir = Builder::new().prefix("tmp").tempdir().unwrap();
     let expression_path = tmp_dir.path().join("expression.lurk");
 
     let mut expression_file = File::create(&expression_path).unwrap();
@@ -108,7 +108,7 @@ fn test_prove_and_verify_expression() {
     let expression = "(* 9 7)";
     let expected = "63";
 
-    let tmp_dir = TempDir::new("tmp").unwrap();
+    let tmp_dir = Builder::new().prefix("tmp").tempdir().unwrap();
     let proof_path = tmp_dir.path().join("proof.json");
     let fcomm_data_path = tmp_dir.path().join("fcomm_data");
     let expression_path = tmp_dir.path().join("expression.lurk");
@@ -155,7 +155,7 @@ fn test_create_open_and_verify_functional_commitment_aux(
     function_input: &str,
     expected_output: &str,
 ) {
-    let tmp_dir = TempDir::new("tmp").unwrap();
+    let tmp_dir = Builder::new().prefix("tmp").tempdir().unwrap();
 
     test_aux(
         function_source,
@@ -169,7 +169,7 @@ fn test_create_open_and_verify_chained_functional_commitment_aux(
     function_source: &str,
     expected_io: Vec<(&str, &str)>,
 ) {
-    let tmp_dir = TempDir::new("tmp").unwrap();
+    let tmp_dir = Builder::new().prefix("tmp").tempdir().unwrap();
 
     test_aux(function_source, expected_io, true, tmp_dir);
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.67.1"
+channel = "1.68.2"
 targets = [ "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "wasm32-unknown-unknown" ]
 components = [ "rustc", "cargo", "clippy", "rustfmt", "rust-src", "rust-analysis", "rust-analyzer" ]
 profile = "default"

--- a/src/field.rs
+++ b/src/field.rs
@@ -1,3 +1,9 @@
+#![deny(missing_docs)]
+//! The finite field used in the language.
+//!
+//! This defines the LurkField trait used pervasively in the code base
+//! as an extension of the ff::PrimeField trait, with conveniance methods
+//! relating this field to the expresions of the language.
 use anyhow::anyhow;
 use ff::{PrimeField, PrimeFieldBits};
 use serde::{Deserialize, Serialize};
@@ -15,14 +21,19 @@ use rand::{rngs::StdRng, SeedableRng};
 use crate::tag::{ContTag, ExprTag, Op1, Op2};
 
 /// The type of finite fields used in the language
+/// For Pallas/Vesta see https://electriccoin.co/blog/the-pasta-curves-for-halo-2-and-beyond/
 pub enum LanguageField {
+    /// The Pallas field,
     Pallas,
+    /// The Vesta field,
     Vesta,
+    /// The BLS12-381 scalar field,
     BLS12_381,
 }
 
 /// Trait implemented by finite fields used in the language
 pub trait LurkField: PrimeField + PrimeFieldBits {
+    /// The type of the field element's representation
     const FIELD: LanguageField;
 
     /// Converts the field element to a byte vector

--- a/src/field.rs
+++ b/src/field.rs
@@ -233,7 +233,7 @@ impl<F: LurkField> Arbitrary for FWrap<F> {
     }
 }
 
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 impl<F: LurkField> Hash for FWrap<F> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.0.to_repr().as_ref().hash(state);

--- a/src/num.rs
+++ b/src/num.rs
@@ -42,7 +42,7 @@ impl<F: LurkField> Display for Num<F> {
     }
 }
 
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 impl<F: LurkField> Hash for Num<F> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         match self {

--- a/src/num.rs
+++ b/src/num.rs
@@ -1,3 +1,8 @@
+#![deny(missing_docs)]
+//! This module defines the `Num` type, which is used to represent field elements in Lurk.
+//! The `Num` type is an enum that can represent a field element in either full field representation
+//! or in U64 representation. The U64 representation is used for convenience, and is converted to full
+//! field representation when necessary (e.g. overflow).
 use crate::field::FWrap;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -13,7 +18,9 @@ use crate::uint::UInt;
 /// Finite field element type for Lurk. Has different internal representations to optimize evaluation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Num<F: LurkField> {
+    /// a scalar field element in full field representation
     Scalar(F),
+    /// a small scalar field element in U64 representation for convenience
     U64(u64),
 }
 
@@ -168,9 +175,10 @@ impl<F: LurkField> DivAssign for Num<F> {
 }
 
 impl<F: LurkField> Num<F> {
+    /// Determines if `self` is zero.
     pub fn is_zero(&self) -> bool {
         match self {
-            Num::Scalar(s) => s.is_zero_vartime(),
+            Num::Scalar(s) => s.is_zero().into(),
             Num::U64(n) => n == &0,
         }
     }
@@ -193,10 +201,12 @@ impl<F: LurkField> Num<F> {
         }
     }
 
+    /// Returns the most negative value representable by `Num<F>`.
     pub fn most_negative() -> Self {
         Num::Scalar(F::most_negative())
     }
 
+    /// Returns the most positive value representable by `Num<F>`.
     pub fn most_positive() -> Self {
         Num::Scalar(F::most_positive())
     }
@@ -210,6 +220,7 @@ impl<F: LurkField> Num<F> {
         }
     }
 
+    /// Converts `self` into a scalar value of type `F`.
     pub fn into_scalar(self) -> F {
         match self {
             Num::U64(n) => F::from(n),
@@ -217,6 +228,7 @@ impl<F: LurkField> Num<F> {
         }
     }
 
+    /// Creates a new `Num<F>` from the given scalar `s`.
     pub fn from_scalar(s: F) -> Self {
         Num::Scalar(s)
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -189,7 +189,7 @@ struct PoseidonCache<F: LurkField> {
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 struct CacheKey<F: LurkField, const N: usize>([F; N]);
 
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 impl<F: LurkField, const N: usize> Hash for CacheKey<F, N> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         for el in &self.0 {
@@ -250,7 +250,7 @@ pub trait Pointer<F: LurkField + From<u64>>: fmt::Debug + Copy + Clone + Partial
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Ptr<F: LurkField>(ExprTag, RawPtr<F>);
 
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 impl<F: LurkField> Hash for Ptr<F> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.0.hash(state);
@@ -373,7 +373,7 @@ impl<E: Tag, F: LurkField> Encodable for SPtr<E, F> {
     }
 }
 
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 impl<E: Tag, F: LurkField> Hash for SPtr<E, F> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.0.to_field_bytes::<F>().as_ref().hash(state);
@@ -456,7 +456,7 @@ pub type ScalarContPtr<F> = SPtr<ContTag, F>;
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ContPtr<F: LurkField>(ContTag, RawPtr<F>);
 
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 impl<F: LurkField> Hash for ContPtr<F> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.0.hash(state);
@@ -502,7 +502,7 @@ impl<F: LurkField> RawPtr<F> {
     }
 }
 
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 impl<F: LurkField> Hash for RawPtr<F> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.0.hash(state);
@@ -547,7 +547,7 @@ pub struct Thunk<F: LurkField> {
     pub(crate) continuation: ContPtr<F>,
 }
 
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 impl<F: LurkField> Hash for Thunk<F> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.value.hash(state);


### PR DESCRIPTION
- fixes documentation and usage of `is_zero_vartime()` in `num.rs`
- improves documentation in `field.rs`
- the lack of checks, notably overflow checks, due to our running in `--release` mode, hides overflow behavior. #273 allows us to run tests efficiently without release mode (at 3% slowdown), so this:
    - removes `--release` from CI,
    - includes a custom profile and additional commands for running the circuit tests w/o debug assertions
- updates the toolchain to 1.68.2 and correspondingly fixes some clippy warnings,
- removes the `tempdir` dependency from the project, which was unmaintained and affected by a RUSTSEC.