### PR TITLE
Add Nix Wasm build & instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,18 @@ git submodule update --init --recursive
 
 ## Wasm
 
-Lurk can be compiled to Wasm with `cargo build --target wasm32-unknown-unknown`
+### Prerequisites
+- [clang](https://clang.llvm.org/get_started.html)
+
+Lurk can be compiled to Wasm with
+```
+cargo build --target wasm32-unknown-unknown
+```
+
+If using Nix without a system-wide `clang` install (e.g. NixOS):
+```
+CC=clang cargo build --target wasm32-unknown-unknown
+```
 
 ## Repl
 

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         toolchain = with fenix.packages.${system}; fromToolchainFile {
           file = ./rust-toolchain.toml; # alternatively, dir = ./.;
-          sha256 = "sha256-S4dA7ne2IpFHG+EnjXfogmqwGyDFSRWFnJ8cy4KZr1k=";
+          sha256 = "sha256-4vetmUhTUsew5FODnjlnQYInzyLNyDwocGa4IvMk3DM=";
         };
 
       in rec {
@@ -38,6 +38,7 @@
           buildInputs = with pkgs; [
             ocl-icd
             toolchain
+            clang
           ];
         };
       }


### PR DESCRIPTION
This fixes an issue where `blst` wouldn't recognize the `clang` path if installed with Nix, although there is probably a more direct fix.