### PR TITLE
Problem: machine-generated files risk ending up in the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /target
 result*
 /scratch
-
+.direnv/


### PR DESCRIPTION
Solution:

 - Add .direnv/ to .gitignore

 .direnv/ gets generated by `direnv allow` and populated with nix flake related files

---

Closes #344