### PR TITLE
Add SHA256 benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
+name = "anymap"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33954243bd79057c2de7338850b85983a44588021f8a5fee574a8888c6de4344"
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,7 +538,6 @@ dependencies = [
  "assert_cmd",
  "blstrs",
  "clap 4.2.4",
- "fcomm",
  "fil_pasta_curves",
  "lurk",
  "pretty_env_logger",
@@ -1358,7 +1363,9 @@ version = "0.2.0"
 dependencies = [
  "ahash",
  "anyhow",
+ "anymap",
  "assert_cmd",
+ "base64",
  "bellperson",
  "blstrs",
  "cid",
@@ -1370,6 +1377,7 @@ dependencies = [
  "fil_pasta_curves",
  "generic-array 0.14.7",
  "getrandom",
+ "hex",
  "indexmap",
  "itertools 0.9.0",
  "log",
@@ -1397,7 +1405,9 @@ dependencies = [
  "rustyline",
  "rustyline-derive",
  "serde",
+ "serde_json",
  "serde_repr",
+ "sha2",
  "string-interner",
  "structopt",
  "tap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ repository = "https://github.com/lurk-lab/lurk-rs"
 
 [dependencies]
 anyhow = "1.0.69"
+base64 = "0.13.1"
+hex = { version = "0.4.3", features = ["serde"] }
 thiserror = "1.0.38"
 bellperson = "0.24"
 blstrs = "0.6.1"
@@ -28,8 +30,10 @@ pretty_env_logger = "0.4"
 rand_core = { version = "0.6.4", default-features = false }
 rayon = "1.7.0"
 rustyline-derive = "0.8.0"
+rand = "0.8"
 rand_xorshift = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0" }
 serde_repr = "0.1.10"
 indexmap = { version = "1.9.2", features = ["rayon"] }
 ahash = "0.7.6"
@@ -45,6 +49,7 @@ num-traits = "0.2.15"
 nom = "7.1.3"
 clap = "4.1.8"
 tap = "1.0.1"
+anymap = "0.12.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 memmap = { version = "0.5.10", package = "memmap2" }
@@ -68,6 +73,8 @@ portable = ["blstrs/portable", "pasta-msm/portable"]
 
 [dev-dependencies]
 criterion = "0.3.6"
+hex = "0.4.3"
+sha2 = { version = "0.10.2"}
 structopt = { version = "0.3", default-features = false }
 tap = "1.0.1"
 assert_cmd = "2.0.8"

--- a/clutch/Cargo.toml
+++ b/clutch/Cargo.toml
@@ -13,7 +13,6 @@ repository = "https://github.com/lurk-lab/lurk-rs"
 anyhow = "1.0.69"
 blstrs = "0.6.1"
 clap = "4.1.8"
-fcomm = { path = "../fcomm" }
 lurk = { path = "../" }
 pasta_curves = { version = "0.5.2", features = ["repr-c", "serde"], package = "fil_pasta_curves" }
 pretty_env_logger = "0.4"

--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -1,0 +1,202 @@
+use std::env;
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::time::Instant;
+
+use lurk::circuit::gadgets::data::GlobalAllocations;
+use lurk::circuit::gadgets::pointer::{AllocatedContPtr, AllocatedPtr};
+use lurk::coprocessor::{CoCircuit, Coprocessor};
+use lurk::eval::{empty_sym_env, lang::Lang};
+use lurk::field::LurkField;
+use lurk::proof::{nova::NovaProver, Prover};
+use lurk::ptr::Ptr;
+use lurk::public_parameters::public_params;
+use lurk::store::Store;
+use lurk::sym::Sym;
+use lurk::tag::{ExprTag, Tag};
+use lurk::Num;
+use lurk_macros::Coproc;
+
+use bellperson::gadgets::boolean::{AllocatedBit, Boolean};
+use bellperson::gadgets::multipack::pack_bits;
+use bellperson::gadgets::num::AllocatedNum;
+use bellperson::gadgets::sha256::sha256;
+use bellperson::{ConstraintSystem, SynthesisError};
+
+use itertools::enumerate;
+use pasta_curves::pallas::Scalar as Fr;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+const REDUCTION_COUNT: usize = 10;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct Sha256Coprocessor<F: LurkField> {
+    n: usize,
+    pub(crate) _p: PhantomData<F>,
+}
+
+impl<F: LurkField> CoCircuit<F> for Sha256Coprocessor<F> {
+    fn arity(&self) -> usize {
+        0
+    }
+
+    fn synthesize<CS: ConstraintSystem<F>>(
+        &self,
+        cs: &mut CS,
+        g: &GlobalAllocations<F>,
+        store: &Store<F>,
+        _input_exprs: &[AllocatedPtr<F>],
+        input_env: &AllocatedPtr<F>,
+        input_cont: &AllocatedContPtr<F>,
+    ) -> Result<(AllocatedPtr<F>, AllocatedPtr<F>, AllocatedContPtr<F>), SynthesisError> {
+        // // TODO: Maybe fix this
+        let false_bool = Boolean::from(AllocatedBit::alloc(cs.namespace(|| "false"), Some(false))?);
+
+        let preimage = vec![false_bool; self.n * 8];
+
+        let mut bits = sha256(cs.namespace(|| "SHAhash"), &preimage)?;
+
+        bits.reverse();
+
+        let nums: Vec<AllocatedNum<_>> = (0..2)
+            .map(|i| {
+                pack_bits(
+                    cs.namespace(|| format!("num{i}")),
+                    &bits[(128 * i)..(128 * (i + 1))],
+                )
+                .unwrap()
+            })
+            .collect();
+
+        let result_ptr = enumerate(nums).try_fold(g.nil_ptr.clone(), |acc, (i, num)| {
+            let ptr = AllocatedPtr::alloc_tag(
+                &mut cs.namespace(|| format!("limb_value_{i}")),
+                ExprTag::Num.to_field(),
+                num,
+            )?;
+            AllocatedPtr::construct_cons(cs.namespace(|| format!("limb_{i}")), g, store, &ptr, &acc)
+        })?;
+
+        Ok((result_ptr, input_env.clone(), input_cont.clone()))
+    }
+}
+
+impl<F: LurkField> Coprocessor<F> for Sha256Coprocessor<F> {
+    fn eval_arity(&self) -> usize {
+        0
+    }
+
+    fn simple_evaluate(&self, s: &mut Store<F>, _args: &[Ptr<F>]) -> Ptr<F> {
+        let mut hasher = Sha256::new();
+
+        let input = vec![0u8; self.n];
+
+        hasher.update(input);
+        let result = hasher.finalize();
+
+        let u: Vec<u128> = (0..2)
+            .map(|i| {
+                let a: [u8; 16] = result[(16 * i)..(16 * (i + 1))].try_into().unwrap();
+                u128::from_be_bytes(a)
+            })
+            .collect();
+
+        let blah = &[u[0], u[1]].map(|x| s.intern_num(u128_into_scalar::<F>(x)));
+        s.list(blah)
+    }
+}
+
+fn u128_into_scalar<F: LurkField>(u: u128) -> Num<F> {
+    let bytes: [u8; 16] = u.to_le_bytes();
+    let zeroes: [u8; 16] = [0u8; 16];
+    let result: [u8; 32] = [bytes, zeroes].concat().try_into().unwrap();
+    Num::Scalar(F::from_bytes(&result).unwrap())
+}
+
+impl<F: LurkField> Sha256Coprocessor<F> {
+    pub(crate) fn new(n: usize) -> Self {
+        Self {
+            n,
+            _p: Default::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Coproc, Serialize, Deserialize)]
+enum Sha256Coproc<F: LurkField> {
+    SC(Sha256Coprocessor<F>),
+}
+
+/// Run the example in this file with
+/// `cargo run --example sha256 1 f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b false`
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    let num_of_64_bytes = args[1].parse::<usize>().unwrap();
+    let expect = hex::decode(args[2].parse::<String>().unwrap()).unwrap();
+    let setup_only = args[3].parse::<bool>().unwrap();
+
+    let input_size = 64 * num_of_64_bytes;
+
+    let store = &mut Store::<Fr>::new();
+    let mut lang = Lang::<Fr, Sha256Coproc<Fr>>::new();
+    let sym_str = format!(".sha256.hash-{}-zero-bytes", input_size);
+    let name = Sym::new(sym_str.clone());
+    let coprocessor: Sha256Coprocessor<Fr> = Sha256Coprocessor::<Fr>::new(input_size);
+    let coproc = Sha256Coproc::SC(coprocessor);
+
+    lang.add_coprocessor(name, coproc, store);
+
+    let coproc_expr = format!("({})", sym_str);
+
+    let mut u: [u128; 2] = [0u128; 2];
+
+    for i in 0..2 {
+        u[i] = u128::from_be_bytes(expect[(i * 16)..(i + 1) * 16].try_into().unwrap())
+    }
+    let result_expr = format!("({} {})", u[0], u[1]);
+
+    let expr = format!("(emit (eq {coproc_expr} (quote {result_expr})))");
+    let ptr = store.read(&expr).unwrap();
+
+    let nova_prover = NovaProver::<Fr, Sha256Coproc<Fr>>::new(REDUCTION_COUNT, lang.clone());
+    let lang_rc = Arc::new(lang);
+
+    println!("Setting up public parameters...");
+
+    let pp_start = Instant::now();
+    let pp = public_params::<Sha256Coproc<Fr>>(REDUCTION_COUNT, lang_rc.clone()).unwrap();
+    let pp_end = pp_start.elapsed();
+
+    println!("Public parameters took {:?}", pp_end);
+
+    if setup_only {
+        return;
+    }
+
+    println!("Beginning proof step...");
+
+    let proof_start = Instant::now();
+    let (proof, z0, zi, num_steps) = nova_prover
+        .evaluate_and_prove(&pp, ptr, empty_sym_env(store), store, 10000, lang_rc)
+        .unwrap();
+    let proof_end = proof_start.elapsed();
+
+    println!("Proofs took {:?}", proof_end);
+
+    println!("Verifying proof...");
+
+    let verify_start = Instant::now();
+    let res = proof.verify(&pp, num_steps, z0, &zi).unwrap();
+    let verify_end = verify_start.elapsed();
+
+    println!("Verify took {:?}", verify_end);
+
+    if res {
+        println!(
+            "Congratulations! You proved and verified a SHA256 hash calculation in {:?} time!",
+            pp_end + proof_end + verify_end
+        );
+    }
+}

--- a/fcomm/src/bin/fcomm.rs
+++ b/fcomm/src/bin/fcomm.rs
@@ -4,6 +4,7 @@ use std::env;
 use std::fs::read_to_string;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use hex::FromHex;
 use serde::de::DeserializeOwned;
@@ -21,8 +22,8 @@ use lurk::store::{Store, TypePredicates};
 use clap::{AppSettings, Args, Parser, Subcommand};
 use clap_verbosity_flag::{Verbosity, WarnLevel};
 
-use fcomm::{
-    self, committed_expression_store, error::Error, evaluate, public_params, Claim, Commitment,
+use lurk::public_parameters::{
+    committed_expression_store, error::Error, evaluate, public_params, Claim, Commitment,
     CommittedExpression, Evaluation, Expression, FileStore, LurkPtr, Opening, OpeningRequest,
     Proof, ReductionCount, S1,
 };
@@ -218,8 +219,9 @@ impl Open {
 
         let s = &mut Store::<S1>::default();
         let rc = ReductionCount::try_from(self.reduction_count).unwrap();
-        let prover = NovaProver::<S1, Coproc<S1>>::new(rc.count(), fcomm::lang().clone());
-        let pp = public_params(rc.count()).unwrap();
+        let prover = NovaProver::<S1, Coproc<S1>>::new(rc.count(), lang.clone());
+        let lang_rc = Arc::new(lang.clone());
+        let pp = public_params(rc.count(), lang_rc).unwrap();
         let function_map = committed_expression_store();
 
         let handle_proof = |out_path, proof: Proof<S1>| {
@@ -231,13 +233,15 @@ impl Open {
 
         let handle_claim = |claim: Claim<S1>| serde_json::to_writer(io::stdout(), &claim);
 
+        let lang_rc = Arc::new(lang.clone());
         if let Some(request_path) = &self.request {
             assert!(!self.chain, "chain and request may not both be specified");
             let request = opening_request(request_path).expect("failed to read opening request");
 
             if let Some(out_path) = &self.proof {
                 let proof =
-                    Opening::open_and_prove(s, request, limit, false, &prover, &pp, lang).unwrap();
+                    Opening::open_and_prove(s, request, limit, false, &prover, &pp, lang_rc)
+                        .unwrap();
 
                 handle_proof(out_path, proof);
             } else {
@@ -275,10 +279,11 @@ impl Open {
 
             let input_path = self.input.as_ref().expect("input missing");
             let input = input(s, input_path, eval_input, limit, self.quote_input, lang).unwrap();
+            let lang_rc = Arc::new(lang.clone());
 
             if let Some(out_path) = &self.proof {
                 let proof = Opening::apply_and_prove(
-                    s, input, function, limit, self.chain, false, &prover, &pp, lang,
+                    s, input, function, limit, self.chain, false, &prover, &pp, lang_rc,
                 )
                 .unwrap();
 
@@ -316,8 +321,9 @@ impl Prove {
     fn prove(&self, limit: usize, lang: &Lang<S1, Coproc<S1>>) {
         let s = &mut Store::<S1>::default();
         let rc = ReductionCount::try_from(self.reduction_count).unwrap();
-        let prover = NovaProver::<S1, Coproc<S1>>::new(rc.count(), fcomm::lang().clone());
-        let pp = public_params(rc.count()).unwrap();
+        let prover = NovaProver::<S1, Coproc<S1>>::new(rc.count(), lang.clone());
+        let lang_rc = Arc::new(lang.clone());
+        let pp = public_params(rc.count(), lang_rc.clone()).unwrap();
 
         let proof = match &self.claim {
             Some(claim) => {
@@ -332,7 +338,7 @@ impl Prove {
                     false,
                     &prover,
                     &pp,
-                    lang,
+                    lang_rc,
                 )
                 .unwrap()
             }
@@ -347,7 +353,7 @@ impl Prove {
                 )
                 .unwrap();
 
-                Proof::eval_and_prove(s, expr, None, limit, false, &prover, &pp, lang).unwrap()
+                Proof::eval_and_prove(s, expr, None, limit, false, &prover, &pp, lang_rc).unwrap()
             }
         };
 
@@ -362,7 +368,8 @@ impl Prove {
 impl Verify {
     fn verify(&self, cli_error: bool, lang: &Lang<S1, Coproc<S1>>) {
         let proof = proof(Some(&self.proof)).unwrap();
-        let pp = public_params(proof.reduction_count.count()).unwrap();
+        let lang_rc = Arc::new(lang.clone());
+        let pp = public_params(proof.reduction_count.count(), lang_rc).unwrap();
         let result = proof.verify(&pp, lang).unwrap();
 
         serde_json::to_writer(io::stdout(), &result).unwrap();
@@ -493,7 +500,9 @@ fn main() {
         .filter_level(cli.verbose.log_level_filter())
         .init();
 
+    // TODO: make this properly configurable, e.g. allowing coprocessors
     let lang = Lang::new();
+
     match &cli.command {
         Command::Commit(c) => c.commit(cli.limit, &lang),
         Command::Open(o) => o.open(cli.limit, cli.eval_input, &lang),

--- a/fcomm/tests/proof_tests.rs
+++ b/fcomm/tests/proof_tests.rs
@@ -7,7 +7,7 @@ use tempfile::{Builder, TempDir};
 
 use pasta_curves::pallas;
 
-use fcomm::{Commitment, CommittedExpression, FileStore, LurkPtr, Proof};
+use lurk::public_parameters::{Commitment, CommittedExpression, FileStore, LurkPtr, Proof};
 use lurk::store::Store;
 
 use camino::Utf8Path;

--- a/lurk-macros/src/lib.rs
+++ b/lurk-macros/src/lib.rs
@@ -37,27 +37,27 @@ fn impl_enum_coproc(name: &Ident, variants: &DataEnum) -> TokenStream {
     let arity_arms = arity_match_arms(name, variants);
     let synthesize_arms = synthesize_match_arms(name, variants);
     let res = quote! {
-        impl <F: crate::field::LurkField> crate::coprocessor::Coprocessor<F> for #name<F> {
+        impl <F: lurk::field::LurkField> lurk::coprocessor::Coprocessor<F> for #name<F> {
             fn eval_arity(&self) -> usize {
                 match self {
                     #eval_arity_arms
                 }
             }
 
-            fn evaluate(&self, s: &mut crate::store::Store<F>, args: crate::ptr::Ptr<F>, env: crate::ptr::Ptr<F>, cont: crate::ptr::ContPtr<F>) -> crate::eval::IO<F> {
+            fn evaluate(&self, s: &mut lurk::store::Store<F>, args: lurk::ptr::Ptr<F>, env: lurk::ptr::Ptr<F>, cont: lurk::ptr::ContPtr<F>) -> lurk::eval::IO<F> {
                 match self {
                     #evaluate_arms
                 }
             }
 
-            fn simple_evaluate(&self, s: &mut crate::store::Store<F>, args: &[crate::ptr::Ptr<F>]) -> crate::ptr::Ptr<F> {
+            fn simple_evaluate(&self, s: &mut lurk::store::Store<F>, args: &[lurk::ptr::Ptr<F>]) -> lurk::ptr::Ptr<F> {
                 match self {
                     #simple_evaluate_arms
                 }
             }
         }
 
-        impl<F: crate::field::LurkField> crate::coprocessor::CoCircuit<F> for #name<F> {
+        impl<F: lurk::field::LurkField> lurk::coprocessor::CoCircuit<F> for #name<F> {
             fn arity(&self) -> usize {
                 match self {
                     #arity_arms
@@ -67,11 +67,12 @@ fn impl_enum_coproc(name: &Ident, variants: &DataEnum) -> TokenStream {
             fn synthesize<CS: bellperson::ConstraintSystem<F>>(
                 &self,
                 cs: &mut CS,
-                store: &crate::store::Store<F>,
-                input_exprs: &[crate::circuit::gadgets::pointer::AllocatedPtr<F>],
-                input_env: &crate::circuit::gadgets::pointer::AllocatedPtr<F>,
-                input_cont: &crate::circuit::gadgets::pointer::AllocatedContPtr<F>,
-            ) -> Result<(crate::circuit::gadgets::pointer::AllocatedPtr<F>, crate::circuit::gadgets::pointer::AllocatedPtr<F>, crate::circuit::gadgets::pointer::AllocatedContPtr<F>), bellperson::SynthesisError> {
+                g: &lurk::circuit::gadgets::data::GlobalAllocations<F>,
+                store: &lurk::store::Store<F>,
+                input_exprs: &[lurk::circuit::gadgets::pointer::AllocatedPtr<F>],
+                input_env: &lurk::circuit::gadgets::pointer::AllocatedPtr<F>,
+                input_cont: &lurk::circuit::gadgets::pointer::AllocatedContPtr<F>,
+            ) -> Result<(lurk::circuit::gadgets::pointer::AllocatedPtr<F>, lurk::circuit::gadgets::pointer::AllocatedPtr<F>, lurk::circuit::gadgets::pointer::AllocatedContPtr<F>), bellperson::SynthesisError> {
                 match self {
                     #synthesize_arms
                 }
@@ -135,7 +136,7 @@ fn synthesize_match_arms(name: &Ident, variants: &DataEnum) -> proc_macro2::Toke
         let variant_ident = &variant.ident;
 
         match_arms.extend(quote! {
-            #name::#variant_ident(cocircuit) => cocircuit.synthesize(cs, store, input_exprs, input_env, input_cont),
+            #name::#variant_ident(cocircuit) => cocircuit.synthesize(cs, g, store, input_exprs, input_env, input_cont),
         });
     }
     match_arms

--- a/src/circuit/gadgets/mod.rs
+++ b/src/circuit/gadgets/mod.rs
@@ -3,6 +3,6 @@ pub(crate) mod macros;
 
 pub(crate) mod case;
 pub(crate) mod constraints;
-pub(crate) mod data;
+pub mod data;
 pub(crate) mod hashes;
-pub(crate) mod pointer;
+pub mod pointer;

--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -5,7 +5,8 @@ use crate::eval::IO;
 use crate::store::Store;
 
 #[macro_use]
-pub(crate) mod gadgets;
+pub mod gadgets;
+
 mod circuit_frame;
 pub(crate) use circuit_frame::*;
 

--- a/src/coprocessor.rs
+++ b/src/coprocessor.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 
 use bellperson::{ConstraintSystem, SynthesisError};
 
+use crate::circuit::gadgets::data::GlobalAllocations;
 use crate::circuit::gadgets::pointer::{AllocatedContPtr, AllocatedPtr};
 use crate::eval::IO;
 use crate::field::LurkField;
@@ -68,6 +69,7 @@ pub trait CoCircuit<F: LurkField>: Send + Sync + Clone {
     fn synthesize<CS: ConstraintSystem<F>>(
         &self,
         _cs: &mut CS,
+        _g: &GlobalAllocations<F>,
         _store: &Store<F>,
         _input_exprs: &[AllocatedPtr<F>],
         _input_env: &AllocatedPtr<F>,
@@ -80,13 +82,15 @@ pub trait CoCircuit<F: LurkField>: Send + Sync + Clone {
 
 #[cfg(test)]
 pub(crate) mod test {
+    use serde::{Deserialize, Serialize};
+
     use super::*;
     use crate::circuit::gadgets::constraints::{add, mul};
     use crate::tag::{ExprTag, Tag};
     use std::marker::PhantomData;
 
     /// A dumb Coprocessor for testing.
-    #[derive(Clone, Debug)]
+    #[derive(Clone, Debug, Serialize, Deserialize)]
     pub(crate) struct DumbCoprocessor<F: LurkField> {
         pub(crate) _p: PhantomData<F>,
     }
@@ -99,6 +103,7 @@ pub(crate) mod test {
         fn synthesize<CS: ConstraintSystem<F>>(
             &self,
             cs: &mut CS,
+            _g: &GlobalAllocations<F>,
             _store: &Store<F>,
             input_exprs: &[AllocatedPtr<F>],
             input_env: &AllocatedPtr<F>,

--- a/src/eval/lang.rs
+++ b/src/eval/lang.rs
@@ -11,6 +11,8 @@ use crate::ptr::{Ptr, ScalarPtr};
 use crate::store::Store;
 use crate::sym::Sym;
 
+use crate as lurk;
+
 /// `DummyCoprocessor` is a concrete implementation of the [`crate::coprocessor::Coprocessor`] trait.
 ///
 /// It provides specific behavior for a dummy coprocessor.
@@ -84,6 +86,21 @@ impl<F: LurkField, C: Coprocessor<F>> Lang<F, C> {
         Self {
             coprocessors: Default::default(),
         }
+    }
+
+    pub fn key(&self) -> String {
+        let mut key = String::new();
+
+        for coprocessor in &self.coprocessors {
+            let name = match coprocessor.0 {
+                Sym::Sym(sym) => &sym.path,
+                Sym::Key(sym) => &sym.path,
+            }
+            .join("-");
+
+            key += name.as_str()
+        }
+        key
     }
 
     pub fn add_coprocessor(&mut self, name: Sym, cproc: C, store: &mut Store<F>) {

--- a/src/eval/tests/mod.rs
+++ b/src/eval/tests/mod.rs
@@ -9,6 +9,8 @@ use crate::writer::Write;
 use lurk_macros::{let_store, lurk, Coproc};
 use pasta_curves::pallas::Scalar as Fr;
 
+use crate as lurk;
+
 fn test_aux<C: Coprocessor<Fr>>(
     s: &mut Store<Fr>,
     expr: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod package;
 pub mod parser;
 pub mod proof;
 pub mod ptr;
+pub mod public_parameters;
 pub mod repl;
 pub mod scalar_store;
 pub mod store;

--- a/src/proof/groth16.rs
+++ b/src/proof/groth16.rs
@@ -20,6 +20,7 @@ use pairing_lib::{Engine, MultiMillerLoop};
 use rand_core::{RngCore, SeedableRng};
 use rand_xorshift::XorShiftRng;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 use crate::circuit::MultiFrame;
 use crate::coprocessor::Coprocessor;
@@ -102,7 +103,7 @@ impl<C: Coprocessor<Scalar>> Groth16Prover<Bls12, C, Scalar> {
     /// Creates Groth16 parameters using the given reduction count.
     pub fn create_groth_params(
         reduction_count: usize,
-        lang: &Lang<Scalar, C>,
+        lang: Arc<Lang<Scalar, C>>,
     ) -> Result<PublicParams<Bls12>, SynthesisError> {
         let multiframe: MultiFrame<'_, Scalar, IO<Scalar>, Witness<Scalar>, C> =
             MultiFrame::blank(reduction_count, lang);
@@ -138,13 +139,14 @@ impl<C: Coprocessor<Scalar>> Groth16Prover<Bls12, C, Scalar> {
         store: &mut Store<Scalar>,
         limit: usize,
         mut rng: R,
-        lang: &Lang<Scalar, C>,
+        lang: Arc<Lang<Scalar, C>>,
     ) -> Result<(Proof<Bls12>, IO<Scalar>, IO<Scalar>), ProofError> {
         let padding_predicate = |count| self.needs_frame_padding(count);
-        let frames = Evaluator::generate_frames(expr, env, store, limit, padding_predicate, lang)?;
+        let frames = Evaluator::generate_frames(expr, env, store, limit, padding_predicate, &lang)?;
         store.hydrate_scalar_cache();
 
-        let multiframes = MultiFrame::from_frames(self.reduction_count(), &frames, store, lang);
+        let multiframes =
+            MultiFrame::from_frames(self.reduction_count(), &frames, store, lang.clone());
         let mut proofs = Vec::with_capacity(multiframes.len());
         let mut statements = Vec::with_capacity(multiframes.len());
 
@@ -389,8 +391,12 @@ mod tests {
     ) {
         let rng = OsRng;
 
-        let public_params =
-            Groth16Prover::<_, C, Fr>::create_groth_params(DEFAULT_REDUCTION_COUNT, &lang).unwrap();
+        let lang_rc = Arc::new(lang.clone());
+        let public_params = Groth16Prover::<_, C, Fr>::create_groth_params(
+            DEFAULT_REDUCTION_COUNT,
+            lang_rc.clone(),
+        )
+        .unwrap();
         let groth_prover = Groth16Prover::new(DEFAULT_REDUCTION_COUNT, lang.clone());
         let groth_params = &public_params.0;
 
@@ -404,7 +410,8 @@ mod tests {
                 Evaluator::generate_frames(expr, e, s, limit, padding_predicate, &lang).unwrap();
             s.hydrate_scalar_cache();
 
-            let multi_frames = MultiFrame::from_frames(DEFAULT_REDUCTION_COUNT, &frames, s, &lang);
+            let multi_frames =
+                MultiFrame::from_frames(DEFAULT_REDUCTION_COUNT, &frames, s, lang_rc.clone());
 
             let cs = groth_prover.outer_synthesize(&multi_frames).unwrap();
 
@@ -425,7 +432,7 @@ mod tests {
             let constraint_systems_verified = verify_sequential_css::<Scalar, C>(&cs).unwrap();
             assert!(constraint_systems_verified);
 
-            check_cs_deltas(&cs, limit, &lang);
+            check_cs_deltas(&cs, limit, lang_rc.clone());
         }
 
         let proof_results = if check_groth16 {
@@ -439,7 +446,7 @@ mod tests {
                         s,
                         limit,
                         rng,
-                        &lang,
+                        lang_rc,
                     )
                     .unwrap(),
             )
@@ -468,7 +475,7 @@ mod tests {
     fn check_cs_deltas<C: Coprocessor<Fr>>(
         constraint_systems: &SequentialCS<'_, Fr, IO<Fr>, Witness<Fr>, C>,
         limit: usize,
-        lang: &Lang<Fr, C>,
+        lang: Arc<Lang<Fr, C>>,
     ) {
         let mut cs_blank = MetricCS::<Fr>::new();
         let blank_frame = MultiFrame::<Scalar, _, _, C>::blank(DEFAULT_REDUCTION_COUNT, lang);

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -14,6 +14,7 @@ use nova::{
 };
 use pasta_curves::{pallas, vesta};
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 use crate::circuit::{
     gadgets::{
@@ -81,10 +82,10 @@ pub enum Proof<'a, C: Coprocessor<S1>> {
 }
 
 /// Generates the public parameters for the Nova proving system.
-pub fn public_params<C: Coprocessor<S1>>(
+pub fn public_params<'a, C: Coprocessor<S1>>(
     num_iters_per_step: usize,
-    lang: &Lang<S1, C>,
-) -> PublicParams<'_, C> {
+    lang: Arc<Lang<S1, C>>,
+) -> PublicParams<'a, C> {
     let (circuit_primary, circuit_secondary) = C1::circuits(num_iters_per_step, lang);
 
     let pp = nova::PublicParams::setup(circuit_primary, circuit_secondary);
@@ -93,7 +94,7 @@ pub fn public_params<C: Coprocessor<S1>>(
 }
 
 impl<'a, C: Coprocessor<S1>> MultiFrame<'a, S1, IO<S1>, Witness<S1>, C> {
-    fn circuits(count: usize, lang: &'a Lang<S1, C>) -> (C1<'a, C>, C2) {
+    fn circuits(count: usize, lang: Arc<Lang<S1, C>>) -> (C1<'a, C>, C2) {
         (
             MultiFrame::blank(count, lang),
             TrivialTestCircuit::default(),
@@ -155,12 +156,13 @@ impl<C: Coprocessor<S1>> NovaProver<S1, C> {
         env: Ptr<S1>,
         store: &'a mut Store<S1>,
         limit: usize,
-        lang: &'a Lang<S1, C>,
+        lang: Arc<Lang<S1, C>>,
     ) -> Result<(Proof<'_, C>, Vec<S1>, Vec<S1>, usize), ProofError> {
-        let frames = self.get_evaluation_frames(expr, env, store, limit, lang)?;
+        let frames = self.get_evaluation_frames(expr, env, store, limit, &lang)?;
         let z0 = frames[0].input.to_vector(store)?;
         let zi = frames.last().unwrap().output.to_vector(store)?;
-        let circuits = MultiFrame::from_frames(self.reduction_count(), &frames, store, lang);
+        let circuits =
+            MultiFrame::from_frames(self.reduction_count(), &frames, store, lang.clone());
         let num_steps = circuits.len();
         let proof =
             Proof::prove_recursively(pp, store, &circuits, self.reduction_count, z0.clone(), lang)?;
@@ -238,7 +240,7 @@ impl<'a: 'b, 'b, C: Coprocessor<S1>> Proof<'a, C> {
         circuits: &[C1<'a, C>],
         num_iters_per_step: usize,
         z0: Vec<S1>,
-        lang: &'a Lang<S1, C>,
+        lang: Arc<Lang<S1, C>>,
     ) -> Result<Self, ProofError> {
         assert!(!circuits.is_empty());
         assert_eq!(circuits[0].arity(), z0.len());
@@ -344,7 +346,7 @@ impl<'a: 'b, 'b, C: Coprocessor<S1>> Proof<'a, C> {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use crate::num::Num;
 
     use super::*;
@@ -362,7 +364,8 @@ mod tests {
 
     const DEFAULT_REDUCTION_COUNT: usize = 5;
     const REDUCTION_COUNTS_TO_TEST: [usize; 3] = [1, 2, 5];
-    fn test_aux<C: Coprocessor<Fr>>(
+    /// fake docs
+    pub fn test_aux<C: Coprocessor<Fr>>(
         s: &mut Store<Fr>,
         expr: &str,
         expected_result: Option<Ptr<Fr>>,
@@ -370,7 +373,7 @@ mod tests {
         expected_cont: Option<ContPtr<Fr>>,
         expected_emitted: Option<Vec<Ptr<Fr>>>,
         expected_iterations: usize,
-        lang: Option<&Lang<Fr, C>>,
+        lang: Option<Arc<Lang<Fr, C>>>,
     ) {
         for chunk_size in REDUCTION_COUNTS_TO_TEST {
             nova_test_full_aux(
@@ -384,7 +387,7 @@ mod tests {
                 chunk_size,
                 false,
                 None,
-                lang,
+                lang.clone(),
             )
         }
     }
@@ -400,7 +403,7 @@ mod tests {
         reduction_count: usize,
         check_nova: bool,
         limit: Option<usize>,
-        lang: Option<&Lang<Fr, C>>,
+        lang: Option<Arc<Lang<Fr, C>>>,
     ) {
         let expr = s.read(expr).unwrap();
 
@@ -424,7 +427,7 @@ mod tests {
             f(l)
         } else {
             let lang = Lang::new();
-            f(&lang)
+            f(Arc::new(lang))
         };
     }
 
@@ -439,18 +442,18 @@ mod tests {
         reduction_count: usize,
         check_nova: bool,
         limit: Option<usize>,
-        lang: &Lang<Fr, C>,
+        lang: Arc<Lang<Fr, C>>,
     ) {
         let limit = limit.unwrap_or(10000);
 
         let e = empty_sym_env(s);
 
-        let nova_prover = NovaProver::<Fr, C>::new(reduction_count, lang.clone());
+        let nova_prover = NovaProver::<Fr, C>::new(reduction_count, (*lang).clone());
 
         if check_nova {
-            let pp = public_params(reduction_count, lang);
+            let pp = public_params(reduction_count, lang.clone());
             let (proof, z0, zi, num_steps) = nova_prover
-                .evaluate_and_prove(&pp, expr, empty_sym_env(s), s, limit, &lang)
+                .evaluate_and_prove(&pp, expr, empty_sym_env(s), s, limit, lang.clone())
                 .unwrap();
 
             let res = proof.verify(&pp, num_steps, z0.clone(), &zi);
@@ -469,7 +472,8 @@ mod tests {
             .get_evaluation_frames(expr, e, s, limit, &lang)
             .unwrap();
 
-        let multiframes = MultiFrame::from_frames(nova_prover.reduction_count(), &frames, s, &lang);
+        let multiframes =
+            MultiFrame::from_frames(nova_prover.reduction_count(), &frames, s, lang.clone());
         let len = multiframes.len();
 
         let adjusted_iterations = nova_prover.expected_total_iterations(expected_iterations);
@@ -3447,7 +3451,7 @@ mod tests {
         let expr = s.list(&[fun, input]);
         let res = s.num(10);
         let terminal = s.get_cont_terminal();
-        let lang: Lang<Fr, Coproc<Fr>> = Lang::new();
+        let lang: Arc<Lang<Fr, Coproc<Fr>>> = Arc::new(Lang::new());
 
         nova_test_full_aux2(
             s,
@@ -3460,7 +3464,7 @@ mod tests {
             DEFAULT_REDUCTION_COUNT,
             false,
             None,
-            &lang,
+            lang,
         );
     }
 
@@ -3600,10 +3604,29 @@ mod tests {
 
         let res = s.num(89);
         let error = s.get_cont_error();
+        let lang = Arc::new(lang);
 
-        test_aux(s, &expr, Some(res), None, None, None, 1, Some(&lang));
-        test_aux(s, &expr2, Some(res), None, None, None, 3, Some(&lang));
-        test_aux(s, &expr3, None, None, Some(error), None, 1, Some(&lang));
-        test_aux(s, &expr4, None, None, Some(error), None, 1, Some(&lang));
+        test_aux(s, &expr, Some(res), None, None, None, 1, Some(lang.clone()));
+        test_aux(
+            s,
+            &expr2,
+            Some(res),
+            None,
+            None,
+            None,
+            3,
+            Some(lang.clone()),
+        );
+        test_aux(
+            s,
+            &expr3,
+            None,
+            None,
+            Some(error),
+            None,
+            1,
+            Some(lang.clone()),
+        );
+        test_aux(s, &expr4, None, None, Some(error), None, 1, Some(lang));
     }
 }

--- a/src/public_parameters/error.rs
+++ b/src/public_parameters/error.rs
@@ -1,5 +1,5 @@
+use crate::store;
 use bellperson::SynthesisError;
-use lurk::store;
 use std::io;
 use thiserror::Error;
 

--- a/src/public_parameters/mod.rs
+++ b/src/public_parameters/mod.rs
@@ -1,25 +1,13 @@
-#![doc = include_str!("../README.md")]
-
 use log::info;
-use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fs::File;
 use std::io::{self, BufReader, BufWriter};
 use std::path::Path;
 use std::str::FromStr;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
-use ff::PrimeField;
-use hex::FromHex;
-use libipld::{
-    cbor::DagCborCodec,
-    json::DagJsonCodec,
-    multihash::{Code, MultihashDigest},
-    prelude::Codec,
-    serde::{from_ipld, to_ipld},
-    Cid, Ipld,
-};
-use lurk::{
+use crate::coprocessor::Coprocessor;
+use crate::{
     circuit::ToInputs,
     eval::{
         empty_sym_env,
@@ -35,6 +23,16 @@ use lurk::{
     tag::ExprTag,
     writer::Write,
 };
+use ff::PrimeField;
+use hex::FromHex;
+use libipld::{
+    cbor::DagCborCodec,
+    json::DagJsonCodec,
+    multihash::{Code, MultihashDigest},
+    prelude::Codec,
+    serde::{from_ipld, to_ipld},
+    Cid, Ipld,
+};
 use once_cell::sync::OnceCell;
 use pasta_curves::pallas;
 use rand::rngs::OsRng;
@@ -43,6 +41,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub mod error;
 mod file_map;
+mod registry;
 
 use error::Error;
 use file_map::FileMap;
@@ -56,12 +55,12 @@ mod base64 {
     use serde::{Deserialize, Serialize};
     use serde::{Deserializer, Serializer};
 
-    pub fn serialize<S: Serializer>(v: &Vec<u8>, s: S) -> Result<S::Ok, S::Error> {
+    pub(crate) fn serialize<S: Serializer>(v: &Vec<u8>, s: S) -> Result<S::Ok, S::Error> {
         let base64 = base64::encode(v);
         String::serialize(&base64, s)
     }
 
-    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
+    pub(crate) fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
         let base64 = String::deserialize(d)?;
         base64::decode(base64.as_bytes()).map_err(serde::de::Error::custom)
     }
@@ -69,7 +68,7 @@ mod base64 {
 
 pub type NovaProofCache = FileMap<Cid, Proof<'static, S1>>;
 pub fn nova_proof_cache(reduction_count: usize) -> NovaProofCache {
-    FileMap::<Cid, Proof<S1>>::new(format!("nova_proofs.{}", reduction_count)).unwrap()
+    FileMap::<Cid, Proof<'_, S1>>::new(format!("nova_proofs.{}", reduction_count)).unwrap()
 }
 
 pub type CommittedExpressionMap = FileMap<Commitment<S1>, CommittedExpression<S1>>;
@@ -77,46 +76,12 @@ pub fn committed_expression_store() -> CommittedExpressionMap {
     FileMap::<Commitment<S1>, CommittedExpression<S1>>::new("committed_expressions").unwrap()
 }
 
-pub type PublicParamMemCache = Mutex<HashMap<usize, Arc<PublicParams<'static, Coproc<S1>>>>>;
-fn public_param_mem_cache() -> &'static PublicParamMemCache {
-    static CACHE: OnceCell<PublicParamMemCache> = OnceCell::new();
-    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
-}
-
-pub type PublicParamDiskCache = FileMap<String, PublicParams<'static, Coproc<S1>>>;
-fn public_param_disk_cache() -> PublicParamDiskCache {
-    FileMap::new("public_params").unwrap()
-}
-
-pub fn lang<'a>() -> &'a Lang<S1, Coproc<S1>> {
-    static LANG: OnceCell<Lang<S1, Coproc<S1>>> = OnceCell::new();
-
-    LANG.get_or_init(Lang::<S1, Coproc<S1>>::new)
-}
-
-pub fn public_params(rc: usize) -> Result<Arc<PublicParams<'static, Coproc<S1>>>, Error> {
-    let mut mem_cache = public_param_mem_cache().lock().unwrap();
-    match mem_cache.get(&rc) {
-        Some(pp) => Ok(pp.clone()),
-        None => {
-            let disk_cache = public_param_disk_cache();
-            // TODO: Add versioning to cache key
-            let key = format!("public-params-rc-{rc}");
-            if let Some(pp) = disk_cache.get(&key) {
-                let pp = Arc::new(pp);
-                mem_cache.insert(rc, pp.clone());
-                Ok(pp)
-            } else {
-                let lang = lang();
-                let pp = Arc::new(nova::public_params(rc, lang));
-                mem_cache.insert(rc, pp.clone());
-                disk_cache
-                    .set(key, &pp)
-                    .map_err(|e| Error::CacheError(format!("Disk write error: {e}")))?;
-                Ok(pp)
-            }
-        }
-    }
+pub fn public_params<C: Coprocessor<S1> + Serialize + DeserializeOwned + 'static>(
+    rc: usize,
+    lang: Arc<Lang<S1, C>>,
+) -> Result<Arc<PublicParams<'static, C>>, Error> {
+    let f = |lang: Arc<Lang<S1, C>>| Arc::new(nova::public_params(rc, lang));
+    registry::CACHE_REG.get_coprocessor_or_update_with(rc, f, lang)
 }
 
 // Number of circuit reductions per step, equivalent to `chunk_frame_count`
@@ -690,7 +655,7 @@ impl LurkCont {
         _s: &mut Store<F>,
         cont_ptr: &ContPtr<F>,
     ) -> Self {
-        use lurk::tag::ContTag;
+        use crate::tag::ContTag;
 
         match cont_ptr.tag {
             ContTag::Outermost => Self::Outermost,
@@ -725,10 +690,10 @@ impl<'a> Opening<S1> {
         chain: bool,
         only_use_cached_proofs: bool,
         nova_prover: &'a NovaProver<S1, Coproc<S1>>,
-        pp: &'a PublicParams<Coproc<S1>>,
-        lang: &'a Lang<S1, Coproc<S1>>,
+        pp: &'a PublicParams<'_, Coproc<S1>>,
+        lang: Arc<Lang<S1, Coproc<S1>>>,
     ) -> Result<Proof<'a, S1>, Error> {
-        let claim = Self::apply(s, input, function, limit, chain, lang)?;
+        let claim = Self::apply(s, input, function, limit, chain, &lang)?;
         Proof::prove_claim(
             s,
             &claim,
@@ -746,10 +711,10 @@ impl<'a> Opening<S1> {
         limit: usize,
         only_use_cached_proofs: bool,
         nova_prover: &'a NovaProver<S1, Coproc<S1>>,
-        pp: &'a PublicParams<Coproc<S1>>,
-        lang: &'a Lang<S1, Coproc<S1>>,
+        pp: &'a PublicParams<'_, Coproc<S1>>,
+        lang: Arc<Lang<S1, Coproc<S1>>>,
     ) -> Result<Proof<'a, S1>, Error> {
-        let input = request.input.expr.ptr(s, limit, lang);
+        let input = request.input.expr.ptr(s, limit, &lang);
         let commitment = request.commitment;
 
         let function_map = committed_expression_store();
@@ -847,7 +812,7 @@ impl<'a> Opening<S1> {
 
         let input_string = input.fmt_to_string(s);
         let status =
-            <lurk::eval::IO<S1> as Evaluable<S1, Witness<S1>, Coproc<S1>>>::status(&public_output);
+            <crate::eval::IO<S1> as Evaluable<S1, Witness<S1>, Coproc<S1>>>::status(&public_output);
         let output_string = if status.is_terminal() {
             // Only actual output if result is terminal.
             output_expr.fmt_to_string(s)
@@ -879,8 +844,8 @@ impl<'a> Proof<'a, S1> {
         limit: usize,
         only_use_cached_proofs: bool,
         nova_prover: &'a NovaProver<S1, Coproc<S1>>,
-        pp: &'a PublicParams<Coproc<S1>>,
-        lang: &'a Lang<S1, Coproc<S1>>,
+        pp: &'a PublicParams<'_, Coproc<S1>>,
+        lang: Arc<Lang<S1, Coproc<S1>>>,
     ) -> Result<Self, Error> {
         let env = supplied_env.unwrap_or_else(|| empty_sym_env(s));
         let cont = s.intern_cont_outermost();
@@ -888,7 +853,7 @@ impl<'a> Proof<'a, S1> {
 
         // TODO: It's a little silly that we evaluate here, but evaluation is also repeated in `NovaProver::evaluate_and_prove()`.
         // Refactor to avoid that.
-        let (public_output, _iterations) = evaluate(s, expr, supplied_env, limit, lang)?;
+        let (public_output, _iterations) = evaluate(s, expr, supplied_env, limit, &lang)?;
 
         let claim = if supplied_env.is_some() {
             // This is a bit of a hack, but the idea is that if the env was supplied it's likely to contain a literal function,
@@ -917,8 +882,8 @@ impl<'a> Proof<'a, S1> {
         limit: usize,
         only_use_cached_proofs: bool,
         nova_prover: &'a NovaProver<S1, Coproc<S1>>,
-        pp: &'a PublicParams<Coproc<S1>>,
-        lang: &'a Lang<S1, Coproc<S1>>,
+        pp: &'a PublicParams<'_, Coproc<S1>>,
+        lang: Arc<Lang<S1, Coproc<S1>>>,
     ) -> Result<Self, Error> {
         let reduction_count = nova_prover.reduction_count();
 
@@ -943,7 +908,7 @@ impl<'a> Proof<'a, S1> {
                 s.read(&e.expr).expect("bad expression"),
                 s.read(&e.env).expect("bad env"),
             ),
-            Claim::PtrEvaluation(e) => (e.expr.ptr(s, limit, lang), e.env.ptr(s, limit, lang)),
+            Claim::PtrEvaluation(e) => (e.expr.ptr(s, limit, &lang), e.env.ptr(s, limit, &lang)),
             Claim::Opening(o) => {
                 let commitment = o.commitment;
 
@@ -954,7 +919,7 @@ impl<'a> Proof<'a, S1> {
 
                 let input = s.read(&o.input).expect("bad expression");
                 let (c, expression) =
-                    Commitment::construct_with_fun_application(s, function, input, limit, lang)?;
+                    Commitment::construct_with_fun_application(s, function, input, limit, &lang)?;
 
                 assert_eq!(commitment, c);
                 (expression, empty_sym_env(s))
@@ -962,7 +927,7 @@ impl<'a> Proof<'a, S1> {
         };
 
         let (proof, _public_input, _public_output, num_steps) = nova_prover
-            .evaluate_and_prove(pp, expr, env, s, limit, lang)
+            .evaluate_and_prove(pp, expr, env, s, limit, lang.clone())
             .expect("Nova proof failed");
 
         let proof = Self {
@@ -990,7 +955,7 @@ impl<'a> Proof<'a, S1> {
             }
         };
 
-        proof.verify(pp, lang).expect("Nova verification failed");
+        proof.verify(pp, &lang).expect("Nova verification failed");
 
         proof_map.set(cid, &proof).unwrap();
 
@@ -999,7 +964,7 @@ impl<'a> Proof<'a, S1> {
 
     pub fn verify(
         &self,
-        pp: &PublicParams<Coproc<S1>>,
+        pp: &PublicParams<'_, Coproc<S1>>,
         lang: &Lang<S1, Coproc<S1>>,
     ) -> Result<VerificationResult, Error> {
         let (public_inputs, public_outputs) = self.io_vecs(lang)?;
@@ -1169,7 +1134,11 @@ pub fn evaluate<F: LurkField>(
 
     let (io, iterations, _) = evaluator.eval().map_err(|_| Error::EvaluationFailure)?;
 
-    assert!(<lurk::eval::IO<F> as Evaluable<F, Witness<F>, Coproc<F>>>::is_terminal(&io));
+    assert!(<crate::eval::IO<F> as Evaluable<
+        F,
+        Witness<F>,
+        Coproc<F>,
+    >>::is_terminal(&io));
     Ok((io, iterations))
 }
 

--- a/src/public_parameters/registry.rs
+++ b/src/public_parameters/registry.rs
@@ -1,0 +1,91 @@
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    sync::{Arc, Mutex},
+};
+
+use once_cell::sync::Lazy;
+use pasta_curves::pallas;
+use serde::{de::DeserializeOwned, Serialize};
+use tap::TapFallible;
+
+use crate::public_parameters::Error;
+use crate::{coprocessor::Coprocessor, eval::lang::Lang, proof::nova::PublicParams};
+
+use super::file_map::FileIndex;
+
+type S1 = pallas::Scalar;
+type AnyMap = anymap::Map<dyn anymap::any::Any + Send + Sync>;
+type PublicParamMemCache<C> = HashMap<usize, Arc<PublicParams<'static, C>>>;
+
+/// This is a global registry for Coproc-specific parameters.
+/// It is used to cache parameters for each Coproc, so that they are not
+/// re-initialized on each call to `eval`.
+/// The use of AnyMap is a workaround for the fact that we need static storage for generic parameters,
+/// noting that this is not possible in Rust.
+#[derive(Clone)]
+pub(crate) struct Registry {
+    registry: Arc<Mutex<AnyMap>>,
+}
+
+pub(crate) static CACHE_REG: Lazy<Registry> = Lazy::new(|| Registry {
+    registry: Arc::new(Mutex::new(AnyMap::new())),
+});
+
+impl Registry {
+    fn get_from_file_cache_or_update_with<
+        C: Coprocessor<S1> + Serialize + DeserializeOwned + 'static,
+        F: FnOnce(Arc<Lang<S1, C>>) -> Arc<PublicParams<'static, C>>,
+    >(
+        &'static self,
+        rc: usize,
+        default: F,
+        lang: Arc<Lang<S1, C>>,
+    ) -> Result<Arc<PublicParams<'static, C>>, Error> {
+        // subdirectory search
+        let disk_cache = FileIndex::new("public_params").unwrap();
+        // use the cached language key
+        let lang_key = lang.key();
+        // Sanity-check: we're about to use a lang-dependent disk cache, which should be specialized
+        // for this lang/coprocessor.
+        let key = format!("public-params-rc-{rc}-coproc-{lang_key}");
+        // read the file if it exists, otherwise initialize
+        if let Some(pp) = disk_cache.get::<PublicParams<'static, C>>(&key) {
+            eprintln!("Using disk-cached public params for lang {}", lang_key);
+            Ok(Arc::new(pp))
+        } else {
+            let pp = default(lang);
+            disk_cache
+                .set(key, &*pp)
+                .tap_ok(|_| eprintln!("Writing public params to disk-cache: {}", lang_key))
+                .map_err(|e| Error::CacheError(format!("Disk write error: {e}")))?;
+            Ok(pp)
+        }
+    }
+
+    /// Check if params for this Coproc are in registry, if so, return them.
+    /// Otherwise, initialize with the passed in function.
+    pub(crate) fn get_coprocessor_or_update_with<
+        C: Coprocessor<S1> + Serialize + DeserializeOwned + 'static,
+        F: FnOnce(Arc<Lang<S1, C>>) -> Arc<PublicParams<'static, C>>,
+    >(
+        &'static self,
+        rc: usize,
+        default: F,
+        lang: Arc<Lang<S1, C>>,
+    ) -> Result<Arc<PublicParams<'static, C>>, Error> {
+        // re-grab the lock
+        let mut registry = self.registry.lock().unwrap();
+        // retrieve the per-Coproc public param table
+        let entry = registry.entry::<PublicParamMemCache<C>>();
+        // deduce the map and populate it if needed
+        let param_entry = entry.or_insert_with(HashMap::new);
+        match param_entry.entry(rc) {
+            Entry::Occupied(o) => Ok(o.into_mut()),
+            Entry::Vacant(v) => {
+                let val = self.get_from_file_cache_or_update_with(rc, default, lang)?;
+                Ok(v.insert(val))
+            }
+        }
+        .cloned()
+    }
+}

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -28,6 +28,7 @@ use std::marker::PhantomData;
 use std::path::Path;
 #[cfg(not(target_arch = "wasm32"))]
 use std::path::PathBuf;
+use std::sync::Arc;
 use tap::TapOptional;
 
 #[derive(Completer, Helper, Highlighter, Hinter)]
@@ -46,7 +47,7 @@ pub struct ReplState<F: LurkField, C: Coprocessor<F>> {
     pub env: Ptr<F>,
     pub limit: usize,
     pub command: Option<Command>,
-    pub lang: Lang<F, C>,
+    pub lang: Arc<Lang<F, C>>,
 }
 
 pub struct Repl<F: LurkField, T: ReplTrait<F, C>, C: Coprocessor<F>> {
@@ -309,7 +310,7 @@ impl<F: LurkField, C: Coprocessor<F>> ReplState<F, C> {
             env: empty_sym_env(s),
             limit,
             command,
-            lang,
+            lang: Arc::new(lang),
         }
     }
     pub fn eval_expr(
@@ -340,7 +341,7 @@ impl<F: LurkField, C: Coprocessor<F>> ReplTrait<F, C> for ReplState<F, C> {
             env: empty_sym_env(s),
             limit,
             command,
-            lang,
+            lang: Arc::new(lang),
         }
     }
 


### PR DESCRIPTION
The main purpose of this PR is to include a benchmark that matches those in the https://github.com/celer-network/zk-benchmark repository.

To run the benchmark run `cargo run --example sha256 1 f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b false` in the terminal.

The expected output is `T` when the input hex number equals the expected hash, together with timing information for each step of the proof generation and verification.

To achieve the above goal a number of changes in the larger repository are made:
* Define a SHA256 coprocessor using the bellperson SHA256 circuit.
* Fix a bug with coprocessors with arity 0 not evaluating correctly.
* Change the expected reduction count steps for associated tests.
* Change the visibility of some modules so they can be used in an example.

The major (ongoing) change is that related to moving the public parameter and proof caching mechanism from `fcomm` to lurk core. This is a WIP and has not been incorporated into the example yet. 

As such, it may be in your best interest to run the benchmark with reduction count 1 to minimize the setup phase until the changes are finished.

Fixes #382 