### PR TITLE
Don't require keywords for meta commands.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,7 @@ jobs:
       - restore-sccache-cache
       - run:
           name: Linux Tests
-          command: cargo nextest run --profile ci --workspace --cargo-profile dev-ci --run-ignored all -E 'all() - test(groth16::tests::outer_prove_recursion) - test(fcomm::test_make_fcomm_examples) - test(test_functional_commitments_demo) - test(test_chained_functional_commitments_demo)'
+          command: cargo nextest run --profile ci --workspace --cargo-profile dev-ci --run-ignored all -E 'all() - test(groth16::tests::outer_prove_recursion) - test(test_make_fcomm_examples) - test(test_functional_commitments_demo) - test(test_chained_functional_commitments_demo)'
       - run:
           name: Benches build successfully
           command: cargo bench --no-run --profile dev-ci

--- a/clutch/demo/bank.lurk
+++ b/clutch/demo/bank.lurk
@@ -2,13 +2,13 @@
 
 ;; We'll start by defining a tiny database of people and their balances.
 
-!(:def people '((:first-name "Alonzo" :last-name "Church" :balance 123 :id 0)
+!(def people '((:first-name "Alonzo" :last-name "Church" :balance 123 :id 0)
                 (:first-name "Alan" :last-name "Turing" :balance 456 :id 1)
                 (:first-name "Satoshi" :last-name "Nakamoto" :balance 9000 :id 2)))
 
 ;; We need a way to look up keys in the database records, so we define a getter.
 
-!(:defrec get (lambda (key plist)
+!(defrec get (lambda (key plist)
                 (if plist
                     (if (eq key (car plist))
                         (car (cdr plist))
@@ -21,7 +21,7 @@
 
 ;; We also need some functional helpers. Map applies a function to each element of a list.
 
-!(:defrec map (lambda (f list)
+!(defrec map (lambda (f list)
                 (if list
                     (cons (f (car list))
                           (map f (cdr list)))
@@ -29,7 +29,7 @@
 
 ;; Filter removes elements of a list that don't satisfy a predicate function.
 
-!(:defrec filter (lambda (pred list)
+!(defrec filter (lambda (pred list)
                    (if list
                        (if (pred (car list))
                            (cons (car list) (filter pred (cdr list)))
@@ -38,7 +38,7 @@
 
 ;; Let's write a predicate that is true when an entry's balance is at least a specified amount.
 
-!(:def balance-at-least? (lambda (x)
+!(def balance-at-least? (lambda (x)
                            (lambda (entry)
                              (>= (get :balance entry) x))))
 
@@ -52,26 +52,26 @@
 
 ;; We can define a function to sum a list of values recursively.
 
-!(:defrec sum (lambda (vals)
+!(defrec sum (lambda (vals)
                 (if vals
                     (+ (car vals) (sum (cdr vals)))
                     0)))
 
 ;; Apply this to the balances, and we can calculate the total funds in a database.
 
-!(:def total-funds (lambda (db) (sum (map (get :balance) db))))
+!(def total-funds (lambda (db) (sum (map (get :balance) db))))
 
 ;; Let's snapshot the initial funds.
 
-!(:def initial-total-funds (emit (total-funds people)))
+!(def initial-total-funds (emit (total-funds people)))
 
 ;; We can check a database to see if funds were conserved by comparing with the inital total.
 
-!(:def funds-are-conserved? (lambda (db) (= initial-total-funds (total-funds db))))
+!(def funds-are-conserved? (lambda (db) (= initial-total-funds (total-funds db))))
 
 ;; Here's a setter.
 
-!(:def set (lambda (key value plist)
+!(def set (lambda (key value plist)
              (letrec ((aux (lambda (acc plist)
                              (if plist
                                  (if (eq key (car plist))
@@ -89,7 +89,7 @@
 
 ;; More useful is an update function that modifes a field based on its current value.
 
-!(:def update (lambda (key update-fn plist)
+!(def update (lambda (key update-fn plist)
                 (letrec ((aux (lambda (acc plist)
                                 (if plist
                                     (if (eq key (car plist))
@@ -107,7 +107,7 @@
 
 ;; And, here's a function that updates only the rows that satisfy a predicate.
 
-!(:def update-where (lambda (predicate key update-fn db)
+!(def update-where (lambda (predicate key update-fn db)
                       (letrec ((aux (lambda (db)
                                       (if db
                                           (if (predicate (car db))
@@ -120,7 +120,7 @@
 
 ;; Let's write a predicate for selecting rows by ID.
 
-!(:def has-id? (lambda (id x) (eq id (get :id x))))
+!(def has-id? (lambda (id x) (eq id (get :id x))))
 
 ;; That lets us change the first letter of the first name of the person with ID 2.
 
@@ -136,7 +136,7 @@
 
 ;; If the sender doesn't have enough funds, we display an insufficient funds message, and return the database unchanged.
 
-!(:def send (lambda (amount from-id to-id db)
+!(def send (lambda (amount from-id to-id db)
               (let ((from (car (filter (has-id? from-id) db))))
                 (if (balance-at-least? amount from)
                     (let ((debited (update-where (has-id? from-id) :balance (lambda (x) (- x amount)) db))
@@ -146,25 +146,27 @@
 
 ;; In token of this new function, we'll call our database of people a ledger.
 
-!(:def ledger people)
+!(def ledger people)
 
 ;; We can send 200 from account 1 to account 0.
 
-(send 200 1 0 ledger)
+!(def ledger1 (send 200 1 0 ledger))
+
+ledger1
 
 ;; And assert that funds were conserved. (Nothing was created or destroyed.)
 
-;; [ERRATUM: This assertion should have run against the result of send, not the original ledger.]
-!(:assert (funds-are-conserved? ledger))
+!(assert (funds-are-conserved? ledger1))
 
 ;; Or, using the original ledger, we can try sending 200 from account 0 to 1.
 
-(send 200 0 1 ledger)
+!(def ledger2 (send 200 0 1 ledger))
+
+ledger2
 
 ;; Notice that this transaction fails due to insufficient funds. However,
 
-;; [ERRATUM: This assertion should have run against the result of send, not the original ledger.]
-!(:assert (funds-are-conserved? ledger))
+!(assert (funds-are-conserved? ledger2))
 
 ;; funds are still conserved
 
@@ -175,7 +177,7 @@
 
 ;; Transfer function takes an amount, a source id, and a destination id, then attempts to send the funds.
 
-!(:def fn<-db (lambda (db)
+!(def fn<-db (lambda (db)
                 (lambda (transfer)
                   (let ((amount (car transfer))
                         (rest (cdr transfer))
@@ -186,26 +188,26 @@
 
 ;; Now let's create a transfer function for our ledger, and commit to it.
 
-!(:commit (fn<-db ledger))
+!(commit (fn<-db ledger))
 
 ;; Now we can open the committed ledger transfer function on a transaction.
 
-!(:call 0x36283c9973a837574e3e5a15815b60a541df265b0f218ab048e99a7c44ee3769 '(1 0 2))
+!(call 0x36283c9973a837574e3e5a15815b60a541df265b0f218ab048e99a7c44ee3769 '(1 0 2))
 
 ;; And the record reflects that Church sent one unit to Satoshi.
 
 ;; Let's prove it.
 
-!(:prove)
+!(prove)
 
 ;; We can verify the proof..
 
-!(:verify "bafkr4id2eiiu2ajtlrobeizxqjzdhzpdymmhj7fwugl73fx5kgl5n2jtzi")
+!(verify "bafkr4ielfk4oipbywfvulebtpzdunvxrnztwumlcd72e5daat4d6w3lapu")
 
 ;; Unfortunately, this functional commitment doesn't let us maintain state.
 ;; Let's turn our single-transaction function into a chained function.
 
-!(:def chain<-db (lambda (db secret)
+!(def chain<-db (lambda (db secret)
                    (letrec ((foo (lambda (state msg)
                                    (let ((new-state ((fn<-db state) msg)))
                                      (cons new-state (hide secret (foo new-state)))))))
@@ -213,28 +215,28 @@
 
 ;; We'll call this on our ledger, and protect write-access with a secret value (999).
 
-!(:commit (chain<-db ledger 999))
+!(commit (chain<-db ledger 999))
 
 ;; Now we can transfer one unit from Church to Satoshi like before.
 
-!(:chain  0x0757a47095c97d0a58a8ff66a2146949ee9d60d3f0a82887c203edf1748be711 '(1 0 2))
+!(chain 0x0757a47095c97d0a58a8ff66a2146949ee9d60d3f0a82887c203edf1748be711 '(1 0 2))
 
-!(:prove)
+!(prove)
 
-!(:verify "bafkr4ifwpaa53jdsh7qz62efvt33l3ts7fen6hcwu6m2xcmp3ysv25wxt4")
+!(verify "bafkr4ia47sgd6vvx5iuvjh7o4o5bu6x7773r2phugezgap4ah6y6aq5g2e")
 
 ;; Then we can transfer 5 more, proceeding from the new head of the chain.
 
-!(:chain 0x14f7a28206656cb7cd6bfcdda773c470653f3136d894d9cb8240e28e3eb52e55 '(5 0 2))
+!(chain 0x14f7a28206656cb7cd6bfcdda773c470653f3136d894d9cb8240e28e3eb52e55 '(5 0 2))
 
-!(:prove)
+!(prove)
 
-!(:verify "bafkr4idsf5btj7bl6nsyx26gfqrqjlchyo4hvmm7gda4b35lhvhew5qbkm")
+!(verify "bafkr4ig7rwromuzptnabqfwqybmcn7zrunykxskkaccvi2gdkxhrjsp4t4") 
 
 ;; And once more, this time we'll transfer 20 from Turing to Church.
 
-!(:chain 0x363b52b6be70c524df767e3a0f0289e5a1ebb0abf2c04d01fe4078b18627a66c '(20 1 0))
+!(chain 0x363b52b6be70c524df767e3a0f0289e5a1ebb0abf2c04d01fe4078b18627a66c '(20 1 0))
 
-!(:prove)
+!(prove)
 
-!(:verify "bafkr4icwzzdqzmmxia6u3inlcj5tyre3n5qtbhofjub32uwitw5awmplha")
+!(verify "bafkr4icrldch5akjnor2gvieqmjcij22ppwnjp2moumrqavgcyomnplume")

--- a/clutch/demo/chained-functional-commitment.lurk
+++ b/clutch/demo/chained-functional-commitment.lurk
@@ -2,14 +2,14 @@
 
 ;; The function returns a new counter value and a commitment to a replacement function wrapping the new counter.
 
-!(:commit (letrec ((add (lambda (counter x)
+!(commit (letrec ((add (lambda (counter x)
                           (let ((counter (+ counter x)))
                             (cons counter (commit (add counter)))))))
             (add 0)))
 
 ;; We chain a next commitment by applying the committed function to a value of 9.
 
-!(:chain 0x3ce3d2df00eb623965384c5b57e162221eb984065eadb19f9daa3190afdcb121 9)
+!(chain 0x3ce3d2df00eb623965384c5b57e162221eb984065eadb19f9daa3190afdcb121 9)
 
 ;; The new counter value is 9, and the function returns a new functional commitment.
 
@@ -17,39 +17,39 @@
 
 ;; Next, we ccreate a proof of this transtion.
 
-!(:prove)
+!(prove)
 
 ;; We can verify the proof.
 
-!(:verify "bafkr4if5f6jgci5ot7k57icbiglq3o7dpkmrfhuahddbxuorte7zdudgeq")
+!(verify "bafkr4ienz7ksx2kmv35vrdr5ptfr7ng3zrylkicr3b5b6c5b7nkdnidfwq")
 
 ;; Now let's chain another call to the new head, adding 12 to the counter.
 
-!(:chain 0x16e909ae4e83b4fc29faa8e8dad0a90f301cf99fd2a1329f6cec685b81d1091a 12)
+!(chain 0x16e909ae4e83b4fc29faa8e8dad0a90f301cf99fd2a1329f6cec685b81d1091a 12)
 
 ;; Now the counter is 21, and we have a new head commitment.
 
 ;; Prove it.
 
-!(:prove)
+!(prove)
 
 ;; And verify.
 
-!(:verify "bafkr4ienaoeogd2n6oy4tttgrza5kjff2fqxzdng6lhpnmaqzlilbphpra")
+!(verify "bafkr4iawd7nchejy73jdhg6ua4aji4nsfllnkgac3exm5jmicpfowjbh7u")
 
 ;; One more time, we'll add 14 to the head commitment's internal state.
 
-!(:chain 0x1f9c18bdabf909167df079312b1921010ec5250aa352195ded4eaf6a2aa9c66e 14)
+!(chain 0x1f9c18bdabf909167df079312b1921010ec5250aa352195ded4eaf6a2aa9c66e 14)
 
 ;; 21 + 14 = 35, as expected.
 
 ;; Prove.
 
-!(:prove)
+!(prove)
 
 ;; Verify.
 
-!(:verify "bafkr4ier43cylaoprfa4sjxqduy3lsjgdimewk6vtottrktapkxf6r4ase")
+!(verify "bafkr4ie7xnlqlaoqpg63d3nbtgw2qsj3uae23v7tyngkfl2rkguaxvezga")
 
 ;; Repeat indefinitely.
 

--- a/clutch/demo/functional-commitment.lurk
+++ b/clutch/demo/functional-commitment.lurk
@@ -1,33 +1,33 @@
 ;; Let's define a function: f(x) = 3x^2 + 9x + 2
 
-!(:def f (lambda (x) (+ (* 3 (* x x)) (+ (* 9 x) 2))))
+!(def f (lambda (x) (+ (* 3 (* x x)) (+ (* 9 x) 2))))
 
-!(:assert-eq (f 5) 122)
+!(assert-eq (f 5) 122)
 
 ;; We can create a cryptographic commitment to f.
 
-!(:commit f)
+!(commit f)
 
 ;; We open the functional commitment on input 5: Evaluate f(5).
 
-!(:call 0x396e9cd726a3c323ad1ec3a7651da94bc08c2d7baa68211186101d3735fb31d3 5)
+!(call 0x396e9cd726a3c323ad1ec3a7651da94bc08c2d7baa68211186101d3735fb31d3 5)
 
 ;; We can prove the functional-commitment opening.
 
-!(:prove)
+!(prove)
 
 ;; We can inspect the input expression that was proved.
 
-!(:proof-in-expr "bafkr4icpnzlbslcikkdcitwtgdq6krfxgzsgfdvtrdfzbpgrzwtohaf6dq")
+!(proof-in-expr "bafkr4icba2o33x7tupuu7p6a5jdtsohreiyn6qfa3d4swa4nqo2urr6vgq")
 
 ;; And also the output expression.
 
-!(:proof-out-expr "bafkr4icpnzlbslcikkdcitwtgdq6krfxgzsgfdvtrdfzbpgrzwtohaf6dq")
+!(proof-out-expr "bafkr4icba2o33x7tupuu7p6a5jdtsohreiyn6qfa3d4swa4nqo2urr6vgq")
 
 ;; We can also see exactly what we claim to have proved.
 
-!(:proof-claim "bafkr4icpnzlbslcikkdcitwtgdq6krfxgzsgfdvtrdfzbpgrzwtohaf6dq")
+!(proof-claim "bafkr4icba2o33x7tupuu7p6a5jdtsohreiyn6qfa3d4swa4nqo2urr6vgq")
 
 ;; Finally, and most importantly, we can verify the proof.
 
-!(:verify "bafkr4icpnzlbslcikkdcitwtgdq6krfxgzsgfdvtrdfzbpgrzwtohaf6dq")
+!(verify "bafkr4icba2o33x7tupuu7p6a5jdtsohreiyn6qfa3d4swa4nqo2urr6vgq")

--- a/clutch/demo/simple.lurk
+++ b/clutch/demo/simple.lurk
@@ -2,16 +2,16 @@
 
 (+ 1 1)
 
-!(:def square (lambda (x) (* x x)))
+!(def square (lambda (x) (* x x)))
 
 (square 8)
 
-!(:def make-adder
+!(def make-adder
    (lambda (n)
      (lambda (x)
        (+ x n))))
 
-!(:def five-plus
+!(def five-plus
    (make-adder 5))
 
 (five-plus 3)

--- a/clutch/demo/vdf.lurk
+++ b/clutch/demo/vdf.lurk
@@ -1,4 +1,3 @@
-
 ;; Hat tip to JP Aumasson.
 !(defrec fastexp (lambda (b e)
                     (if (= e 0) 1

--- a/clutch/demo/vdf.lurk
+++ b/clutch/demo/vdf.lurk
@@ -1,6 +1,6 @@
 
 ;; Hat tip to JP Aumasson.
-!(:defrec fastexp (lambda (b e)
+!(defrec fastexp (lambda (b e)
                     (if (= e 0) 1
                         (if (< (/ e 2) 0) ; is e odd?
                             (* b (fastexp (* b b) (/ (- e 1) 2)))
@@ -9,17 +9,17 @@
 (fastexp 2 5)
 
 ;; (4p - 3) / 5
-!(:def r 23158417847463239084714197001737581570690445185553317903743794198714690358477)
+!(def r 23158417847463239084714197001737581570690445185553317903743794198714690358477)
 
-!(:def fifth-root (lambda (n) (fastexp n r)))
+!(def fifth-root (lambda (n) (fastexp n r)))
 
-!(:def fifth (lambda (n) (fastexp n 5)))
+!(def fifth (lambda (n) (fastexp n 5)))
 
 (fifth-root 42)
 
 (fifth 0x2e6606ca7e8983f71964677e06cd8fd13ee0d46bf3c3e52d3af1b80df06f730b)
 
-!(:def round (lambda (state)
+!(def round (lambda (state)
                (let ((x (car state))
                      (y (car (cdr state)))
                      (i (car (cdr (cdr state)))))
@@ -27,7 +27,7 @@
                        (cons (+ x i)
                              (cons (+ i 1) nil))))))
 
-!(:def inverse-round (lambda (state)
+!(def inverse-round (lambda (state)
                        (let ((x (car state))
                              (y (car (cdr state)))
                              (i (car (cdr (cdr state))))
@@ -36,12 +36,12 @@
                              (new-y (- (fifth x) new-x)))
                          (cons new-x (cons new-y (cons new-i nil))))))
 
-!(:defrec minroot (lambda (state rounds)
+!(defrec minroot (lambda (state rounds)
                     (if (= rounds 0)
                         state
                         (minroot (round state) (- rounds 1)))))
 
-!(:defrec minroot-inverse (lambda (state rounds)
+!(defrec minroot-inverse (lambda (state rounds)
                             (if (= rounds 0)
                                 state
                                 (minroot-inverse (inverse-round state) (- rounds 1)))))
@@ -50,16 +50,16 @@
 
 (minroot-inverse '(0x27ec1d892ff1b85d98dd8e61509c0ce63b6954da8a743ee54b1f405cde722eb1 0x0da555f3ff604e853948466204d773c4c34d8cf38cea55351c9c97593613fb3b 11) 10)
 
-!(:prove)
+!(prove)
 
-!(:verify "bafkr4ihoaqtkt3fa2gbcurqd6io4iqf4s7e63efknh7xxa65g4e4nkwdl4")
+!(verify "bafkr4ihoaqtkt3fa2gbcurqd6io4iqf4s7e63efknh7xxa65g4e4nkwdl4")
 
-!(:def timelock-encrypt (lambda (secret-key plaintext rounds)
+!(def timelock-encrypt (lambda (secret-key plaintext rounds)
                           (let ((ciphertext (+ secret-key plaintext))
                                 (timelocked-key-state (minroot-inverse (cons secret-key '(0 1)) rounds)))
                             (cons timelocked-key-state ciphertext))))
 
-!(:def timelock-decrypt (lambda (timelocked-key-state ciphertext rounds)
+!(def timelock-decrypt (lambda (timelocked-key-state ciphertext rounds)
                           (let ((secret-key (car (minroot timelocked-key-state rounds)))
                                 (plaintext (- ciphertext secret-key)))
                             plaintext)))

--- a/clutch/src/lib.rs
+++ b/clutch/src/lib.rs
@@ -14,6 +14,7 @@ use lurk::package::Package;
 use lurk::proof::{nova::NovaProver, Prover};
 use lurk::repl::{ReplState, ReplTrait};
 use lurk::store::{Expression, Pointer, Ptr, Store};
+use lurk::sym::Sym;
 use lurk::tag::ExprTag;
 use lurk::writer::Write;
 
@@ -192,7 +193,7 @@ impl ReplTrait<F> for ClutchState<F> {
 
         let res: Option<Ptr<F>> = match expr {
             Expression::Cons(car, rest) => match &store.fetch(&car).unwrap() {
-                Expression::Sym(s) => match s.name().as_str() {
+                Expression::Sym(Sym::Sym(s)) => match s.name().as_str() {
                     "CALL" => self.call(store, rest)?,
                     "CHAIN" => self.chain(store, rest)?,
                     "COMMIT" => self.commit(store, rest)?,

--- a/clutch/src/lib.rs
+++ b/clutch/src/lib.rs
@@ -192,24 +192,18 @@ impl ReplTrait<F> for ClutchState<F> {
 
         let res: Option<Ptr<F>> = match expr {
             Expression::Cons(car, rest) => match &store.fetch(&car).unwrap() {
-                Expression::Sym(s) => {
-                    if let Some(name) = s.simple_keyword_name() {
-                        match name.as_str() {
-                            "CALL" => self.call(store, rest)?,
-                            "CHAIN" => self.chain(store, rest)?,
-                            "COMMIT" => self.commit(store, rest)?,
-                            "OPEN" => self.open(store, rest)?,
-                            "PROOF-IN-EXPR" => self.proof_in_expr(store, rest)?,
-                            "PROOF-OUT-EXPR" => self.proof_out_expr(store, rest)?,
-                            "PROOF-CLAIM" => self.proof_claim(store, rest)?,
-                            "PROVE" => self.prove(store, rest)?,
-                            "VERIFY" => self.verify(store, rest)?,
-                            _ => return delegate!(),
-                        }
-                    } else {
-                        return delegate!();
-                    }
-                }
+                Expression::Sym(s) => match s.name().as_str() {
+                    "CALL" => self.call(store, rest)?,
+                    "CHAIN" => self.chain(store, rest)?,
+                    "COMMIT" => self.commit(store, rest)?,
+                    "OPEN" => self.open(store, rest)?,
+                    "PROOF-IN-EXPR" => self.proof_in_expr(store, rest)?,
+                    "PROOF-OUT-EXPR" => self.proof_out_expr(store, rest)?,
+                    "PROOF-CLAIM" => self.proof_claim(store, rest)?,
+                    "PROVE" => self.prove(store, rest)?,
+                    "VERIFY" => self.verify(store, rest)?,
+                    _ => return delegate!(),
+                },
                 Expression::Comm(_, c) => {
                     // NOTE: this cannot happen from a text-based REPL, since there is not currrently a literal Comm syntax.
                     self.apply_comm(store, *c, rest)?


### PR DESCRIPTION
UPDATE: This PR failed to merge as expected, but I've updated lurk-lib anyway; and pushed the next set of changes which *disallow* keyword meta commands. There's no reason we need to checkpoint through the rhetorical state of deprecating but allowing the keywords now that we've also merged the PR to update lurk-lib.

---
This PR is a small incremental change, making the 'meta' command syntax from the REPL (lurkrs and clutch) more permissive. Specifically, it allows using non-keyword (no colon) symbols to name commands. Eventually, we will make the non-keyword form mandatory. (The goal is that eventually, meta-lurk is semantically just 'lurk', even though some capabilities cannot yet be included in proofs.)

In order to ease the transition, this PR allows both syntaxes to co-exist. However, the keyword form should be considered deprecated once this PR merges.

Once we then update the `lurk-lib` examples (and perhaps published references to the keyword syntax), we can take the next step and disallow the keyword form.

See examples that work now but would not have previously:

lurkrs
```
Lurk REPL welcomes you.
> !(def foo (lambda (x) (+ x 9)))
FOO
> (foo 1)
[7 iterations] => 10
>
```

clutch
```
Lurk Clutch welcomes you.

!> !(prove (+ 1 1))
Claim::PtrEvaluation elided.
"bafkr4igy75y3xmnj742f3tyelpgwbcsirfzauo7r5s2glutomrnkzgbb5u"

!> !(verify "bafkr4igy75y3xmnj742f3tyelpgwbcsirfzauo7r5s2glutomrnkzgbb5u")
T

!>
```