### PR TITLE
Coprocessor results should be applied to continuation.

### DIFF
--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -2659,7 +2659,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>, C: Coprocessor<F>>(
     }
 
     for c in &coprocessor_results {
-        results.add_clauses_cons(*c.0.value(), &c.1, &c.2, &c.3, &g.false_num);
+        results.add_clauses_cons(*c.0.value(), &c.1, &c.2, &c.3, &g.true_num);
     }
 
     let is_zero_arg_call = rest_is_nil;

--- a/src/coprocessor.rs
+++ b/src/coprocessor.rs
@@ -49,6 +49,7 @@ pub trait Coprocessor<F: LurkField>: Clone + Debug + Sync + CoCircuit<F> {
         }
     }
 
+    /// As with all evaluation, the value returned from `simple_evaluate` must be fully evaluated.
     fn simple_evaluate(&self, s: &mut Store<F>, args: &[Ptr<F>]) -> Ptr<F>;
 }
 
@@ -71,7 +72,8 @@ pub trait CoCircuit<F: LurkField>: Send + Sync + Clone {
         _input_env: &AllocatedPtr<F>,
         _input_cont: &AllocatedContPtr<F>,
     ) -> Result<(AllocatedPtr<F>, AllocatedPtr<F>, AllocatedContPtr<F>), SynthesisError> {
-        todo!()
+        // A `synthesize` implementation needs to be provided by implementers of `CoCircuit`.
+        unimplemented!()
     }
 }
 

--- a/src/coprocessor.rs
+++ b/src/coprocessor.rs
@@ -78,6 +78,8 @@ pub trait CoCircuit<F: LurkField>: Send + Sync + Clone {
 #[cfg(test)]
 pub(crate) mod test {
     use super::*;
+    use crate::circuit::gadgets::constraints::{add, mul};
+    use crate::tag::{ExprTag, Tag};
     use std::marker::PhantomData;
 
     /// A dumb Coprocessor for testing.
@@ -86,7 +88,33 @@ pub(crate) mod test {
         pub(crate) _p: PhantomData<F>,
     }
 
-    impl<F: LurkField> CoCircuit<F> for DumbCoprocessor<F> {}
+    impl<F: LurkField> CoCircuit<F> for DumbCoprocessor<F> {
+        fn arity(&self) -> usize {
+            2
+        }
+
+        fn synthesize<CS: ConstraintSystem<F>>(
+            &self,
+            cs: &mut CS,
+            _store: &Store<F>,
+            input_exprs: &[AllocatedPtr<F>],
+            input_env: &AllocatedPtr<F>,
+            input_cont: &AllocatedContPtr<F>,
+        ) -> Result<(AllocatedPtr<F>, AllocatedPtr<F>, AllocatedContPtr<F>), SynthesisError>
+        {
+            let a = input_exprs[0].clone();
+            let b = &input_exprs[1];
+
+            // FIXME: Check tags.
+
+            // a^2 + b = c
+            let a2 = mul(&mut cs.namespace(|| "square"), a.hash(), a.hash())?;
+            let c = add(&mut cs.namespace(|| "add"), &a2, b.hash())?;
+            let c_ptr = AllocatedPtr::alloc_tag(cs, ExprTag::Num.to_field(), c)?;
+
+            Ok((c_ptr, input_env.clone(), input_cont.clone()))
+        }
+    }
 
     impl<F: LurkField> Coprocessor<F> for DumbCoprocessor<F> {
         /// Dumb Coprocessor takes two arguments.

--- a/src/eval/reduction.rs
+++ b/src/eval/reduction.rs
@@ -551,7 +551,10 @@ fn reduce_with_witness_inner<F: LurkField, C: Coprocessor<F>>(
                             let IO { expr, env, cont } =
                                 coprocessor.evaluate(store, args, env, cont);
 
-                            return Ok((Control::Return(expr, env, cont), closure_to_extend));
+                            return Ok((
+                                Control::ApplyContinuation(expr, env, cont),
+                                closure_to_extend,
+                            ));
                         };
 
                         // `fun_form` must be a function or potentially evaluate to one.

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -3600,8 +3600,8 @@ mod tests {
         let res = s.num(89);
         let error = s.get_cont_error();
 
-        test_aux(s, &expr, Some(res), None, None, None, 2, Some(&lang));
-        test_aux(s, &expr2, Some(res), None, None, None, 4, Some(&lang));
+        test_aux(s, &expr, Some(res), None, None, None, 1, Some(&lang));
+        test_aux(s, &expr2, Some(res), None, None, None, 3, Some(&lang));
         test_aux(s, &expr3, None, None, Some(error), None, 1, Some(&lang));
         test_aux(s, &expr4, None, None, Some(error), None, 1, Some(&lang));
     }


### PR DESCRIPTION
The initial implementation wrongly failed to apply the continuation to coprocessor results. The example circuit was also implemented on wrapper enum, rather than the Coprocessor itself. This fixes those issues.