### PR TITLE
Lint module doc & a few other things

### DIFF
--- a/clutch/src/lib.rs
+++ b/clutch/src/lib.rs
@@ -1,14 +1,4 @@
-//! Clutch is a hatchery where nascent Lurk abstractions incubate. Clutch manages the friction point allowing seamless shifting
-//! of loosely-coupled gears.
-//!
-//! Clutch depends on both Lurk and fcomm. It provides a REPL that is a superset of `lurkrs`, and makes some of `fcomm`
-//! available from the REPL.
-//!
-//! In the future, it will likely also included expanded CLI features. It is expected that code will migrate between these
-//! (and other) crates as eventual structure is concretized.
-//!
-//! Ideally, the `clutch` binary will eventually converge on being the most useful tool for using Lurk. Along the way, it
-//! should be viewed as a fast-moving prototype where ideas can be implemented and evolve quickly.
+#![doc = include_str!("../README.md")]
 
 use anyhow::{anyhow, bail, Context, Result};
 use clap::{Arg, ArgAction, Command};

--- a/fcomm/src/lib.rs
+++ b/fcomm/src/lib.rs
@@ -1,4 +1,4 @@
-//! The `fcomm` CLI exposes an interface for creating and verifying Lurk proofs, and for manipulating functional commitments.
+#![doc = include_str!("../README.md")]
 
 use log::info;
 use std::collections::HashMap;

--- a/src/circuit/gadgets/case.rs
+++ b/src/circuit/gadgets/case.rs
@@ -17,9 +17,9 @@ use std::fmt::Debug;
 Initialized map entry for a fixed `key` with
 an allocated `value` computed at runtime.
 */
-pub struct CaseClause<'a, F: LurkField> {
-    pub key: F,
-    pub value: &'a AllocatedNum<F>,
+pub(crate) struct CaseClause<'a, F: LurkField> {
+    pub(crate) key: F,
+    pub(crate) value: &'a AllocatedNum<F>,
 }
 
 impl<F: LurkField + Debug> Debug for CaseClause<'_, F> {
@@ -42,7 +42,7 @@ impl<F: LurkField + Debug> Debug for CaseClause<'_, F> {
 An allocated `selected_key` supposedly equal to one of the fixed keys
 in the list of allocated map entries defined in `clauses`.
 */
-pub struct CaseConstraint<'a, F: LurkField> {
+pub(crate) struct CaseConstraint<'a, F: LurkField> {
     selected_key: AllocatedNum<F>,
     clauses: &'a [CaseClause<'a, F>],
 }
@@ -179,10 +179,10 @@ fn selector_dot_product<F: LurkField, CS: ConstraintSystem<F>>(
 Selects the clause whose key is equal to selected and returns its value,
 or if no key is selected, returns the default.
 */
-pub fn case<F: LurkField, CS: ConstraintSystem<F>>(
+pub(crate) fn case<F: LurkField, CS: ConstraintSystem<F>>(
     cs: &mut CS,
     selected: &AllocatedNum<F>,
-    clauses: &[CaseClause<F>],
+    clauses: &[CaseClause<'_, F>],
     default: &AllocatedNum<F>,
     g: &GlobalAllocations<F>,
 ) -> Result<AllocatedNum<F>, SynthesisError> {
@@ -194,10 +194,10 @@ Selects the clauses whose key is equal to selected and returns
 a vector containing the corresponding values, or if no key is selected,
 returns the default.
 */
-pub fn multi_case<F: LurkField, CS: ConstraintSystem<F>>(
+pub(crate) fn multi_case<F: LurkField, CS: ConstraintSystem<F>>(
     cs: &mut CS,
     selected: &AllocatedNum<F>,
-    cases: &[&[CaseClause<F>]],
+    cases: &[&[CaseClause<'_, F>]],
     defaults: &[&AllocatedNum<F>],
     g: &GlobalAllocations<F>,
 ) -> Result<Vec<AllocatedNum<F>>, SynthesisError> {
@@ -210,10 +210,10 @@ pub fn multi_case<F: LurkField, CS: ConstraintSystem<F>>(
  * Returns not only the selected clause, but also a Boolean that can
  * be used to determine if the default clause was returned.
  */
-pub fn multi_case_aux<F: LurkField, CS: ConstraintSystem<F>>(
+pub(crate) fn multi_case_aux<F: LurkField, CS: ConstraintSystem<F>>(
     cs: &mut CS,
     selected: &AllocatedNum<F>,
-    cases: &[&[CaseClause<F>]],
+    cases: &[&[CaseClause<'_, F>]],
     defaults: &[&AllocatedNum<F>],
     g: &GlobalAllocations<F>,
 ) -> Result<(Vec<AllocatedNum<F>>, Boolean), SynthesisError> {
@@ -445,7 +445,7 @@ mod tests {
         ];
 
         {
-            let clauses0: [CaseClause<Fr>; 2] = [
+            let clauses0: [CaseClause<'_, Fr>; 2] = [
                 CaseClause {
                     key: x,
                     value: &val0,
@@ -455,7 +455,7 @@ mod tests {
                     value: &val1,
                 },
             ];
-            let clauses1: [CaseClause<Fr>; 2] = [
+            let clauses1: [CaseClause<'_, Fr>; 2] = [
                 CaseClause {
                     key: x,
                     value: &val1,
@@ -465,7 +465,7 @@ mod tests {
                     value: &val0,
                 },
             ];
-            let clauses2: [CaseClause<Fr>; 2] = [
+            let clauses2: [CaseClause<'_, Fr>; 2] = [
                 CaseClause {
                     key: x,
                     value: &val2,
@@ -475,7 +475,7 @@ mod tests {
                     value: &val0,
                 },
             ];
-            let clauses_vec: [&[CaseClause<Fr>]; 3] = [&clauses0, &clauses1, &clauses2];
+            let clauses_vec: [&[CaseClause<'_, Fr>]; 3] = [&clauses0, &clauses1, &clauses2];
 
             // Test regular multicase, select first clause
             let mut result = multi_case(
@@ -541,7 +541,7 @@ mod tests {
             &AllocatedNum::alloc(cs.namespace(|| "default1"), || Ok(Fr::from(998))).unwrap(),
         ];
 
-        let clauses0: [CaseClause<Fr>; 2] = [
+        let clauses0: [CaseClause<'_, Fr>; 2] = [
             CaseClause {
                 key: x,
                 value: &val0,
@@ -551,7 +551,7 @@ mod tests {
                 value: &val1,
             },
         ];
-        let clauses1: [CaseClause<Fr>; 2] = [
+        let clauses1: [CaseClause<'_, Fr>; 2] = [
             CaseClause {
                 key: x,
                 value: &val2,
@@ -563,7 +563,7 @@ mod tests {
         ];
 
         // Test repeated keys
-        let invalid_clauses_vec: [&[CaseClause<Fr>]; 2] = [&clauses0, &clauses1];
+        let invalid_clauses_vec: [&[CaseClause<'_, Fr>]; 2] = [&clauses0, &clauses1];
 
         let _ = multi_case(
             &mut cs.namespace(|| "selected case"),
@@ -598,7 +598,7 @@ mod tests {
             &AllocatedNum::alloc(cs.namespace(|| "default2"), || Ok(Fr::from(997))).unwrap(),
         ];
 
-        let clauses0: [CaseClause<Fr>; 2] = [
+        let clauses0: [CaseClause<'_, Fr>; 2] = [
             CaseClause {
                 key: x,
                 value: &val0,
@@ -608,7 +608,7 @@ mod tests {
                 value: &val1,
             },
         ];
-        let clauses1: [CaseClause<Fr>; 2] = [
+        let clauses1: [CaseClause<'_, Fr>; 2] = [
             CaseClause {
                 key: y,
                 value: &val2,
@@ -619,7 +619,7 @@ mod tests {
             },
         ];
 
-        let invalid_clauses_vec: [&[CaseClause<Fr>]; 2] = [&clauses0, &clauses1];
+        let invalid_clauses_vec: [&[CaseClause<'_, Fr>]; 2] = [&clauses0, &clauses1];
 
         // Test keys ordering
         let _ = multi_case(
@@ -653,7 +653,7 @@ mod tests {
             &AllocatedNum::alloc(cs.namespace(|| "default1"), || Ok(Fr::from(998))).unwrap(),
         ];
 
-        let clauses0: [CaseClause<Fr>; 2] = [
+        let clauses0: [CaseClause<'_, Fr>; 2] = [
             CaseClause {
                 key: x,
                 value: &val0,
@@ -663,7 +663,7 @@ mod tests {
                 value: &val1,
             },
         ];
-        let clauses1: [CaseClause<Fr>; 3] = [
+        let clauses1: [CaseClause<'_, Fr>; 3] = [
             CaseClause {
                 key: x,
                 value: &val2,
@@ -679,7 +679,7 @@ mod tests {
         ];
 
         // Test invalid clauses sizes
-        let invalid_clauses_vec: [&[CaseClause<Fr>]; 2] = [&clauses0, &clauses1];
+        let invalid_clauses_vec: [&[CaseClause<'_, Fr>]; 2] = [&clauses0, &clauses1];
 
         let _ = multi_case(
             &mut cs.namespace(|| "selected case"),
@@ -730,7 +730,7 @@ mod tests {
         let val0 = AllocatedNum::alloc(cs.namespace(|| "val0"), || Ok(Fr::from(666))).unwrap();
         let val1 = AllocatedNum::alloc(cs.namespace(|| "val1"), || Ok(Fr::from(777))).unwrap();
         let val2 = AllocatedNum::alloc(cs.namespace(|| "val2"), || Ok(Fr::from(700))).unwrap();
-        let clauses0: [CaseClause<Fr>; 2] = [
+        let clauses0: [CaseClause<'_, Fr>; 2] = [
             CaseClause {
                 key: x,
                 value: &val0,
@@ -740,7 +740,7 @@ mod tests {
                 value: &val1,
             },
         ];
-        let clauses1: [CaseClause<Fr>; 3] = [
+        let clauses1: [CaseClause<'_, Fr>; 3] = [
             CaseClause {
                 key: x,
                 value: &val2,
@@ -754,7 +754,7 @@ mod tests {
                 value: &val0,
             },
         ];
-        let clauses_vec: [&[CaseClause<Fr>]; 2] = [&clauses0, &clauses1];
+        let clauses_vec: [&[CaseClause<'_, Fr>]; 2] = [&clauses0, &clauses1];
 
         // Test invalid, empty defaults
         let _ = multi_case(
@@ -784,7 +784,7 @@ mod tests {
             &AllocatedNum::alloc(cs.namespace(|| "default0"), || Ok(Fr::from(999))).unwrap(),
             &AllocatedNum::alloc(cs.namespace(|| "default1"), || Ok(Fr::from(998))).unwrap(),
         ];
-        let clauses0: [CaseClause<Fr>; 2] = [
+        let clauses0: [CaseClause<'_, Fr>; 2] = [
             CaseClause {
                 key: x,
                 value: &val0,
@@ -795,7 +795,7 @@ mod tests {
             },
         ];
         let clauses1 = [];
-        let clauses_vec: [&[CaseClause<Fr>]; 2] = [&clauses0, &clauses1];
+        let clauses_vec: [&[CaseClause<'_, Fr>]; 2] = [&clauses0, &clauses1];
 
         // Test invalid, empty clauses.
         let _ = multi_case(

--- a/src/circuit/gadgets/constraints.rs
+++ b/src/circuit/gadgets/constraints.rs
@@ -14,7 +14,7 @@ use ff::PrimeField;
 /// Adds a constraint to CS, enforcing an equality relationship between the allocated numbers a and b.
 ///
 /// a == b
-pub fn enforce_equal<F: PrimeField, A, AR, CS: ConstraintSystem<F>>(
+pub(crate) fn enforce_equal<F: PrimeField, A, AR, CS: ConstraintSystem<F>>(
     cs: &mut CS,
     annotation: A,
     a: &AllocatedNum<F>,
@@ -36,7 +36,7 @@ pub fn enforce_equal<F: PrimeField, A, AR, CS: ConstraintSystem<F>>(
 /// Adds a constraint to CS, enforcing a add relationship between the allocated numbers a, b, and sum.
 ///
 /// a + b = sum
-pub fn enforce_sum<F: PrimeField, A, AR, CS: ConstraintSystem<F>>(
+pub(crate) fn enforce_sum<F: PrimeField, A, AR, CS: ConstraintSystem<F>>(
     cs: &mut CS,
     annotation: A,
     a: &AllocatedNum<F>,
@@ -55,7 +55,7 @@ pub fn enforce_sum<F: PrimeField, A, AR, CS: ConstraintSystem<F>>(
     );
 }
 
-pub fn add<F: PrimeField, CS: ConstraintSystem<F>>(
+pub(crate) fn add<F: PrimeField, CS: ConstraintSystem<F>>(
     mut cs: CS,
     a: &AllocatedNum<F>,
     b: &AllocatedNum<F>,
@@ -78,7 +78,7 @@ pub fn add<F: PrimeField, CS: ConstraintSystem<F>>(
 ///
 /// summation(v) = sum
 #[allow(dead_code)]
-pub fn popcount<F: PrimeField, CS: ConstraintSystem<F>>(
+pub(crate) fn popcount<F: PrimeField, CS: ConstraintSystem<F>>(
     cs: &mut CS,
     v: &[Boolean],
     sum: &AllocatedNum<F>,
@@ -99,7 +99,7 @@ pub fn popcount<F: PrimeField, CS: ConstraintSystem<F>>(
     Ok(())
 }
 
-pub fn add_to_lc<F: PrimeField, CS: ConstraintSystem<F>>(
+pub(crate) fn add_to_lc<F: PrimeField, CS: ConstraintSystem<F>>(
     b: &Boolean,
     lc: LinearCombination<F>,
     scalar: F,
@@ -121,7 +121,7 @@ pub fn add_to_lc<F: PrimeField, CS: ConstraintSystem<F>>(
 }
 
 // Enforce v is the bit decomposition of num, therefore we have that 0 <= num < 2ˆ(sizeof(v)).
-pub fn enforce_pack<F: LurkField, CS: ConstraintSystem<F>>(
+pub(crate) fn enforce_pack<F: LurkField, CS: ConstraintSystem<F>>(
     mut cs: CS,
     v: &[Boolean],
     num: &AllocatedNum<F>,
@@ -147,7 +147,7 @@ pub fn enforce_pack<F: LurkField, CS: ConstraintSystem<F>>(
 /// Adds a constraint to CS, enforcing a difference relationship between the allocated numbers a, b, and difference.
 ///
 /// a - b = difference
-pub fn enforce_difference<F: PrimeField, A, AR, CS: ConstraintSystem<F>>(
+pub(crate) fn enforce_difference<F: PrimeField, A, AR, CS: ConstraintSystem<F>>(
     cs: &mut CS,
     annotation: A,
     a: &AllocatedNum<F>,
@@ -168,7 +168,7 @@ pub fn enforce_difference<F: PrimeField, A, AR, CS: ConstraintSystem<F>>(
     );
 }
 
-pub fn sub<F: PrimeField, CS: ConstraintSystem<F>>(
+pub(crate) fn sub<F: PrimeField, CS: ConstraintSystem<F>>(
     mut cs: CS,
     a: &AllocatedNum<F>,
     b: &AllocatedNum<F>,
@@ -191,7 +191,7 @@ pub fn sub<F: PrimeField, CS: ConstraintSystem<F>>(
 /// a * b + c = num is enforced.
 ///
 /// a * b = num - c
-pub fn linear<F: PrimeField, A, AR, CS: ConstraintSystem<F>>(
+pub(crate) fn linear<F: PrimeField, A, AR, CS: ConstraintSystem<F>>(
     cs: &mut CS,
     annotation: A,
     a: &AllocatedNum<F>,
@@ -214,7 +214,7 @@ pub fn linear<F: PrimeField, A, AR, CS: ConstraintSystem<F>>(
 /// Adds a constraint to CS, enforcing a product relationship between the allocated numbers a, b, and product.
 ///
 /// a * b = product
-pub fn product<F: PrimeField, A, AR, CS: ConstraintSystem<F>>(
+pub(crate) fn product<F: PrimeField, A, AR, CS: ConstraintSystem<F>>(
     cs: &mut CS,
     annotation: A,
     a: &AllocatedNum<F>,
@@ -233,7 +233,7 @@ pub fn product<F: PrimeField, A, AR, CS: ConstraintSystem<F>>(
     );
 }
 
-pub fn mul<F: PrimeField, CS: ConstraintSystem<F>>(
+pub(crate) fn mul<F: PrimeField, CS: ConstraintSystem<F>>(
     mut cs: CS,
     a: &AllocatedNum<F>,
     b: &AllocatedNum<F>,
@@ -251,7 +251,7 @@ pub fn mul<F: PrimeField, CS: ConstraintSystem<F>>(
     Ok(res)
 }
 
-pub fn div<F: PrimeField, CS: ConstraintSystem<F>>(
+pub(crate) fn div<F: PrimeField, CS: ConstraintSystem<F>>(
     mut cs: CS,
     a: &AllocatedNum<F>,
     b: &AllocatedNum<F>,
@@ -278,7 +278,7 @@ pub fn div<F: PrimeField, CS: ConstraintSystem<F>>(
 /// The returned result contains the selected element, and constraints are enforced.
 /// `from.len()` must be a power of two.
 #[allow(dead_code)]
-pub fn select<F: PrimeField, CS: ConstraintSystem<F>>(
+pub(crate) fn select<F: PrimeField, CS: ConstraintSystem<F>>(
     mut cs: CS,
     from: &[AllocatedNum<F>],
     path_bits: &[Boolean],
@@ -308,7 +308,7 @@ pub fn select<F: PrimeField, CS: ConstraintSystem<F>>(
 }
 
 /// Takes two allocated numbers (`a`, `b`) and returns `a` if the condition is true, and `b` otherwise.
-pub fn pick<F: PrimeField, CS: ConstraintSystem<F>>(
+pub(crate) fn pick<F: PrimeField, CS: ConstraintSystem<F>>(
     mut cs: CS,
     condition: &Boolean,
     a: &AllocatedNum<F>,
@@ -341,7 +341,7 @@ where
 }
 
 /// Takes two numbers (`a`, `b`) and returns `a` if the condition is true, and `b` otherwise.
-pub fn pick_const<F: PrimeField, CS: ConstraintSystem<F>>(
+pub(crate) fn pick_const<F: PrimeField, CS: ConstraintSystem<F>>(
     mut cs: CS,
     condition: &Boolean,
     a: F,
@@ -374,7 +374,7 @@ where
 }
 
 /// Convert from Boolean to AllocatedNum
-pub fn boolean_to_num<F: PrimeField, CS: ConstraintSystem<F>>(
+pub(crate) fn boolean_to_num<F: PrimeField, CS: ConstraintSystem<F>>(
     mut cs: CS,
     bit: &Boolean,
 ) -> Result<AllocatedNum<F>, SynthesisError>
@@ -401,7 +401,7 @@ where
 }
 
 // This could now use alloc_is_zero to avoid duplication.
-pub fn alloc_equal<CS: ConstraintSystem<F>, F: PrimeField>(
+pub(crate) fn alloc_equal<CS: ConstraintSystem<F>, F: PrimeField>(
     mut cs: CS,
     a: &AllocatedNum<F>,
     b: &AllocatedNum<F>,
@@ -456,7 +456,7 @@ pub fn alloc_equal<CS: ConstraintSystem<F>, F: PrimeField>(
 }
 
 // Like `alloc_equal`, but with second argument a constant.
-pub fn alloc_equal_const<CS: ConstraintSystem<F>, F: PrimeField>(
+pub(crate) fn alloc_equal_const<CS: ConstraintSystem<F>, F: PrimeField>(
     mut cs: CS,
     a: &AllocatedNum<F>,
     b: F,
@@ -510,14 +510,14 @@ pub fn alloc_equal_const<CS: ConstraintSystem<F>, F: PrimeField>(
     Ok(Boolean::Is(result))
 }
 
-pub fn alloc_is_zero<CS: ConstraintSystem<F>, F: PrimeField>(
+pub(crate) fn alloc_is_zero<CS: ConstraintSystem<F>, F: PrimeField>(
     cs: CS,
     x: &AllocatedNum<F>,
 ) -> Result<Boolean, SynthesisError> {
     alloc_num_is_zero(cs, Num::from(x.clone()))
 }
 
-pub fn alloc_num_is_zero<CS: ConstraintSystem<F>, F: PrimeField>(
+pub(crate) fn alloc_num_is_zero<CS: ConstraintSystem<F>, F: PrimeField>(
     mut cs: CS,
     num: Num<F>,
 ) -> Result<Boolean, SynthesisError> {
@@ -565,7 +565,7 @@ pub fn alloc_num_is_zero<CS: ConstraintSystem<F>, F: PrimeField>(
     Ok(Boolean::Is(result))
 }
 
-pub fn or_v<CS: ConstraintSystem<F>, F: PrimeField>(
+pub(crate) fn or_v<CS: ConstraintSystem<F>, F: PrimeField>(
     mut cs: CS,
     v: &[&Boolean],
 ) -> Result<Boolean, SynthesisError> {
@@ -586,7 +586,7 @@ pub fn or_v<CS: ConstraintSystem<F>, F: PrimeField>(
     Ok(nor.not())
 }
 
-pub fn and_v<CS: ConstraintSystem<F>, F: PrimeField>(
+pub(crate) fn and_v<CS: ConstraintSystem<F>, F: PrimeField>(
     mut cs: CS,
     v: &[&Boolean],
 ) -> Result<Boolean, SynthesisError> {
@@ -607,7 +607,7 @@ pub fn and_v<CS: ConstraintSystem<F>, F: PrimeField>(
     Ok(and)
 }
 
-pub fn enforce_implication<CS: ConstraintSystem<F>, F: PrimeField>(
+pub(crate) fn enforce_implication<CS: ConstraintSystem<F>, F: PrimeField>(
     mut cs: CS,
     a: &Boolean,
     b: &Boolean,
@@ -617,7 +617,7 @@ pub fn enforce_implication<CS: ConstraintSystem<F>, F: PrimeField>(
     Ok(())
 }
 
-pub fn enforce_true<CS: ConstraintSystem<F>, F: PrimeField>(
+pub(crate) fn enforce_true<CS: ConstraintSystem<F>, F: PrimeField>(
     cs: CS,
     prop: &Boolean,
 ) -> Result<(), SynthesisError> {
@@ -625,7 +625,7 @@ pub fn enforce_true<CS: ConstraintSystem<F>, F: PrimeField>(
 }
 
 #[allow(dead_code)]
-pub fn enforce_false<CS: ConstraintSystem<F>, F: PrimeField>(
+pub(crate) fn enforce_false<CS: ConstraintSystem<F>, F: PrimeField>(
     cs: CS,
     prop: &Boolean,
 ) -> Result<(), SynthesisError> {
@@ -634,7 +634,7 @@ pub fn enforce_false<CS: ConstraintSystem<F>, F: PrimeField>(
 
 // a => b
 // not (a and (not b))
-pub fn implies<CS: ConstraintSystem<F>, F: PrimeField>(
+pub(crate) fn implies<CS: ConstraintSystem<F>, F: PrimeField>(
     cs: CS,
     a: &Boolean,
     b: &Boolean,
@@ -642,7 +642,7 @@ pub fn implies<CS: ConstraintSystem<F>, F: PrimeField>(
     Ok(Boolean::and(cs, a, &b.not())?.not())
 }
 
-pub fn or<CS: ConstraintSystem<F>, F: PrimeField>(
+pub(crate) fn or<CS: ConstraintSystem<F>, F: PrimeField>(
     mut cs: CS,
     a: &Boolean,
     b: &Boolean,
@@ -655,7 +655,7 @@ pub fn or<CS: ConstraintSystem<F>, F: PrimeField>(
 }
 
 #[allow(dead_code)]
-pub fn must_be_simple_bit(x: &Boolean) -> AllocatedBit {
+pub(crate) fn must_be_simple_bit(x: &Boolean) -> AllocatedBit {
     match x {
         Boolean::Constant(_) => panic!("Expected a non-constant Boolean."),
         Boolean::Is(b) => b.clone(),
@@ -670,7 +670,7 @@ pub fn must_be_simple_bit(x: &Boolean) -> AllocatedBit {
 // field, then a modular reduction must have been carried out, changing the parity that
 // should be even (since we multiplied by 2) to odd. In other words, we define
 // negative numbers to be those field elements that are larger than p/2.
-pub fn allocate_is_negative<F: LurkField, CS: ConstraintSystem<F>>(
+pub(crate) fn allocate_is_negative<F: LurkField, CS: ConstraintSystem<F>>(
     mut cs: CS,
     num: &AllocatedNum<F>,
 ) -> Result<Boolean, SynthesisError> {

--- a/src/circuit/gadgets/data.rs
+++ b/src/circuit/gadgets/data.rs
@@ -283,7 +283,7 @@ impl<F: LurkField> GlobalAllocations<F> {
     }
 }
 
-pub fn hash_poseidon<CS: ConstraintSystem<F>, F: LurkField, A: Arity<F>>(
+pub(crate) fn hash_poseidon<CS: ConstraintSystem<F>, F: LurkField, A: Arity<F>>(
     cs: CS,
     preimage: Vec<AllocatedNum<F>>,
     constants: &PoseidonConstants<F, A>,
@@ -385,7 +385,7 @@ impl<F: LurkField> Ptr<F> {
     }
 }
 
-pub fn allocate_constant<F: LurkField, CS: ConstraintSystem<F>>(
+pub(crate) fn allocate_constant<F: LurkField, CS: ConstraintSystem<F>>(
     cs: &mut CS,
     val: F,
 ) -> Result<AllocatedNum<F>, SynthesisError> {

--- a/src/circuit/gadgets/hashes.rs
+++ b/src/circuit/gadgets/hashes.rs
@@ -17,25 +17,25 @@ pub struct AllocatedHash<F: LurkField, PreimageType> {
     digest: AllocatedNum<F>,
 }
 
-pub type AllocatedPtrHash<F> = AllocatedHash<F, AllocatedPtr<F>>;
-pub type AllocatedNumHash<F> = AllocatedHash<F, AllocatedNum<F>>;
+pub(crate) type AllocatedPtrHash<F> = AllocatedHash<F, AllocatedPtr<F>>;
+pub(crate) type AllocatedNumHash<F> = AllocatedHash<F, AllocatedNum<F>>;
 
 #[derive(Clone, Debug)]
-pub struct Slot<Name: Debug, AllocatedType> {
+pub(crate) struct Slot<Name: Debug, AllocatedType> {
     name: Result<Name, ()>,
     allocated: AllocatedType,
     consumed: bool,
 }
 
 impl<Name: Debug, F: LurkField, PreimageType> Slot<Name, AllocatedHash<F, PreimageType>> {
-    pub fn new(name: Name, allocated: AllocatedHash<F, PreimageType>) -> Self {
+    pub(crate) fn new(name: Name, allocated: AllocatedHash<F, PreimageType>) -> Self {
         Self {
             name: Ok(name),
             allocated,
             consumed: false,
         }
     }
-    pub fn new_dummy(allocated: AllocatedHash<F, PreimageType>) -> Self {
+    pub(crate) fn new_dummy(allocated: AllocatedHash<F, PreimageType>) -> Self {
         Self {
             name: Err(()),
             allocated,
@@ -43,13 +43,13 @@ impl<Name: Debug, F: LurkField, PreimageType> Slot<Name, AllocatedHash<F, Preima
         }
     }
     #[allow(dead_code)]
-    pub fn is_dummy(&self) -> bool {
+    pub(crate) fn is_dummy(&self) -> bool {
         self.name.is_err()
     }
-    pub fn is_blank(&self) -> bool {
+    pub(crate) fn is_blank(&self) -> bool {
         self.allocated.digest.get_value().is_none()
     }
-    pub fn is_consumed(&self) -> bool {
+    pub(crate) fn is_consumed(&self) -> bool {
         self.consumed
     }
     fn consume(&mut self) {
@@ -85,9 +85,9 @@ impl<'a, VanillaWitness, Name: Debug, F: LurkField, PreimageType>
     }
 }
 
-pub type AllocatedConsWitness<'a, F> =
+pub(crate) type AllocatedConsWitness<'a, F> =
     AllocatedWitness<'a, ConsWitness<F>, ConsName, AllocatedPtrHash<F>>;
-pub type AllocatedContWitness<'a, F> =
+pub(crate) type AllocatedContWitness<'a, F> =
     AllocatedWitness<'a, ContWitness<F>, ContName, AllocatedNumHash<F>>;
 
 impl<F: LurkField> AllocatedPtrHash<F> {

--- a/src/circuit/gadgets/mod.rs
+++ b/src/circuit/gadgets/mod.rs
@@ -1,8 +1,8 @@
 #[macro_use]
-pub mod macros;
+pub(crate) mod macros;
 
-pub mod case;
-pub mod constraints;
-pub mod data;
-pub mod hashes;
-pub mod pointer;
+pub(crate) mod case;
+pub(crate) mod constraints;
+pub(crate) mod data;
+pub(crate) mod hashes;
+pub(crate) mod pointer;

--- a/src/circuit/gadgets/pointer.rs
+++ b/src/circuit/gadgets/pointer.rs
@@ -294,7 +294,7 @@ impl<F: LurkField> AllocatedPtr<F> {
         car: &AllocatedPtr<F>,
         cdr: &AllocatedPtr<F>,
         name: ConsName,
-        allocated_cons_witness: &mut AllocatedConsWitness<F>,
+        allocated_cons_witness: &mut AllocatedConsWitness<'_, F>,
         not_dummy: &Boolean,
     ) -> Result<AllocatedPtr<F>, SynthesisError> {
         let expect_dummy = !(not_dummy.get_value().unwrap_or(false));
@@ -698,7 +698,7 @@ impl<F: LurkField> AllocatedContPtr<F> {
         name: ContName,
         cont_tag: &AllocatedNum<F>,
         components: &[&dyn AsAllocatedHashComponents<F>; 4],
-        allocated_cont_witness: &mut AllocatedContWitness<F>,
+        allocated_cont_witness: &mut AllocatedContWitness<'_, F>,
         not_dummy: &Boolean,
     ) -> Result<Self, SynthesisError> {
         let expect_dummy = !(not_dummy.get_value().unwrap_or(false));
@@ -749,7 +749,7 @@ impl<F: LurkField> AllocatedContPtr<F> {
         name: ContName,
         cont_tag: &AllocatedNum<F>,
         components: &[&dyn AsAllocatedHashComponents<F>; 4],
-        allocated_cont_witness: &mut AllocatedContWitness<F>,
+        allocated_cont_witness: &mut AllocatedContWitness<'_, F>,
     ) -> Result<(Self, AllocatedNum<F>), SynthesisError> {
         let (found_components, hash) = allocated_cont_witness.get_components_unconstrained(name);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::single_match, clippy::type_complexity)]
 #![allow(clippy::uninlined_format_args)]
-
-extern crate core;
+#![warn(rust_2018_idioms, unreachable_pub)]
 
 #[macro_use]
 extern crate alloc;
@@ -22,7 +21,7 @@ pub mod tag;
 pub mod uint;
 pub mod writer;
 
-mod error;
+pub mod error;
 mod num;
 pub use num::Num;
 pub use sym::{Sym, Symbol};

--- a/src/light_data/light_store.rs
+++ b/src/light_data/light_store.rs
@@ -352,7 +352,7 @@ impl<F: LurkField> Encodable for LightExpr<F> {
 }
 
 #[cfg(test)]
-pub mod tests {
+mod tests {
     use super::*;
     use pasta_curves::pallas::Scalar;
     use std::collections::BTreeMap;

--- a/src/proof/groth16.rs
+++ b/src/proof/groth16.rs
@@ -420,8 +420,8 @@ mod tests {
         };
     }
 
-    pub fn check_cs_deltas(
-        constraint_systems: &SequentialCS<Fr, IO<Fr>, Witness<Fr>>,
+    fn check_cs_deltas(
+        constraint_systems: &SequentialCS<'_, Fr, IO<Fr>, Witness<Fr>>,
         limit: usize,
     ) {
         let mut cs_blank = MetricCS::<Fr>::new();

--- a/src/proof/groth16.rs
+++ b/src/proof/groth16.rs
@@ -35,12 +35,14 @@ const DUMMY_RNG_SEED: [u8; 16] = [
     0x01, 0x03, 0x02, 0x04, 0x05, 0x07, 0x06, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0C, 0x0B, 0x0A,
 ];
 
+/// The SRS for the inner product argument.
 #[cfg(not(target_arch = "wasm32"))]
 pub static INNER_PRODUCT_SRS: Lazy<GenericSRS<Bls12>> = Lazy::new(|| load_srs().unwrap());
 
 #[cfg(not(target_arch = "wasm32"))]
 const MAX_FAKE_SRS_SIZE: usize = (2 << 14) + 1;
 
+/// A domain separator for the transcript.
 pub const TRANSCRIPT_INCLUDE: &[u8] = b"LURK-CIRCUIT";
 
 // If you don't have a real SnarkPack SRS symlinked, generate a fake one.
@@ -70,6 +72,7 @@ fn load_srs() -> Result<GenericSRS<Bls12>, io::Error> {
     }
 }
 
+/// A struct representing a proof using the Groth16 proving system with the specified engine.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Proof<E: Engine + MultiMillerLoop>
 where
@@ -80,16 +83,20 @@ where
     <E as Engine>::Fr: Serialize,
     <E as Engine>::Gt: blstrs::Compress + Serialize,
 {
+    /// The aggregate proof and instance.
     #[serde(bound(
         serialize = "AggregateProofAndInstance<E>: Serialize",
         deserialize = "AggregateProofAndInstance<E>: Deserialize<'de>"
     ))]
     pub proof: AggregateProofAndInstance<E>,
+    /// The number of proofs in the aggregate proof.
     pub proof_count: usize,
+    /// The number of reductions used in the proof.
     pub reduction_count: usize,
 }
 
 impl Groth16Prover<Bls12> {
+    /// Creates Groth16 parameters using the given reduction count.
     pub fn create_groth_params(
         reduction_count: usize,
     ) -> Result<PublicParams<Bls12>, SynthesisError> {
@@ -104,6 +111,7 @@ impl Groth16Prover<Bls12> {
         Ok(PublicParams(params))
     }
 
+    /// Generates a Groth16 proof using the given multi_frame, parameters, and random number generator.
     pub fn prove<R: RngCore>(
         &self,
         multi_frame: MultiFrame<'_, Scalar, IO<Scalar>, Witness<Scalar>>,
@@ -113,6 +121,8 @@ impl Groth16Prover<Bls12> {
         groth16::create_random_proof(multi_frame, params, &mut rng)
     }
 
+    /// Generates an outer Groth16 proof using the given parameters, SRS, expression, environment,
+    /// store, limit, and random number generator.
     #[allow(clippy::too_many_arguments)]
     pub fn outer_prove<R: RngCore + Clone>(
         &self,
@@ -192,6 +202,7 @@ impl Groth16Prover<Bls12> {
         ))
     }
 
+    /// Verifies a single Groth16 proof using the given multi_frame, prepared verifier key, and proof.
     pub fn verify_groth16_proof(
         // multiframe need not have inner frames populated for verification purposes.
         multiframe: MultiFrame<'_, Scalar, IO<Scalar>, Witness<Scalar>>,
@@ -203,6 +214,7 @@ impl Groth16Prover<Bls12> {
         verify_proof(pvk, &proof, &inputs)
     }
 
+    /// Verifies an aggregated Groth16 proof using the given prepared verifier key, SRS, public parameters, proof and rng.
     pub fn verify<R: RngCore + Send>(
         pvk: &groth16::PreparedVerifyingKey<Bls12>,
         srs_vk: &VerifierSRS<Bls12>,
@@ -224,11 +236,15 @@ impl Groth16Prover<Bls12> {
     }
 }
 
+/// A prover struct for the Groth16 proving system.
+/// Implements the crate::Prover trait.
 pub struct Groth16Prover<E: Engine + MultiMillerLoop> {
     reduction_count: usize,
     _p: PhantomData<E>,
 }
 
+/// Public parameters for the Groth16 proving system.
+/// implements the crate::PublicParameters trait.
 pub struct PublicParams<E: Engine + MultiMillerLoop>(pub groth16::Parameters<E>);
 
 impl PublicParameters for PublicParams<Bls12> {}

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -18,9 +18,9 @@ pub trait Provable<F: LurkField> {
 
 #[allow(dead_code)]
 pub fn verify_sequential_css<F: LurkField + Copy>(
-    css: &SequentialCS<F, IO<F>, Witness<F>>,
+    css: &SequentialCS<'_, F, IO<F>, Witness<F>>,
 ) -> Result<bool, SynthesisError> {
-    let mut previous_frame: Option<&MultiFrame<F, IO<F>, Witness<F>>> = None;
+    let mut previous_frame: Option<&MultiFrame<'_, F, IO<F>, Witness<F>>> = None;
 
     for (i, (multiframe, cs)) in css.iter().enumerate() {
         if let Some(prev) = previous_frame {
@@ -79,7 +79,7 @@ pub trait Prover<'a, F: LurkField> {
 
     fn outer_synthesize(
         &self,
-        multiframes: &'a [MultiFrame<F, IO<F>, Witness<F>>],
+        multiframes: &'a [MultiFrame<'_, F, IO<F>, Witness<F>>],
     ) -> Result<SequentialCS<'a, F, IO<F>, Witness<F>>, SynthesisError> {
         let res = multiframes
             .iter()

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -114,12 +114,12 @@ impl<F: LurkField> NovaProver<F> {
     }
     pub fn evaluate_and_prove<'a>(
         &'a self,
-        pp: &'a PublicParams,
+        pp: &'a PublicParams<'_>,
         expr: Ptr<S1>,
         env: Ptr<S1>,
         store: &'a mut Store<S1>,
         limit: usize,
-    ) -> Result<(Proof, Vec<S1>, Vec<S1>, usize), ProofError> {
+    ) -> Result<(Proof<'_>, Vec<S1>, Vec<S1>, usize), ProofError> {
         let frames = self.get_evaluation_frames(expr, env, store, limit)?;
         let z0 = frames[0].input.to_vector(store)?;
         let zi = frames.last().unwrap().output.to_vector(store)?;
@@ -193,7 +193,7 @@ impl<'a, F: LurkField> StepCircuit<F> for MultiFrame<'a, F, IO<F>, Witness<F>> {
 
 impl<'a> Proof<'a> {
     pub fn prove_recursively(
-        pp: &'a PublicParams,
+        pp: &'a PublicParams<'_>,
         store: &'a Store<S1>,
         circuits: &[C1<'a>],
         num_iters_per_step: usize,
@@ -256,7 +256,7 @@ impl<'a> Proof<'a> {
         Ok(Self::Recursive(Box::new(recursive_snark.unwrap())))
     }
 
-    pub fn compress(self, pp: &'a PublicParams) -> Result<Self, ProofError> {
+    pub fn compress(self, pp: &'a PublicParams<'_>) -> Result<Self, ProofError> {
         match &self {
             Self::Recursive(recursive_snark) => Ok(Self::Compressed(Box::new(CompressedSNARK::<
                 _,
@@ -276,7 +276,7 @@ impl<'a> Proof<'a> {
 
     pub fn verify(
         &self,
-        pp: &PublicParams,
+        pp: &PublicParams<'_>,
         num_steps: usize,
         z0: Vec<S1>,
         zi: &[S1],
@@ -415,7 +415,7 @@ mod tests {
         let len = multiframes.len();
 
         let adjusted_iterations = nova_prover.expected_total_iterations(expected_iterations);
-        let mut previous_frame: Option<MultiFrame<Fr, IO<Fr>, Witness<Fr>>> = None;
+        let mut previous_frame: Option<MultiFrame<'_, Fr, IO<Fr>, Witness<Fr>>> = None;
 
         let mut cs_blank = MetricCS::<Fr>::new();
 

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -31,7 +31,7 @@ struct InputValidator {
 }
 
 impl Validator for InputValidator {
-    fn validate(&self, ctx: &mut ValidationContext) -> rustyline::Result<ValidationResult> {
+    fn validate(&self, ctx: &mut ValidationContext<'_>) -> rustyline::Result<ValidationResult> {
         self.brackets.validate(ctx)
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -82,23 +82,23 @@ impl<F: LurkField> Default for HashConstants<F> {
 }
 
 impl<F: LurkField> HashConstants<F> {
-    pub fn c3(&self) -> &PoseidonConstants<F, U3> {
+    pub(crate) fn c3(&self) -> &PoseidonConstants<F, U3> {
         self.c3.get_or_init(|| PoseidonConstants::new())
     }
 
-    pub fn c4(&self) -> &PoseidonConstants<F, U4> {
+    pub(crate) fn c4(&self) -> &PoseidonConstants<F, U4> {
         self.c4.get_or_init(|| PoseidonConstants::new())
     }
 
-    pub fn c6(&self) -> &PoseidonConstants<F, U6> {
+    pub(crate) fn c6(&self) -> &PoseidonConstants<F, U6> {
         self.c6.get_or_init(|| PoseidonConstants::new())
     }
 
-    pub fn c8(&self) -> &PoseidonConstants<F, U8> {
+    pub(crate) fn c8(&self) -> &PoseidonConstants<F, U8> {
         self.c8.get_or_init(|| PoseidonConstants::new())
     }
 
-    pub fn constants(&self, arity: HashArity) -> HashConst<F> {
+    pub(crate) fn constants(&self, arity: HashArity) -> HashConst<'_, F> {
         match arity {
             HashArity::A3 => HashConst::A3(self.c3.get_or_init(|| PoseidonConstants::new())),
             HashArity::A4 => HashConst::A4(self.c4.get_or_init(|| PoseidonConstants::new())),
@@ -861,7 +861,7 @@ impl<F: LurkField> Default for Store<F> {
 pub struct Error(pub String);
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "StoreError: {}", self.0)
     }
 }
@@ -1699,7 +1699,7 @@ impl<F: LurkField> Store<F> {
         }
     }
 
-    pub fn fetch(&self, ptr: &Ptr<F>) -> Option<Expression<F>> {
+    pub fn fetch(&self, ptr: &Ptr<F>) -> Option<Expression<'_, F>> {
         if ptr.is_opaque() {
             return Some(Expression::Opaque(*ptr));
         }


### PR DESCRIPTION
- The discipline of importing module doc from the readme is tooling-assisted now,
- lint for ineffective visibility (`#[warn(unreachable_pub)]`), and fix the resulting errors,
- document the proof module,
- other minor changes (e.g. visible lifetimes required in Rust ed. 2021)