### PR TITLE
Make more clutch proofs work.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ jobs:
       - restore-sccache-cache
       - run:
           name: Linux Tests
-          command: cargo nextest run --profile ci --workspace --cargo-profile dev-ci --run-ignored all -E 'all() - test(groth16::tests::outer_prove_recursion) -test(fcomm::test_make_fcomm_examples)'
+          command: cargo nextest run --profile ci --workspace --cargo-profile dev-ci --run-ignored all -E 'all() - test(groth16::tests::outer_prove_recursion) - test(fcomm::test_make_fcomm_examples) - test(test_functional_commitments_demo) - test(test_chained_functional_commitments_demo)'
       - run:
           name: Benches build successfully
           command: cargo bench --no-run --profile dev-ci

--- a/fcomm/src/bin/fcomm.rs
+++ b/fcomm/src/bin/fcomm.rs
@@ -347,7 +347,7 @@ impl Prove {
                 )
                 .unwrap();
 
-                Proof::eval_and_prove(s, expr, limit, false, &prover, &pp).unwrap()
+                Proof::eval_and_prove(s, expr, None, limit, false, &prover, &pp).unwrap()
             }
         };
 
@@ -398,7 +398,7 @@ fn read_eval_from_path<P: AsRef<Path>, F: LurkField + Serialize>(
             cont: _,
         },
         _iterations,
-    ) = evaluate(store, src, limit)?;
+    ) = evaluate(store, src, None, limit)?;
 
     Ok((expr, src))
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -557,7 +557,7 @@ impl<F: LurkField> ReplTrait<F> for ReplState<F> {
                     let input = IO {
                         expr: expr_ptr,
                         env: self.env,
-                        cont: store.get_cont_terminal(),
+                        cont: store.get_cont_outermost(),
                     };
 
                     match next_cont.tag() {
@@ -572,7 +572,7 @@ impl<F: LurkField> ReplTrait<F> for ReplState<F> {
                         _ => println!("Computation incomplete after limit: {}", self.limit),
                     }
 
-                    Ok((input, output, 12345))
+                    Ok((input, output, iterations))
                 }
             }
 


### PR DESCRIPTION
This PR increases the number of clutch proofs that can be successfully proved. Because `fcomm` assumes the claims it receives represent their input as strings, it can't handle types that don't (currently) have a readable representation. To fix that, we add support for claims that identify their input and output expr and env by Ptr rather than string. We add special handling for the simple supported cases of continuations, since those are still currently not expressions and therefore would need significant extra work throughout the code base to support uniformly.

The common case this fixes is proving evaluation of an expression that makes use of a function defined in the repl state's env. Because such a function is a *literal* function at this point (rather than a lambda expression that will evaluate to a function), it cannot be read and leads to an error.

This work fixes that by instead just storing a Ptr to the env in the claim. The cost of this is that the claim is no longer readable. We could patch this by still using a string for the expr, since it wasn't the cause of the problem and is likely what we care 'most' about.

However, I think it's better just to make reading of data serialized from Ptrs work as expected. This should all become much more rational once the LDON work lands and is integrated everywhere, and it's probably better to wait for it than to put too many patches on patches.

The following example shows that this is working — and also the problem noted with illegibility of the claim.
```
Lurk Clutch welcomes you.

!> !(:def square (lambda (x) (* x x)))
SQUARE

!> (square 9)
[7 iterations] => 81

!> !(:prove)
Claim::PtrEvaluation elided.
"bafkr4idpvsf64rxxhvffqnlb5bnit5tz5jmwclv6tcpl7yt4zn5ksqdmre"

!> 
Exiting...
➜  clutch git:(improve-clutch-proofs) ✗ bin/clutch
    Finished release [optimized] target(s) in 0.15s
     Running `/Users/clwk/fil/lurk-rs/target/release/clutch`
Lurk Clutch welcomes you.

!> !(:verify "bafkr4idpvsf64rxxhvffqnlb5bnit5tz5jmwclv6tcpl7yt4zn5ksqdmre")
T

!> !(:proof-in-expr "bafkr4idpvsf64rxxhvffqnlb5bnit5tz5jmwclv6tcpl7yt4zn5ksqdmre")
(<Opaque Sym 0x31c399817dae77925db2beff3ebf5eea40767b89ed477af3fd91e80d99563bcb> . <Opaque Cons 0x354f93a7f7debb1d1d8a18a27f7e09939ad144b06ef0f0f3a8c7b78c347b4563>)

!> !(:proof-out-expr "bafkr4idpvsf64rxxhvffqnlb5bnit5tz5jmwclv6tcpl7yt4zn5ksqdmre")
81

```