### PR TITLE
Remove some redundancy in Eval

### DIFF
--- a/src/eval/reduction.rs
+++ b/src/eval/reduction.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use super::{empty_sym_env, Witness};
 use crate::coprocessor::Coprocessor;
 use crate::error::ReductionError;
@@ -390,9 +392,15 @@ fn reduce_with_witness_inner<F: LurkField, C: Coprocessor<F>>(
                                 }
                             }
                         }
-                    } else if head == c.cons.ptr() {
+                    } else if let Some(op) = HashMap::from([
+                        (c.cons.ptr(), Op2::Cons),
+                        (c.strcons.ptr(), Op2::StrCons),
+                        (c.hide.ptr(), Op2::Hide),
+                        (c.begin.ptr(), Op2::Begin),
+                    ])
+                    .get(&head)
+                    {
                         let (arg1, more) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
-
                         if rest.is_nil() || more.is_nil() {
                             Control::Error(expr, env)
                         } else {
@@ -403,70 +411,7 @@ fn reduce_with_witness_inner<F: LurkField, C: Coprocessor<F>>(
                                     ContName::NewerCont,
                                     store,
                                     Continuation::Binop {
-                                        operator: Op2::Cons,
-                                        saved_env: env,
-                                        unevaled_args: more,
-                                        continuation: cont,
-                                    },
-                                ),
-                            )
-                        }
-                    } else if head == c.strcons.ptr() {
-                        let (arg1, more) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
-
-                        if rest.is_nil() || more.is_nil() {
-                            Control::Error(expr, env)
-                        } else {
-                            Control::Return(
-                                arg1,
-                                env,
-                                cont_witness.intern_named_cont(
-                                    ContName::NewerCont,
-                                    store,
-                                    Continuation::Binop {
-                                        operator: Op2::StrCons,
-                                        saved_env: env,
-                                        unevaled_args: more,
-                                        continuation: cont,
-                                    },
-                                ),
-                            )
-                        }
-                    } else if head == c.hide.ptr() {
-                        let (arg1, more) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
-
-                        if rest.is_nil() || more.is_nil() {
-                            Control::Error(expr, env)
-                        } else {
-                            Control::Return(
-                                arg1,
-                                env,
-                                cont_witness.intern_named_cont(
-                                    ContName::NewerCont,
-                                    store,
-                                    Continuation::Binop {
-                                        operator: Op2::Hide,
-                                        saved_env: env,
-                                        unevaled_args: more,
-                                        continuation: cont,
-                                    },
-                                ),
-                            )
-                        }
-                    } else if head == c.begin.ptr() {
-                        let (arg1, more) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
-
-                        if more.is_nil() {
-                            Control::Return(arg1, env, cont)
-                        } else {
-                            Control::Return(
-                                arg1,
-                                env,
-                                cont_witness.intern_named_cont(
-                                    ContName::NewerCont,
-                                    store,
-                                    Continuation::Binop {
-                                        operator: Op2::Begin,
+                                        operator: *op,
                                         saved_env: env,
                                         unevaled_args: more,
                                         continuation: cont,
@@ -714,9 +659,22 @@ fn reduce_with_witness_inner<F: LurkField, C: Coprocessor<F>>(
                                 ),
                             )
                         }
-                    } else if head == c.sum.ptr() {
+                    } else if let Some(op) = HashMap::from([
+                        (c.sum.ptr(), Op2::Sum),
+                        (c.diff.ptr(), Op2::Diff),
+                        (c.product.ptr(), Op2::Product),
+                        (c.quotient.ptr(), Op2::Quotient),
+                        (c.modulo.ptr(), Op2::Modulo),
+                        (c.num_equal.ptr(), Op2::NumEqual),
+                        (c.equal.ptr(), Op2::Equal),
+                        (c.less.ptr(), Op2::Less),
+                        (c.greater.ptr(), Op2::Greater),
+                        (c.less_equal.ptr(), Op2::LessEqual),
+                        (c.greater_equal.ptr(), Op2::GreaterEqual),
+                    ])
+                    .get(&head)
+                    {
                         let (arg1, more) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
-
                         if rest.is_nil() || more.is_nil() {
                             Control::Error(expr, env)
                         } else {
@@ -727,217 +685,7 @@ fn reduce_with_witness_inner<F: LurkField, C: Coprocessor<F>>(
                                     ContName::NewerCont,
                                     store,
                                     Continuation::Binop {
-                                        operator: Op2::Sum,
-                                        saved_env: env,
-                                        unevaled_args: more,
-                                        continuation: cont,
-                                    },
-                                ),
-                            )
-                        }
-                    } else if head == c.diff.ptr() {
-                        let (arg1, more) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
-
-                        if rest.is_nil() || more.is_nil() {
-                            Control::Error(expr, env)
-                        } else {
-                            Control::Return(
-                                arg1,
-                                env,
-                                cont_witness.intern_named_cont(
-                                    ContName::NewerCont,
-                                    store,
-                                    Continuation::Binop {
-                                        operator: Op2::Diff,
-                                        saved_env: env,
-                                        unevaled_args: more,
-                                        continuation: cont,
-                                    },
-                                ),
-                            )
-                        }
-                    } else if head == c.product.ptr() {
-                        let (arg1, more) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
-
-                        if rest.is_nil() || more.is_nil() {
-                            Control::Error(expr, env)
-                        } else {
-                            Control::Return(
-                                arg1,
-                                env,
-                                cont_witness.intern_named_cont(
-                                    ContName::NewerCont,
-                                    store,
-                                    Continuation::Binop {
-                                        operator: Op2::Product,
-                                        saved_env: env,
-                                        unevaled_args: more,
-                                        continuation: cont,
-                                    },
-                                ),
-                            )
-                        }
-                    } else if head == c.quotient.ptr() {
-                        let (arg1, more) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
-
-                        if rest.is_nil() || more.is_nil() {
-                            Control::Error(expr, env)
-                        } else {
-                            Control::Return(
-                                arg1,
-                                env,
-                                cont_witness.intern_named_cont(
-                                    ContName::NewerCont,
-                                    store,
-                                    Continuation::Binop {
-                                        operator: Op2::Quotient,
-                                        saved_env: env,
-                                        unevaled_args: more,
-                                        continuation: cont,
-                                    },
-                                ),
-                            )
-                        }
-                    } else if head == c.modulo.ptr() {
-                        let (arg1, more) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
-
-                        if rest.is_nil() || more.is_nil() {
-                            Control::Error(expr, env)
-                        } else {
-                            Control::Return(
-                                arg1,
-                                env,
-                                cont_witness.intern_named_cont(
-                                    ContName::NewerCont,
-                                    store,
-                                    Continuation::Binop {
-                                        operator: Op2::Modulo,
-                                        saved_env: env,
-                                        unevaled_args: more,
-                                        continuation: cont,
-                                    },
-                                ),
-                            )
-                        }
-                    } else if head == c.num_equal.ptr() {
-                        let (arg1, more) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
-
-                        if rest.is_nil() || more.is_nil() {
-                            Control::Error(expr, env)
-                        } else {
-                            Control::Return(
-                                arg1,
-                                env,
-                                cont_witness.intern_named_cont(
-                                    ContName::NewerCont,
-                                    store,
-                                    Continuation::Binop {
-                                        operator: Op2::NumEqual,
-                                        saved_env: env,
-                                        unevaled_args: more,
-                                        continuation: cont,
-                                    },
-                                ),
-                            )
-                        }
-                    } else if head == c.equal.ptr() {
-                        let (arg1, more) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
-
-                        if rest.is_nil() || more.is_nil() {
-                            Control::Error(expr, env)
-                        } else {
-                            Control::Return(
-                                arg1,
-                                env,
-                                cont_witness.intern_named_cont(
-                                    ContName::NewerCont,
-                                    store,
-                                    Continuation::Binop {
-                                        operator: Op2::Equal,
-                                        saved_env: env,
-                                        unevaled_args: more,
-                                        continuation: cont,
-                                    },
-                                ),
-                            )
-                        }
-                    } else if head == c.less.ptr() {
-                        let (arg1, more) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
-
-                        if rest.is_nil() || more.is_nil() {
-                            Control::Error(expr, env)
-                        } else {
-                            Control::Return(
-                                arg1,
-                                env,
-                                cont_witness.intern_named_cont(
-                                    ContName::NewerCont,
-                                    store,
-                                    Continuation::Binop {
-                                        operator: Op2::Less,
-                                        saved_env: env,
-                                        unevaled_args: more,
-                                        continuation: cont,
-                                    },
-                                ),
-                            )
-                        }
-                    } else if head == c.greater.ptr() {
-                        let (arg1, more) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
-
-                        if rest.is_nil() || more.is_nil() {
-                            Control::Error(expr, env)
-                        } else {
-                            Control::Return(
-                                arg1,
-                                env,
-                                cont_witness.intern_named_cont(
-                                    ContName::NewerCont,
-                                    store,
-                                    Continuation::Binop {
-                                        operator: Op2::Greater,
-                                        saved_env: env,
-                                        unevaled_args: more,
-                                        continuation: cont,
-                                    },
-                                ),
-                            )
-                        }
-                    } else if head == c.less_equal.ptr() {
-                        let (arg1, more) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
-
-                        if rest.is_nil() || more.is_nil() {
-                            Control::Error(expr, env)
-                        } else {
-                            Control::Return(
-                                arg1,
-                                env,
-                                cont_witness.intern_named_cont(
-                                    ContName::NewerCont,
-                                    store,
-                                    Continuation::Binop {
-                                        operator: Op2::LessEqual,
-                                        saved_env: env,
-                                        unevaled_args: more,
-                                        continuation: cont,
-                                    },
-                                ),
-                            )
-                        }
-                    } else if head == c.greater_equal.ptr() {
-                        let (arg1, more) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
-
-                        if rest.is_nil() || more.is_nil() {
-                            Control::Error(expr, env)
-                        } else {
-                            Control::Return(
-                                arg1,
-                                env,
-                                cont_witness.intern_named_cont(
-                                    ContName::NewerCont,
-                                    store,
-                                    Continuation::Binop {
-                                        operator: Op2::GreaterEqual,
+                                        operator: *op,
                                         saved_env: env,
                                         unevaled_args: more,
                                         continuation: cont,

--- a/src/eval/reduction.rs
+++ b/src/eval/reduction.rs
@@ -419,9 +419,18 @@ fn reduce_with_witness_inner<F: LurkField, C: Coprocessor<F>>(
                                 ),
                             )
                         }
-                    } else if head == c.car.ptr() {
+                    } else if let Some(op) = HashMap::from([
+                        (c.car.ptr(), Op1::Car),
+                        (c.cdr.ptr(), Op1::Cdr),
+                        (c.commit.ptr(), Op1::Commit),
+                        (c.num.ptr(), Op1::Num),
+                        (c.u64.ptr(), Op1::U64),
+                        (c.comm.ptr(), Op1::Comm),
+                        (c.char.ptr(), Op1::Char),
+                    ])
+                    .get(&head)
+                    {
                         let (arg1, end) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
-
                         if rest.is_nil() || !end.is_nil() {
                             Control::Error(expr, env)
                         } else {
@@ -432,121 +441,7 @@ fn reduce_with_witness_inner<F: LurkField, C: Coprocessor<F>>(
                                     ContName::NewerCont,
                                     store,
                                     Continuation::Unop {
-                                        operator: Op1::Car,
-                                        continuation: cont,
-                                    },
-                                ),
-                            )
-                        }
-                    } else if head == c.cdr.ptr() {
-                        let (arg1, end) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
-
-                        if rest.is_nil() || !end.is_nil() {
-                            Control::Error(expr, env)
-                        } else {
-                            Control::Return(
-                                arg1,
-                                env,
-                                cont_witness.intern_named_cont(
-                                    ContName::NewerCont,
-                                    store,
-                                    Continuation::Unop {
-                                        operator: Op1::Cdr,
-                                        continuation: cont,
-                                    },
-                                ),
-                            )
-                        }
-                    } else if head == c.commit.ptr() {
-                        let (arg1, end) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
-
-                        if rest.is_nil() || !end.is_nil() {
-                            Control::Error(expr, env)
-                        } else {
-                            Control::Return(
-                                arg1,
-                                env,
-                                cont_witness.intern_named_cont(
-                                    ContName::NewerCont,
-                                    store,
-                                    Continuation::Unop {
-                                        operator: Op1::Commit,
-                                        continuation: cont,
-                                    },
-                                ),
-                            )
-                        }
-                    } else if head == c.num.ptr() {
-                        let (arg1, end) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
-
-                        if rest.is_nil() || !end.is_nil() {
-                            Control::Error(expr, env)
-                        } else {
-                            Control::Return(
-                                arg1,
-                                env,
-                                cont_witness.intern_named_cont(
-                                    ContName::NewerCont,
-                                    store,
-                                    Continuation::Unop {
-                                        operator: Op1::Num,
-                                        continuation: cont,
-                                    },
-                                ),
-                            )
-                        }
-                    } else if head == c.u64.ptr() {
-                        let (arg1, end) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
-
-                        if rest.is_nil() || !end.is_nil() {
-                            Control::Error(expr, env)
-                        } else {
-                            Control::Return(
-                                arg1,
-                                env,
-                                cont_witness.intern_named_cont(
-                                    ContName::NewerCont,
-                                    store,
-                                    Continuation::Unop {
-                                        operator: Op1::U64,
-                                        continuation: cont,
-                                    },
-                                ),
-                            )
-                        }
-                    } else if head == c.comm.ptr() {
-                        let (arg1, end) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
-
-                        if rest.is_nil() || !end.is_nil() {
-                            Control::Error(expr, env)
-                        } else {
-                            Control::Return(
-                                arg1,
-                                env,
-                                cont_witness.intern_named_cont(
-                                    ContName::NewerCont,
-                                    store,
-                                    Continuation::Unop {
-                                        operator: Op1::Comm,
-                                        continuation: cont,
-                                    },
-                                ),
-                            )
-                        }
-                    } else if head == c.char.ptr() {
-                        let (arg1, end) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
-
-                        if rest.is_nil() || !end.is_nil() {
-                            Control::Error(expr, env)
-                        } else {
-                            Control::Return(
-                                arg1,
-                                env,
-                                cont_witness.intern_named_cont(
-                                    ContName::NewerCont,
-                                    store,
-                                    Continuation::Unop {
-                                        operator: Op1::Char,
+                                        operator: *op,
                                         continuation: cont,
                                     },
                                 ),
@@ -583,9 +478,15 @@ fn reduce_with_witness_inner<F: LurkField, C: Coprocessor<F>>(
                                 ),
                             )
                         }
-                    } else if head == c.open.ptr() {
+                    } else if let Some(op) = HashMap::from([
+                        (c.open.ptr(), Op1::Open),
+                        (c.secret.ptr(), Op1::Secret),
+                        (c.atom.ptr(), Op1::Atom),
+                        (c.emit.ptr(), Op1::Emit),
+                    ])
+                    .get(&head)
+                    {
                         let (arg1, end) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
-
                         if rest.is_nil() || !end.is_nil() {
                             Control::Error(expr, env)
                         } else {
@@ -596,64 +497,7 @@ fn reduce_with_witness_inner<F: LurkField, C: Coprocessor<F>>(
                                     ContName::NewerCont,
                                     store,
                                     Continuation::Unop {
-                                        operator: Op1::Open,
-                                        continuation: cont,
-                                    },
-                                ),
-                            )
-                        }
-                    } else if head == c.secret.ptr() {
-                        let (arg1, end) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
-
-                        if rest.is_nil() || !end.is_nil() {
-                            Control::Error(expr, env)
-                        } else {
-                            Control::Return(
-                                arg1,
-                                env,
-                                cont_witness.intern_named_cont(
-                                    ContName::NewerCont,
-                                    store,
-                                    Continuation::Unop {
-                                        operator: Op1::Secret,
-                                        continuation: cont,
-                                    },
-                                ),
-                            )
-                        }
-                    } else if head == c.atom.ptr() {
-                        let (arg1, end) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
-
-                        if rest.is_nil() || !end.is_nil() {
-                            Control::Error(expr, env)
-                        } else {
-                            Control::Return(
-                                arg1,
-                                env,
-                                cont_witness.intern_named_cont(
-                                    ContName::NewerCont,
-                                    store,
-                                    Continuation::Unop {
-                                        operator: Op1::Atom,
-                                        continuation: cont,
-                                    },
-                                ),
-                            )
-                        }
-                    } else if head == c.emit.ptr() {
-                        let (arg1, end) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
-
-                        if rest.is_nil() || !end.is_nil() {
-                            Control::Error(expr, env)
-                        } else {
-                            Control::Return(
-                                arg1,
-                                env,
-                                cont_witness.intern_named_cont(
-                                    ContName::NewerCont,
-                                    store,
-                                    Continuation::Unop {
-                                        operator: Op1::Emit,
+                                        operator: *op,
                                         continuation: cont,
                                     },
                                 ),

--- a/src/eval/reduction.rs
+++ b/src/eval/reduction.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use super::{empty_sym_env, Witness};
 use crate::coprocessor::Coprocessor;
 use crate::error::ReductionError;
@@ -68,38 +66,6 @@ fn reduce_with_witness_inner<F: LurkField, C: Coprocessor<F>>(
     c: &NamedConstants<F>,
     lang: &Lang<F, C>,
 ) -> Result<(Control<F>, Option<Ptr<F>>), ReductionError> {
-    let UNOPS_MAP: HashMap<Ptr<F>, _> = HashMap::from([
-        (c.car.ptr(), Op1::Car),
-        (c.cdr.ptr(), Op1::Cdr),
-        (c.commit.ptr(), Op1::Commit),
-        (c.num.ptr(), Op1::Num),
-        (c.u64.ptr(), Op1::U64),
-        (c.comm.ptr(), Op1::Comm),
-        (c.char.ptr(), Op1::Char),
-        (c.open.ptr(), Op1::Open),
-        (c.secret.ptr(), Op1::Secret),
-        (c.atom.ptr(), Op1::Atom),
-        (c.emit.ptr(), Op1::Emit),
-    ]);
-
-    let BINOPS_MAP: HashMap<Ptr<F>, _> = HashMap::from([
-        (c.cons.ptr(), Op2::Cons),
-        (c.strcons.ptr(), Op2::StrCons),
-        (c.hide.ptr(), Op2::Hide),
-        (c.begin.ptr(), Op2::Begin),
-        (c.sum.ptr(), Op2::Sum),
-        (c.diff.ptr(), Op2::Diff),
-        (c.product.ptr(), Op2::Product),
-        (c.quotient.ptr(), Op2::Quotient),
-        (c.modulo.ptr(), Op2::Modulo),
-        (c.num_equal.ptr(), Op2::NumEqual),
-        (c.equal.ptr(), Op2::Equal),
-        (c.less.ptr(), Op2::Less),
-        (c.greater.ptr(), Op2::Greater),
-        (c.less_equal.ptr(), Op2::LessEqual),
-        (c.greater_equal.ptr(), Op2::GreaterEqual),
-    ]);
-
     let mut closure_to_extend = None;
 
     Ok((
@@ -312,6 +278,39 @@ fn reduce_with_witness_inner<F: LurkField, C: Coprocessor<F>>(
                         }};
                     }
 
+                    // An array, for performance reasons
+                    let unops_map = [
+                        (c.car.ptr(), Op1::Car),
+                        (c.cdr.ptr(), Op1::Cdr),
+                        (c.commit.ptr(), Op1::Commit),
+                        (c.num.ptr(), Op1::Num),
+                        (c.u64.ptr(), Op1::U64),
+                        (c.comm.ptr(), Op1::Comm),
+                        (c.char.ptr(), Op1::Char),
+                        (c.open.ptr(), Op1::Open),
+                        (c.secret.ptr(), Op1::Secret),
+                        (c.atom.ptr(), Op1::Atom),
+                        (c.emit.ptr(), Op1::Emit),
+                    ];
+
+                    // An array, for performance reasons
+                    let binops_map = [
+                        (c.cons.ptr(), Op2::Cons),
+                        (c.strcons.ptr(), Op2::StrCons),
+                        (c.hide.ptr(), Op2::Hide),
+                        (c.sum.ptr(), Op2::Sum),
+                        (c.diff.ptr(), Op2::Diff),
+                        (c.product.ptr(), Op2::Product),
+                        (c.quotient.ptr(), Op2::Quotient),
+                        (c.modulo.ptr(), Op2::Modulo),
+                        (c.num_equal.ptr(), Op2::NumEqual),
+                        (c.equal.ptr(), Op2::Equal),
+                        (c.less.ptr(), Op2::Less),
+                        (c.greater.ptr(), Op2::Greater),
+                        (c.less_equal.ptr(), Op2::LessEqual),
+                        (c.greater_equal.ptr(), Op2::GreaterEqual),
+                    ];
+
                     if head == lambda {
                         let (args, body) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
                         let (arg, _rest) = if args.is_nil() {
@@ -424,7 +423,7 @@ fn reduce_with_witness_inner<F: LurkField, C: Coprocessor<F>>(
                                 }
                             }
                         }
-                    } else if let Some(op) = BINOPS_MAP.get(&head) {
+                    } else if let Some((_, op)) = binops_map.iter().find(|(ptr, _)| head == *ptr) {
                         let (arg1, more) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
                         if rest.is_nil() || more.is_nil() {
                             Control::Error(expr, env)
@@ -444,7 +443,29 @@ fn reduce_with_witness_inner<F: LurkField, C: Coprocessor<F>>(
                                 ),
                             )
                         }
-                    } else if let Some(op) = UNOPS_MAP.get(&head) {
+                    } else if head == c.begin.ptr() {
+                        let (arg1, more) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
+
+                        // Begin has a different boundary condition than the other binops (rest.is_nil() is OK)
+                        if more.is_nil() {
+                            Control::Return(arg1, env, cont)
+                        } else {
+                            Control::Return(
+                                arg1,
+                                env,
+                                cont_witness.intern_named_cont(
+                                    ContName::NewerCont,
+                                    store,
+                                    Continuation::Binop {
+                                        operator: Op2::Begin,
+                                        saved_env: env,
+                                        unevaled_args: more,
+                                        continuation: cont,
+                                    },
+                                ),
+                            )
+                        }
+                    } else if let Some((_, op)) = unops_map.iter().find(|(ptr, _)| head == *ptr) {
                         let (arg1, end) = car_cdr_named!(ConsName::ExprCdr, &rest)?;
                         if rest.is_nil() || !end.is_nil() {
                             Control::Error(expr, env)


### PR DESCRIPTION
This is a conservative PR that aims at reducing the level of redundancy in eval.rs.

- this has been partially [codemodded](https://gist.github.com/huitseeker/a4a2752055ee747bfd217d21385bd483), in order to minimize any chance of an edit mistake:
- this has ~~very little~~ no impact on benchmarks:
```
go_base_10_16_bls12     time:   [2.2568 ms 2.2587 ms 2.2607 ms]                                 
                        change: [+0.4310% +0.5543% +0.6692%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

go_base_10_160_bls12    time:   [21.565 ms 21.589 ms 21.611 ms]                                 
                        change: [+0.3615% +0.5026% +0.6417%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) low severe
  5 (5.00%) low mild
  1 (1.00%) high severe

go_base_10_16_pasta_pallas                                                                             
                        time:   [2.2996 ms 2.3017 ms 2.3037 ms]
                        change: [+0.6232% +0.7669% +0.9074%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) low mild
  1 (1.00%) high mild

go_base_10_160_pasta_pallas                                                                            
                        time:   [21.966 ms 21.986 ms 22.007 ms]
                        change: [+0.4683% +0.6143% +0.7566%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  1 (1.00%) high severe 
  ```
