### PR TITLE
refactor: Update dependencies to ff/group version 0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,9 +206,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bellperson"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a8623f815c0b1fd89efd9b5f4afbb937f91f51c1ebe3f6dda399c69fa938f3"
+checksum = "93eaee4b4753554139ae52ecf0e8b8c128cbc561b32e1bfaa32f70cba8518c1f"
 dependencies = [
  "bincode",
  "blake2s_simd 1.0.1",
@@ -365,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "blstrs"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ecb6f3a9429706971633edf4b84f922aba9d2e3a7d71bfb450337e64ccb7df0"
+checksum = "33149fccb7f93271f0192614b884430cf274e880506bbd171cbc8918dcc95b14"
 dependencies = [
  "blst",
  "byte-slice-cast",
@@ -488,22 +488,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cl-sys"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8573fa3ff8acd6c49e8e113296c54277e82376b96c6ca6307848632cce38e44"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "cl3"
-version = "0.6.5"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f2217b5993b54a819ac8e8569cc429702c8975a88d52c73e530f1f813576a3"
+checksum = "0e014961508a981c7ef28a65d0c965af7061593b4db50cff83952c62931b39ec"
 dependencies = [
- "cl-sys",
  "libc",
+ "opencl-sys",
 ]
 
 [[package]]
@@ -613,8 +604,8 @@ dependencies = [
  "assert_cmd",
  "blstrs",
  "clap 4.2.7",
- "fil_pasta_curves",
  "lurk",
+ "pasta_curves",
  "pretty_env_logger",
  "serde",
 ]
@@ -855,22 +846,23 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "4.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.7"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
+ "option-ext",
  "redox_users",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -887,9 +879,9 @@ checksum = "bd63582de2b59ea1aa48d7c1941b5d87618d95484397521b3acdfa0e1e9f5e45"
 
 [[package]]
 name = "ec-gpu-gen"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd09bf9d5313ad60379f70250590bccc10f7a04e2773062ac13255a37022584e"
+checksum = "892df2aa20abec5b816e15d5d6383892ca142077708efa3067dd3ac44b75c664"
 dependencies = [
  "bitvec",
  "crossbeam-channel",
@@ -1016,7 +1008,6 @@ dependencies = [
  "clap 3.2.25",
  "clap-verbosity-flag",
  "ff",
- "fil_pasta_curves",
  "hex",
  "log",
  "lurk",
@@ -1024,6 +1015,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "pairing",
+ "pasta_curves",
  "predicates 2.1.5",
  "pretty_env_logger",
  "rand",
@@ -1046,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "bitvec",
  "byteorder",
@@ -1059,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "ff_derive"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17db6fa0748f1f66e9dbafba1881009b50614948c0e900f59083afff2f8d784b"
+checksum = "e9f54704be45ed286151c5e11531316eaef5b8f5af7d597b806fdb8af108d84a"
 dependencies = [
  "addchain",
  "cfg-if",
@@ -1083,24 +1075,6 @@ dependencies = [
  "cuda-driver-sys",
  "rustacuda_core",
  "rustacuda_derive",
-]
-
-[[package]]
-name = "fil_pasta_curves"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3303ea3c462ab949ab95b49f6e6d255d8d9396ebd4f1626ccb34c7037615aa8f"
-dependencies = [
- "blake2b_simd",
- "ec-gpu",
- "ff",
- "group",
- "hex",
- "lazy_static",
- "rand",
- "serde",
- "static_assertions",
- "subtle",
 ]
 
 [[package]]
@@ -1140,7 +1114,7 @@ version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -1201,9 +1175,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "group"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
  "rand",
@@ -1404,9 +1378,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
 dependencies = [
  "cpufeatures",
 ]
@@ -1416,6 +1390,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin 0.5.2",
+]
 
 [[package]]
 name = "libc"
@@ -1472,7 +1449,6 @@ dependencies = [
  "criterion",
  "dashmap",
  "ff",
- "fil_pasta_curves",
  "generic-array 0.14.7",
  "getrandom",
  "hex",
@@ -1482,7 +1458,6 @@ dependencies = [
  "log",
  "lurk-ipld",
  "lurk-macros",
- "lurk-pasta-msm",
  "memmap2",
  "multihash",
  "neptune",
@@ -1493,6 +1468,8 @@ dependencies = [
  "num-traits",
  "once_cell",
  "pairing",
+ "pasta-msm 0.1.4 (git+https://github.com/supranational/pasta-msm)",
+ "pasta_curves",
  "peekmore",
  "pprof",
  "pretty_env_logger",
@@ -1582,24 +1559,11 @@ dependencies = [
 name = "lurk-macros"
 version = "0.1.0"
 dependencies = [
- "fil_pasta_curves",
  "lurk",
+ "pasta_curves",
  "proc-macro2 1.0.56",
  "quote 1.0.26",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "lurk-pasta-msm"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12992280292a2a4ff84591308c426029245d49094c75df079b286f1bb8496e6c"
-dependencies = [
- "cc",
- "fil_pasta_curves",
- "semolina",
- "sppark",
- "which",
 ]
 
 [[package]]
@@ -1676,7 +1640,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "sha2",
- "sha3 0.10.7",
+ "sha3 0.10.8",
  "unsigned-varint",
 ]
 
@@ -1696,9 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "neptune"
-version = "8.1.1"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d47b29bc49c7d957eb446e298f96cd7088829e2d7a549ab04b36bc82434e27b"
+checksum = "4227e5557caad6d2a910b7770f2479f0c9aeb8ddc1dc537623cb6ffec7f01d31"
 dependencies = [
  "bellperson",
  "blake2s_simd 0.5.11",
@@ -1707,11 +1671,10 @@ dependencies = [
  "ec-gpu",
  "ec-gpu-gen",
  "ff",
- "fil_pasta_curves",
  "generic-array 0.14.7",
  "itertools 0.8.2",
- "lazy_static",
  "log",
+ "pasta_curves",
  "serde",
  "trait-set",
 ]
@@ -1746,9 +1709,8 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nova-snark"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b027edd6db7d0e0c60027750f82d9a33893b5e074ca419ec26cc931a91fc404c"
+version = "0.20.3"
+source = "git+https://github.com/huitseeker/nova?branch=bump_ff_group#83086639d3b0716eb054916a0818ffae7e7feee4"
 dependencies = [
  "bellperson",
  "bincode",
@@ -1756,15 +1718,15 @@ dependencies = [
  "byteorder",
  "digest 0.8.1",
  "ff",
- "fil_pasta_curves",
  "flate2",
  "generic-array 0.14.7",
  "itertools 0.9.0",
- "lurk-pasta-msm",
  "neptune",
  "num-bigint 0.4.3",
  "num-integer",
  "num-traits",
+ "pasta-msm 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pasta_curves",
  "rand_chacha",
  "rand_core",
  "rayon",
@@ -1866,14 +1828,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
-name = "opencl3"
-version = "0.6.3"
+name = "opencl-sys"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "931cc2ab3068142384dbdaba142681c11b315cf3b96c7a59e8480d062363387f"
+checksum = "e75919008b8ed7ce9620e2b3580c648db40c7f564a368f271b2647145046d8ba"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "opencl3"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "274085527b193703ea266b8b09bc0f93b2b123da9b50cc7923a7c3e84bda34e3"
 dependencies = [
  "cl3",
  "libc",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "os_str_bytes"
@@ -1883,9 +1860,9 @@ checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "pairing"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
+checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
  "group",
 ]
@@ -1911,6 +1888,49 @@ dependencies = [
  "redox_syscall 0.2.16",
  "smallvec",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "pasta-msm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e85d75eba3e7e9ee3bd11342b669185e194dadda3557934bc1000d9b87159d3"
+dependencies = [
+ "cc",
+ "pasta_curves",
+ "semolina",
+ "sppark",
+ "which",
+]
+
+[[package]]
+name = "pasta-msm"
+version = "0.1.4"
+source = "git+https://github.com/supranational/pasta-msm#2aa8c05071207cc5bde8be6131a24aea305ebd1e"
+dependencies = [
+ "cc",
+ "pasta_curves",
+ "semolina",
+ "sppark",
+ "which",
+]
+
+[[package]]
+name = "pasta_curves"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
+dependencies = [
+ "blake2b_simd",
+ "ec-gpu",
+ "ff",
+ "group",
+ "hex",
+ "lazy_static",
+ "rand",
+ "serde",
+ "static_assertions",
+ "subtle",
 ]
 
 [[package]]
@@ -2286,14 +2306,13 @@ dependencies = [
 
 [[package]]
 name = "rust-gpu-tools"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2838e99bd4c9b3e6a963194440c6c5b66721d3f127625d709236ecaa1a730f"
+checksum = "705270e758cf496103dc2ec8d77a3ecb319801555f0546065f45cf6e70b7c7c7"
 dependencies = [
  "dirs",
  "fil-rustacuda",
  "hex",
- "lazy_static",
  "log",
  "once_cell",
  "opencl3",
@@ -2413,9 +2432,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semolina"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90759f733a01b95d6ba70180b954d1d96e3e7e11f86c3fb0da0231300972e05"
+checksum = "958b2a965e3d50f76bed0f8f8b4c44bb106265959939f61b1abf55e6c22a35c8"
 dependencies = [
  "cc",
  "glob",
@@ -2423,9 +2442,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "71b2f6e1ab5c2b98c05f0f35b236b22e8df7ead6ffbf51d7808da7f8817e7ab6"
 dependencies = [
  "serde_derive",
 ]
@@ -2450,9 +2469,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "a2a0814352fd64b58489904a44ea8d90cb1a91dcb6b4f5ebabc32c8318e93cb6"
 dependencies = [
  "proc-macro2 1.0.56",
  "quote 1.0.26",
@@ -2507,9 +2526,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c2bb1a323307527314a36bfb73f24febb08ce2b8a554bf4ffd6f51ad15198c"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.6",
  "keccak",
@@ -2520,6 +2539,12 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -2687,11 +2712,11 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "temp-env"
-version = "0.2.0"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45107136c2ddf8c4b87453c02294fd0adf41751796e81e8ba3f7fd951977ab57"
+checksum = "9547444bfe52cbd79515c6c8087d8ae6ca8d64d2d31a27746320f5cb81d1a15c"
 dependencies = [
- "once_cell",
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,9 +448,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "ciborium"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -459,15 +459,15 @@ dependencies = [
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
 dependencies = [
  "ciborium-io",
  "half",
@@ -1408,9 +1408,9 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b64f40e5e03e0d54f03845c8197d0291253cdbedfb1cb46b13c2c117554a9f4c"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
 name = "lock_api"
@@ -1468,7 +1468,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "pairing",
- "pasta-msm 0.1.4 (git+https://github.com/supranational/pasta-msm)",
+ "pasta-msm",
  "pasta_curves",
  "peekmore",
  "pprof",
@@ -1709,8 +1709,9 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nova-snark"
-version = "0.20.3"
-source = "git+https://github.com/huitseeker/nova?branch=bump_ff_group#83086639d3b0716eb054916a0818ffae7e7feee4"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6247c61ab29e5da01c8f80403c25c40956045f0343d79793a2675bf7775dd80"
 dependencies = [
  "bellperson",
  "bincode",
@@ -1725,7 +1726,7 @@ dependencies = [
  "num-bigint 0.4.3",
  "num-integer",
  "num-traits",
- "pasta-msm 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pasta-msm",
  "pasta_curves",
  "rand_chacha",
  "rand_core",
@@ -1895,18 +1896,6 @@ name = "pasta-msm"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e85d75eba3e7e9ee3bd11342b669185e194dadda3557934bc1000d9b87159d3"
-dependencies = [
- "cc",
- "pasta_curves",
- "semolina",
- "sppark",
- "which",
-]
-
-[[package]]
-name = "pasta-msm"
-version = "0.1.4"
-source = "git+https://github.com/supranational/pasta-msm#2aa8c05071207cc5bde8be6131a24aea305ebd1e"
 dependencies = [
  "cc",
  "pasta_curves",
@@ -2346,9 +2335,9 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.37.18"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bbfc1d1c7c40c01715f47d71444744a81669ca84e8b63e25a55e169b1f86433"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
  "bitflags",
  "errno",
@@ -2877,9 +2866,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dad5567ad0cf5b760e5665964bec1b47dfd077ba8a2544b513f3556d3d239a2"
+checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,27 +845,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1848,12 +1827,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
 name = "os_str_bytes"
 version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2245,17 +2218,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom",
- "redox_syscall 0.2.16",
- "thiserror",
-]
-
-[[package]]
 name = "regex"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2295,13 +2257,13 @@ dependencies = [
 
 [[package]]
 name = "rust-gpu-tools"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705270e758cf496103dc2ec8d77a3ecb319801555f0546065f45cf6e70b7c7c7"
+checksum = "b0ce78d5548a74fad25177825d0c20f4cfbc6eaf796bcee53afe792e39ede4e2"
 dependencies = [
- "dirs",
  "fil-rustacuda",
  "hex",
+ "home",
  "log",
  "once_cell",
  "opencl3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,17 +14,19 @@ anyhow = "1.0.69"
 base64 = "0.13.1"
 hex = { version = "0.4.3", features = ["serde"] }
 thiserror = "1.0.38"
-bellperson = "0.24"
-blstrs = "0.6.1"
-ff = "0.12.1"
+bellperson = "0.25"
+blstrs = "0.7.0"
+ff = "0.13"
 generic-array = "0.14.6"
 itertools = "0.9"
 log = "0.4.17"
 lurk-macros = { path = "lurk-macros" }
-neptune = { version = "8.1.1", features = ["arity2","arity4","arity8","arity16","pasta","bls"] }
-nova = { package = "nova-snark", version = "0.19.0", default-features = false }
+neptune = { version = "9.0.0", features = ["arity2","arity4","arity8","arity16","pasta","bls"] }
+# DO NOT COMMIT
+nova = { package = "nova-snark", version = "0.20", default-features = false, git = "https://github.com/huitseeker/nova", branch="bump_ff_group"}
+# DO NOT COMMIT
 once_cell = "1.17.1"
-pairing_lib = { version = "0.22", package = "pairing" }
+pairing_lib = { version = "0.23", package = "pairing" }
 peekmore = "1.1.0"
 pretty_env_logger = "0.4"
 rand_core = { version = "0.6.4", default-features = false }
@@ -37,7 +39,7 @@ serde_json = { version = "1.0" }
 serde_repr = "0.1.10"
 indexmap = { version = "1.9.2", features = ["rayon"] }
 ahash = "0.7.6"
-pasta_curves = { version = "0.5.2", features = ["repr-c", "serde"], package = "fil_pasta_curves" }
+pasta_curves = { version = "0.5.1", features = ["repr-c", "serde"] }
 string-interner = "0.14.0"
 dashmap = "5.4.0"
 libipld = { package = "lurk-ipld", version = "0.3.0", default-features = false, features = ["dag-cbor", "dag-json", "serde-codec"] }
@@ -54,7 +56,9 @@ bincode = "1.3.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 memmap = { version = "0.5.10", package = "memmap2" }
-pasta-msm = { version = "0.1.0", package = "lurk-pasta-msm" }
+# DO NOT COMMIT
+pasta-msm = { version = "0.1.3", git = "https://github.com/supranational/pasta-msm" }
+# DO NOT COMMIT
 proptest = "1.1.0"
 proptest-derive = "0.3.0"
 rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,7 @@ itertools = "0.9"
 log = "0.4.17"
 lurk-macros = { path = "lurk-macros" }
 neptune = { version = "9.0.0", features = ["arity2","arity4","arity8","arity16","pasta","bls"] }
-# DO NOT COMMIT
-nova = { package = "nova-snark", version = "0.20", default-features = false, git = "https://github.com/huitseeker/nova", branch="bump_ff_group"}
-# DO NOT COMMIT
+nova = { package = "nova-snark", version = "0.21", default-features = false }
 once_cell = "1.17.1"
 pairing_lib = { version = "0.23", package = "pairing" }
 peekmore = "1.1.0"
@@ -56,9 +54,7 @@ bincode = "1.3.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 memmap = { version = "0.5.10", package = "memmap2" }
-# DO NOT COMMIT
-pasta-msm = { version = "0.1.3", git = "https://github.com/supranational/pasta-msm" }
-# DO NOT COMMIT
+pasta-msm = "0.1.4"
 proptest = "1.1.0"
 proptest-derive = "0.3.0"
 rand = "0.8.5"

--- a/clutch/Cargo.toml
+++ b/clutch/Cargo.toml
@@ -11,10 +11,10 @@ repository = "https://github.com/lurk-lab/lurk-rs"
 
 [dependencies]
 anyhow = "1.0.69"
-blstrs = "0.6.1"
+blstrs = "0.7.0"
 clap = "4.1.8"
 lurk = { path = "../" }
-pasta_curves = { version = "0.5.2", features = ["repr-c", "serde"], package = "fil_pasta_curves" }
+pasta_curves = { version = "0.5.1", features = ["repr-c", "serde"] }
 pretty_env_logger = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 

--- a/fcomm/Cargo.toml
+++ b/fcomm/Cargo.toml
@@ -13,23 +13,23 @@ path = "src/bin/fcomm.rs"
 
 [dependencies]
 base64 = "0.13.1"
-bellperson = "0.24"
-blstrs = "0.6.1"
+bellperson = "0.25"
+blstrs = "0.7.0"
 clap = { version = "3.2", features = ["derive"] }
 clap-verbosity-flag = "1.0"
-ff = "0.12.1"
+ff = "0.13"
 hex = { version = "0.4.3", features = ["serde"] }
 log = "0.4.17"
 libipld = { package = "lurk-ipld", version = "0.3.0", default-features = false, features = ["dag-cbor", "dag-json", "serde-codec"] }
 lurk = { path = "../", package = "lurk" }
 once_cell = "1.17.1"
-pairing_lib = { version = "0.22", package = "pairing" }
+pairing_lib = { version = "0.23", package = "pairing" }
 pretty_env_logger = "0.4"
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 thiserror = "1.0.38"
-pasta_curves = { version = "0.5.2", features = ["serde"], package = "fil_pasta_curves" }
+pasta_curves = { version = "0.5.1", features = ["repr-c", "serde"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.8"

--- a/lurk-macros/Cargo.toml
+++ b/lurk-macros/Cargo.toml
@@ -17,4 +17,4 @@ proc-macro2 = "1.0.24"
 
 [dev-dependencies]
 lurk_crate = { path = "../", package = "lurk" }
-pasta_curves = { version = "0.5.2", features = ["repr-c", "serde"], package = "fil_pasta_curves" }
+pasta_curves = { version = "0.5.1", features = ["repr-c", "serde"] }

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -3105,7 +3105,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         let digest = result.hash();
 
         let (open_secret_scalar, open_expr_ptr) = store
-            .get_maybe_opaque(ExprTag::Comm, digest.get_value().unwrap_or_else(|| F::ZERO))
+            .get_maybe_opaque(ExprTag::Comm, digest.get_value().unwrap_or(F::ZERO))
             .and_then(|commit| store.open(commit))
             .unwrap_or_else(|| {
                 // nil is dummy
@@ -4759,10 +4759,10 @@ fn to_unsigned_integers<F: LurkField, CS: ConstraintSystem<F>>(
     g: &GlobalAllocations<F>,
     maybe_unsigned: &AllocatedNum<F>,
 ) -> Result<(AllocatedNum<F>, AllocatedNum<F>), SynthesisError> {
-    let field_elem = maybe_unsigned.get_value().unwrap_or_else(|| {
+    let field_elem = maybe_unsigned.get_value().unwrap_or(
         // dummy
-        F::ZERO
-    });
+        F::ZERO,
+    );
     let field_bn = BigUint::from_bytes_le(field_elem.to_repr().as_ref());
     // Since bit decomposition is expensive, we compute it only once here
     let field_elem_bits =

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -3105,14 +3105,11 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         let digest = result.hash();
 
         let (open_secret_scalar, open_expr_ptr) = store
-            .get_maybe_opaque(
-                ExprTag::Comm,
-                digest.get_value().unwrap_or_else(|| F::zero()),
-            )
+            .get_maybe_opaque(ExprTag::Comm, digest.get_value().unwrap_or_else(|| F::ZERO))
             .and_then(|commit| store.open(commit))
             .unwrap_or_else(|| {
                 // nil is dummy
-                (F::zero(), store.get_nil())
+                (F::ZERO, store.get_nil())
             });
 
         let open_expr = AllocatedPtr::alloc(&mut cs.namespace(|| "open_expr"), || {
@@ -4508,7 +4505,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
 
     // This is all clunky because we can't currently return AllocatedBit from case expressions.
     let newer_cont2_not_dummy_result_num = case_results[7].clone();
-    let newer_cont2_not_dummy_ = equal_const!(cs, &newer_cont2_not_dummy_result_num, F::one())?;
+    let newer_cont2_not_dummy_ = equal_const!(cs, &newer_cont2_not_dummy_result_num, F::ONE)?;
     let newer_cont2_not_dummy = and!(cs, &newer_cont2_not_dummy_, not_dummy)?;
 
     implies_equal!(
@@ -4764,7 +4761,7 @@ fn to_unsigned_integers<F: LurkField, CS: ConstraintSystem<F>>(
 ) -> Result<(AllocatedNum<F>, AllocatedNum<F>), SynthesisError> {
     let field_elem = maybe_unsigned.get_value().unwrap_or_else(|| {
         // dummy
-        F::zero()
+        F::ZERO
     });
     let field_bn = BigUint::from_bytes_le(field_elem.to_repr().as_ref());
     // Since bit decomposition is expensive, we compute it only once here
@@ -4797,7 +4794,7 @@ fn to_u64<F: LurkField, CS: ConstraintSystem<F>>(
     g: &GlobalAllocations<F>,
     maybe_u64: &AllocatedNum<F>,
 ) -> Result<AllocatedNum<F>, SynthesisError> {
-    let field_elem = maybe_u64.get_value().unwrap_or_else(|| F::zero()); //
+    let field_elem = maybe_u64.get_value().unwrap_or(F::ZERO); //
     let field_bn = BigUint::from_bytes_le(field_elem.to_repr().as_ref());
     let field_elem_bits = maybe_u64.to_bits_le(&mut cs.namespace(|| "field element bit decomp"))?;
 

--- a/src/circuit/gadgets/case.rs
+++ b/src/circuit/gadgets/case.rs
@@ -145,7 +145,7 @@ fn selector_dot_product<F: LurkField, CS: ConstraintSystem<F>>(
     value_vector: &[AllocatedNum<F>],
     zero: &AllocatedNum<F>, // Must be a constant-allocated zero.
 ) -> Result<AllocatedNum<F>, SynthesisError> {
-    let mut computed_result = F::zero();
+    let mut computed_result = F::ZERO;
 
     let mut all_products = Vec::new();
 

--- a/src/circuit/gadgets/data.rs
+++ b/src/circuit/gadgets/data.rs
@@ -208,9 +208,9 @@ impl<F: LurkField> GlobalAllocations<F> {
         defsym!(dummy_arg_ptr, "_", dummy);
         defsym!(lambda_sym, "lambda", lambda);
 
-        let true_num = allocate_constant(&mut cs.namespace(|| "true"), F::one())?;
-        let false_num = allocate_constant(&mut cs.namespace(|| "false"), F::zero())?;
-        let default_num = allocate_constant(&mut cs.namespace(|| "default"), F::zero())?;
+        let true_num = allocate_constant(&mut cs.namespace(|| "true"), F::ONE)?;
+        let false_num = allocate_constant(&mut cs.namespace(|| "false"), F::ZERO)?;
+        let default_num = allocate_constant(&mut cs.namespace(|| "default"), F::ZERO)?;
 
         let power2_32_ff = F::pow_vartime(&F::from_u64(2), [32]);
         let power2_32_num = allocate_constant(&mut cs.namespace(|| "pow(2,32)"), power2_32_ff)?;
@@ -379,9 +379,9 @@ impl<F: LurkField> Ptr<F> {
         Self::allocate_fun(
             cs,
             store,
-            [F::zero(), F::zero()],
-            [F::zero(), F::zero()],
-            [F::zero(), F::zero()],
+            [F::ZERO, F::ZERO],
+            [F::ZERO, F::ZERO],
+            [F::ZERO, F::ZERO],
         )
     }
 }
@@ -505,12 +505,12 @@ impl<F: LurkField> Thunk<F> {
         store: &Store<F>,
     ) -> Result<(AllocatedNum<F>, AllocatedPtr<F>, AllocatedContPtr<F>), SynthesisError> {
         let value = AllocatedPtr::alloc(&mut cs.namespace(|| "Thunk component: value"), || {
-            Ok(ScalarPtr::from_parts(ExprTag::Nil, F::zero()))
+            Ok(ScalarPtr::from_parts(ExprTag::Nil, F::ZERO))
         })?;
 
         let cont = AllocatedContPtr::alloc(
             &mut cs.namespace(|| "Thunk component: continuation"),
-            || Ok(ScalarContPtr::from_parts(ContTag::Dummy, F::zero())),
+            || Ok(ScalarContPtr::from_parts(ContTag::Dummy, F::ZERO)),
         )?;
 
         let dummy_hash = Self::hash_components(cs.namespace(|| "Thunk"), store, &value, &cont)?;

--- a/src/circuit/gadgets/hashes.rs
+++ b/src/circuit/gadgets/hashes.rs
@@ -155,8 +155,8 @@ impl<'a, F: LurkField> AllocatedConsWitness<'a, F> {
 
             let (car_ptr, cdr_ptr, cons_hash) = match p {
                 Stub::Dummy => (
-                    Some(ScalarPtr::from_parts(ExprTag::Nil, F::zero())),
-                    Some(ScalarPtr::from_parts(ExprTag::Nil, F::zero())),
+                    Some(ScalarPtr::from_parts(ExprTag::Nil, F::ZERO)),
+                    Some(ScalarPtr::from_parts(ExprTag::Nil, F::ZERO)),
                     None,
                 ),
                 Stub::Blank => (None, None, None),
@@ -238,14 +238,14 @@ impl<'a, F: LurkField> AllocatedContWitness<'a, F> {
                 Stub::Dummy => (
                     None,
                     Some([
-                        F::zero(),
-                        F::zero(),
-                        F::zero(),
-                        F::zero(),
-                        F::zero(),
-                        F::zero(),
-                        F::zero(),
-                        F::zero(),
+                        F::ZERO,
+                        F::ZERO,
+                        F::ZERO,
+                        F::ZERO,
+                        F::ZERO,
+                        F::ZERO,
+                        F::ZERO,
+                        F::ZERO,
                     ]),
                 ),
                 Stub::Blank => (None, None),

--- a/src/eval/reduction.rs
+++ b/src/eval/reduction.rs
@@ -903,7 +903,7 @@ fn apply_continuation<F: LurkField>(
                         ExprTag::Num | ExprTag::Comm => store.secret_mut(result)?,
                         _ => return Ok(Control::Error(result, env)),
                     },
-                    Op1::Commit => store.hide(F::zero(), result),
+                    Op1::Commit => store.hide(F::ZERO, result),
                     Op1::Num => match result.tag {
                         ExprTag::Num | ExprTag::Comm | ExprTag::Char | ExprTag::U64 => {
                             let scalar_ptr = store

--- a/src/field.rs
+++ b/src/field.rs
@@ -144,18 +144,18 @@ pub trait LurkField: PrimeField + PrimeFieldBits {
 
     /// We define this to be the smallest negative field element
     fn most_negative() -> Self {
-        Self::most_positive() + Self::one()
+        Self::most_positive() + Self::ONE
     }
 
     /// 0 - 1 is one minus the modulus, which must be even in a prime field.
     /// The result is the largest field element which is even when doubled.
     /// We define this to be the most positive field element.
     fn most_positive() -> Self {
-        let one = Self::one();
+        let one = Self::ONE;
         let two = one + one;
 
         let half = two.invert().unwrap();
-        let modulus_minus_one = Self::zero() - one;
+        let modulus_minus_one = Self::ZERO - one;
         half * modulus_minus_one
     }
 
@@ -377,7 +377,7 @@ pub mod tests {
 
     // Construct field element from possibly canonical bytes
     fn from_le_bytes_canonical<F: LurkField>(bs: &[u8]) -> F {
-        let mut res = F::zero();
+        let mut res = F::ZERO;
         let mut bs = bs.iter().rev().peekable();
         while let Some(b) = bs.next() {
             let b: F = (*b as u64).into();

--- a/src/light_data/light_store.rs
+++ b/src/light_data/light_store.rs
@@ -56,9 +56,9 @@ impl<F: LurkField> LightStore<F> {
             ExprTag::Num => true,
             ExprTag::Char => true,
             ExprTag::U64 => true,
-            ExprTag::Str => *ptr.value() == F::zero(), // the empty string
-            ExprTag::Sym => *ptr.value() == F::zero(), // the root symbol
-            ExprTag::Key => *ptr.value() == F::zero(), // the root keyword
+            ExprTag::Str => *ptr.value() == F::ZERO, // the empty string
+            ExprTag::Sym => *ptr.value() == F::ZERO, // the root symbol
+            ExprTag::Key => *ptr.value() == F::ZERO, // the root keyword
             _ => false,
         }
     }
@@ -71,7 +71,7 @@ impl<F: LurkField> LightStore<F> {
         let mut s = String::new();
         let mut tail_ptrs = vec![];
         let mut ptr = ptr0;
-        let strnil_ptr = ScalarPtr::from_parts(ExprTag::Str, F::zero());
+        let strnil_ptr = ScalarPtr::from_parts(ExprTag::Str, F::ZERO);
 
         // TODO: this needs to bail on encountering an opaque pointer
         while let Some(LightExpr::StrCons(c, cs)) = self.get(&ptr).flatten() {
@@ -118,11 +118,11 @@ impl<F: LurkField> LightStore<F> {
         let mut path = Sym::root();
         let mut tail_ptrs = vec![ptr0];
         let mut ptr = ptr0;
-        let symnil_ptr = ScalarPtr::from_parts(ExprTag::Sym, F::zero());
+        let symnil_ptr = ScalarPtr::from_parts(ExprTag::Sym, F::ZERO);
 
         // TODO: this needs to bail on encountering an opaque pointer
         while let Some(LightExpr::SymCons(s, ss)) = self.get(&ptr).flatten() {
-            let string = if s == ScalarPtr::from_parts(ExprTag::Str, F::zero()) {
+            let string = if s == ScalarPtr::from_parts(ExprTag::Str, F::ZERO) {
                 Ok(String::new())
             } else {
                 self.insert_scalar_string(s, store)

--- a/src/num.rs
+++ b/src/num.rs
@@ -466,10 +466,10 @@ mod tests {
     #[test]
     fn test_negative_positive() {
         let mns = Fr::most_negative();
-        let mps = mns - Fr::one();
+        let mps = mns - Fr::ONE;
         let mn = Num::Scalar(mns);
         let mp = Num::Scalar(mps);
-        let zero = Num::Scalar(Fr::zero());
+        let zero = Num::Scalar(Fr::ZERO);
 
         assert!(mn.is_negative());
         assert!(!mp.is_negative());

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -46,15 +46,10 @@ pub type EE1 = nova::provider::ipa_pc::EvaluationEngine<G1>;
 /// Type alias for the Evaluation Engine using G2 group elements.
 pub type EE2 = nova::provider::ipa_pc::EvaluationEngine<G2>;
 
-/// Type alias for Nova's Trivial Compressed Computation Engine using G1 group elements and EE1.
-type CC1 = nova::spartan::spark::TrivialCompComputationEngine<G1, EE1>;
-/// Type alias for Nova's Trivial Compressed Computation Engine using G2 group elements and EE2.
-type CC2 = nova::spartan::spark::TrivialCompComputationEngine<G2, EE2>;
-
-/// Type alias for the Relaxed R1CS Spartan SNARK using G1 group elements, EE1, and CC1.
-pub type SS1 = nova::spartan::RelaxedR1CSSNARK<G1, EE1, CC1>;
-/// Type alias for the Relaxed R1CS Spartan SNARK using G2 group elements, EE2, and CC2.
-pub type SS2 = nova::spartan::RelaxedR1CSSNARK<G2, EE2, CC2>;
+/// Type alias for the Relaxed R1CS Spartan SNARK using G1 group elements, EE1.
+pub type SS1 = nova::spartan::RelaxedR1CSSNARK<G1, EE1>;
+/// Type alias for the Relaxed R1CS Spartan SNARK using G2 group elements, EE2.
+pub type SS2 = nova::spartan::RelaxedR1CSSNARK<G2, EE2>;
 
 /// Type alias for a MultiFrame with S1 field elements.
 pub type C1<'a, C> = MultiFrame<'a, S1, IO<S1>, Witness<S1>, C>;

--- a/src/store.rs
+++ b/src/store.rs
@@ -1310,7 +1310,7 @@ impl<F: LurkField> Store<F> {
     /// the arguments of each variant of ScalarContinuation with respect to the
     /// sourc position order of elements
     fn get_hash_components_default(&self) -> [[F; 2]; 4] {
-        let def = [F::zero(), F::zero()];
+        let def = [F::ZERO, F::ZERO];
         [def, def, def, def]
     }
 
@@ -1418,7 +1418,7 @@ impl<F: LurkField> Store<F> {
         unevaled_args: &Ptr<F>,
         cont: &ContPtr<F>,
     ) -> Option<[[F; 2]; 4]> {
-        let def = [F::zero(), F::zero()];
+        let def = [F::ZERO, F::ZERO];
         let unevaled_args = self.get_expr_hash(unevaled_args)?.into_hash_components();
         let cont = self.hash_cont(cont)?.into_hash_components();
         Some([unevaled_args, cont, def, def])
@@ -1430,8 +1430,8 @@ impl<F: LurkField> Store<F> {
         arg1: &Ptr<F>,
         cont: &ContPtr<F>,
     ) -> Option<[[F; 2]; 4]> {
-        let def = [F::zero(), F::zero()];
-        let op = [op.to_field(), F::zero()];
+        let def = [F::ZERO, F::ZERO];
+        let op = [op.to_field(), F::ZERO];
         let arg1 = self.get_expr_hash(arg1)?.into_hash_components();
         let cont = self.hash_cont(cont)?.into_hash_components();
         Some([op, arg1, cont, def])
@@ -1444,7 +1444,7 @@ impl<F: LurkField> Store<F> {
         unevaled_args: &Ptr<F>,
         cont: &ContPtr<F>,
     ) -> Option<[[F; 2]; 4]> {
-        let op = [op.to_field(), F::zero()];
+        let op = [op.to_field(), F::ZERO];
         let saved_env = self.get_expr_hash(saved_env)?.into_hash_components();
         let unevaled_args = self.get_expr_hash(unevaled_args)?.into_hash_components();
         let cont = self.hash_cont(cont)?.into_hash_components();
@@ -1452,8 +1452,8 @@ impl<F: LurkField> Store<F> {
     }
 
     fn get_hash_components_unop(&self, op: &Op1, cont: &ContPtr<F>) -> Option<[[F; 2]; 4]> {
-        let def = [F::zero(), F::zero()];
-        let op = [op.to_field(), F::zero()];
+        let def = [F::ZERO, F::ZERO];
+        let op = [op.to_field(), F::ZERO];
         let cont = self.hash_cont(cont)?.into_hash_components();
         Some([op, cont, def, def])
     }
@@ -1463,7 +1463,7 @@ impl<F: LurkField> Store<F> {
         saved_env: &Ptr<F>,
         cont: &ContPtr<F>,
     ) -> Option<[[F; 2]; 4]> {
-        let def = [F::zero(), F::zero()];
+        let def = [F::ZERO, F::ZERO];
         let saved_env = self.get_expr_hash(saved_env)?.into_hash_components();
         let cont = self.hash_cont(cont)?.into_hash_components();
         Some([saved_env, cont, def, def])
@@ -1474,7 +1474,7 @@ impl<F: LurkField> Store<F> {
         saved_env: &Ptr<F>,
         cont: &ContPtr<F>,
     ) -> Option<[[F; 2]; 4]> {
-        let def = [F::zero(), F::zero()];
+        let def = [F::ZERO, F::ZERO];
         let saved_env = self.get_expr_hash(saved_env)?.into_hash_components();
         let cont = self.hash_cont(cont)?.into_hash_components();
         Some([saved_env, cont, def, def])
@@ -1485,7 +1485,7 @@ impl<F: LurkField> Store<F> {
         saved_env: &Ptr<F>,
         cont: &ContPtr<F>,
     ) -> Option<[[F; 2]; 4]> {
-        let def = [F::zero(), F::zero()];
+        let def = [F::ZERO, F::ZERO];
 
         let saved_env = self.get_expr_hash(saved_env)?.into_hash_components();
         let cont = self.hash_cont(cont)?.into_hash_components();
@@ -1499,7 +1499,7 @@ impl<F: LurkField> Store<F> {
         saved_env: &Ptr<F>,
         cont: &ContPtr<F>,
     ) -> Option<[[F; 2]; 4]> {
-        let def = [F::zero(), F::zero()];
+        let def = [F::ZERO, F::ZERO];
         let arg = self.get_expr_hash(arg)?.into_hash_components();
         let saved_env = self.get_expr_hash(saved_env)?.into_hash_components();
         let cont = self.hash_cont(cont)?.into_hash_components();
@@ -1513,7 +1513,7 @@ impl<F: LurkField> Store<F> {
         saved_env: &Ptr<F>,
         cont: &ContPtr<F>,
     ) -> Option<[[F; 2]; 4]> {
-        let def = [F::zero(), F::zero()];
+        let def = [F::ZERO, F::ZERO];
         let fun = self.get_expr_hash(fun)?.into_hash_components();
         let saved_env = self.get_expr_hash(saved_env)?.into_hash_components();
         let cont = self.hash_cont(cont)?.into_hash_components();
@@ -1521,7 +1521,7 @@ impl<F: LurkField> Store<F> {
     }
 
     fn get_hash_components_emit(&self, cont: &ContPtr<F>) -> Option<[[F; 2]; 4]> {
-        let def = [F::zero(), F::zero()];
+        let def = [F::ZERO, F::ZERO];
 
         let cont = self.hash_cont(cont)?.into_hash_components();
 
@@ -1632,7 +1632,7 @@ impl<F: LurkField> Store<F> {
 
     fn hash_symbol(&self, s: &Sym, mode: HashScalar) -> F {
         if s.is_root() {
-            return F::zero();
+            return F::ZERO;
         }
 
         let path = s.path();
@@ -1686,7 +1686,7 @@ impl<F: LurkField> Store<F> {
 
     fn hash_string(&self, s: &str) -> F {
         if s.is_empty() {
-            return F::zero();
+            return F::ZERO;
         };
         let mut chars = s.chars();
         let char = chars.next().unwrap();
@@ -1701,11 +1701,11 @@ impl<F: LurkField> Store<F> {
     pub fn hash_string_mut<T: AsRef<str>>(&mut self, s: T) -> F {
         let s = s.as_ref();
         if s.is_empty() {
-            return F::zero();
+            return F::ZERO;
         };
 
         let initial_scalar_ptr = {
-            let hash = F::zero();
+            let hash = F::ZERO;
             let ptr = self.intern_str_aux("");
             self.create_scalar_ptr(ptr, hash)
         };


### PR DESCRIPTION
- Update dependencies for various crates,
- Refactor `LurkField` trait in `src/field.rs` to use updated definitions,
- Update to Nova 0.20,
- Remove use of `TrivialCompComputationEngine` and change type aliases in `src/proof/nova.rs`

## TODO

- [x] Merge [dependent PR](https://github.com/supranational/pasta-msm/pull/3) in pasta-msm
- [x] Merge [dependent PR](https://github.com/microsoft/Nova/pull/162) in Nova