### PR TITLE
Add `rustyline/with-file-history` feature for non-Wasm targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,7 +709,16 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dece029acd3353e3a58ac2e3eb3c8d6c35827a892edc6cc4138ef9c33df46ecd"
+dependencies = [
+ "dirs-sys 0.4.0",
 ]
 
 [[package]]
@@ -721,6 +730,17 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b"
+dependencies = [
+ "libc",
+ "redox_users",
+ "windows-sys",
 ]
 
 [[package]]
@@ -894,12 +914,12 @@ dependencies = [
 
 [[package]]
 name = "fd-lock"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef1a30ae415c3a691a4f41afddc2dbcd6d70baf338368d85ebc1e8ed92cedb9"
+checksum = "9799aefb4a2e4a01cc47610b1dd47c18ab13d991f27bbcaed9296f5a53d5cbad"
 dependencies = [
  "cfg-if",
- "rustix 0.36.11",
+ "rustix 0.37.5",
  "windows-sys",
 ]
 
@@ -1275,7 +1295,7 @@ dependencies = [
  "clap 4.1.11",
  "criterion",
  "dashmap",
- "dirs",
+ "dirs 5.0.0",
  "ff",
  "fil_pasta_curves",
  "generic-array 0.14.6",
@@ -1303,14 +1323,15 @@ dependencies = [
  "rand_core",
  "rand_xorshift",
  "rayon",
+ "rustyline",
  "rustyline-derive",
  "serde",
  "serde_repr",
  "string-interner",
  "structopt",
  "tap",
+ "tempfile",
  "thiserror",
- "yatima-rustyline",
 ]
 
 [[package]]
@@ -1507,13 +1528,14 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.24.3"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
+ "static_assertions",
 ]
 
 [[package]]
@@ -2003,7 +2025,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b2838e99bd4c9b3e6a963194440c6c5b66721d3f127625d709236ecaa1a730f"
 dependencies = [
- "dirs",
+ "dirs 4.0.0",
  "hex",
  "lazy_static",
  "log",
@@ -2030,9 +2052,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.4"
+version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c348b5dc624ecee40108aa2922fed8bad89d7fcc2b9f8cb18f632898ac4a37f9"
+checksum = "0e78cc525325c06b4a7ff02db283472f3c042b7ff0c391f96c6d5ac6f4f91b75"
 dependencies = [
  "bitflags 1.3.2",
  "errno 0.3.0",
@@ -2061,11 +2083,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustyline-derive"
-version = "0.5.0"
+name = "rustyline"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688599bdab9f42105d0ae1494335a9ffafdeb7d36325e6b10fd4abc5829d6284"
+checksum = "5dfc8644681285d1fb67a467fb3021bfea306b99b4146b166a1fe3ada965eece"
 dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "rustyline-derive",
+ "scopeguard",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "winapi",
+]
+
+[[package]]
+name = "rustyline-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8218eaf5d960e3c478a1b0f129fa888dd3d8d22eb3de097e9af14c1ab4438024"
+dependencies = [
+ "proc-macro2 1.0.53",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -2358,7 +2403,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix 0.37.4",
+ "rustix 0.37.5",
  "windows-sys",
 ]
 
@@ -2725,27 +2770,6 @@ checksum = "8ca6c5a4d66c1a9ea261811cf4773c27343de7e5033e1b75ea3f297dc7db3c1a"
 dependencies = [
  "flume",
  "scopeguard",
-]
-
-[[package]]
-name = "yatima-rustyline"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e615482fe136189e4de6ec92ba867341eb1a32e42a217b6e03d80ad1bcb8df6b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "clipboard-win",
- "fd-lock",
- "libc",
- "log",
- "memchr",
- "nix",
- "scopeguard",
- "unicode-segmentation",
- "unicode-width",
- "utf8parse",
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ repository = "https://github.com/lurk-lab/lurk-rs"
 anyhow = "1.0.69"
 thiserror = "1.0.38"
 bellperson = "0.24"
-dirs = "4.0.0"
 blstrs = "0.6.1"
 ff = "0.12.1"
 generic-array = "0.14.6"
@@ -27,8 +26,7 @@ peekmore = "1.1.0"
 pretty_env_logger = "0.4"
 rand_core = { version = "0.6.4", default-features = false }
 rayon = "1.7.0"
-rustyline = { package = "yatima-rustyline", version = "0.1", default-features = false }
-rustyline-derive = "0.5.0"
+rustyline-derive = "0.8.0"
 rand_xorshift = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_repr = "0.1.10"
@@ -53,9 +51,12 @@ pasta-msm = { version = "0.1.0", package = "lurk-pasta-msm" }
 proptest = "1.1.0"
 proptest-derive = "0.3.0"
 rand = "0.8.5"
+rustyline = { version = "11.0", features = ["derive", "with-file-history"], default-features = false }
+dirs = "5.0.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
+rustyline = { version = "11.0", features = ["derive"], default-features = false }
 
 [features]
 default = []
@@ -66,6 +67,7 @@ criterion = "0.3.6"
 structopt = { version = "0.3", default-features = false }
 tap = "1.0.1"
 assert_cmd = "2.0.8"
+tempfile = "3.5.0"
 
 [[bench]]
 name = "eval"

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -8,7 +8,7 @@ use crate::scalar_store::ScalarStore;
 use crate::store::{ContPtr, Expression, Pointer, Ptr, Store};
 use crate::tag::ContTag;
 use crate::writer::Write;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use clap::{Arg, ArgAction, Command};
 use peekmore::PeekMore;
 use rustyline::error::ReadlineError;
@@ -21,7 +21,7 @@ use rustyline_derive::{Completer, Helper, Highlighter, Hinter};
 use std::fs::{self, read_to_string};
 use std::io::{self, Write as _};
 use std::path::Path;
-#[cfg(not(target = "wasm32"))]
+#[cfg(not(target_arch = "wasm32"))]
 use std::path::PathBuf;
 use tap::TapOptional;
 
@@ -155,10 +155,8 @@ impl<F: LurkField, T: ReplTrait<F>> Repl<F, T> {
         let mut rl = Editor::with_config(config)?;
         rl.set_helper(Some(h));
 
+        #[cfg(not(target_arch = "wasm32"))]
         if history_path.exists() {
-            #[cfg(target_arch = "wasm32")]
-            return Err(anyhow!("File history not allowed on Wasm"));
-            #[cfg(not(target_arch = "wasm32"))]
             rl.load_history(&history_path)?;
         }
 


### PR DESCRIPTION
Follow-up of #316 and #321: we use a fork of rustyline for compatibility reasons and would like to replace it with conditional compilation.