### PR TITLE
refactor: add a generic static registry for Langs & PublicParams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
+name = "anymap"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33954243bd79057c2de7338850b85983a44588021f8a5fee574a8888c6de4344"
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,7 +538,6 @@ dependencies = [
  "assert_cmd",
  "blstrs",
  "clap 4.2.4",
- "fcomm",
  "fil_pasta_curves",
  "lurk",
  "pretty_env_logger",
@@ -1358,6 +1363,7 @@ version = "0.2.0"
 dependencies = [
  "ahash",
  "anyhow",
+ "anymap",
  "assert_cmd",
  "base64",
  "bellperson",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ pretty_env_logger = "0.4"
 rand_core = { version = "0.6.4", default-features = false }
 rayon = "1.7.0"
 rustyline-derive = "0.8.0"
+rand = "0.8"
 rand_xorshift = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
@@ -48,6 +49,7 @@ num-traits = "0.2.15"
 nom = "7.1.3"
 clap = "4.1.8"
 tap = "1.0.1"
+anymap = "0.12.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 memmap = { version = "0.5.10", package = "memmap2" }
@@ -104,9 +106,3 @@ codegen-units = 16
 # being off (they test release behavior in case of duplicate clauses).
 inherits = "dev-ci"
 debug-assertions = false
-
-[source.crates-io]
-replace-with = "vendored-sources"
-
-[source.vendored-sources]
-directory = "vendor"

--- a/clutch/Cargo.toml
+++ b/clutch/Cargo.toml
@@ -13,7 +13,6 @@ repository = "https://github.com/lurk-lab/lurk-rs"
 anyhow = "1.0.69"
 blstrs = "0.6.1"
 clap = "4.1.8"
-fcomm = { path = "../fcomm" }
 lurk = { path = "../" }
 pasta_curves = { version = "0.5.2", features = ["repr-c", "serde"], package = "fil_pasta_curves" }
 pretty_env_logger = "0.4"

--- a/clutch/src/lib.rs
+++ b/clutch/src/lib.rs
@@ -2,12 +2,12 @@
 
 use anyhow::{anyhow, bail, Context, Result};
 use clap::{Arg, ArgAction, Command};
-use pasta_curves::pallas;
-
 use lurk::public_parameters::{
     public_params, Claim, Commitment, CommittedExpression, CommittedExpressionMap, Id, LurkCont,
     LurkPtr, NovaProofCache, Opening, Proof, PtrEvaluation,
 };
+use pasta_curves::pallas;
+
 use lurk::coprocessor::Coprocessor;
 use lurk::eval::{
     lang::{Coproc, Lang},
@@ -27,6 +27,7 @@ use lurk::writer::Write;
 use std::fs::File;
 use std::io::{self, BufRead};
 use std::path::Path;
+use std::sync::Arc;
 use std::thread;
 
 const DEFAULT_REDUCTION_COUNT: usize = 10;
@@ -133,8 +134,9 @@ impl ReplTrait<F, Coproc<F>> for ClutchState<F, Coproc<F>> {
                 .map(|demo_file| Demo::new_from_path(demo_file, l))
         });
 
+        let lang_rc = Arc::new(lang.clone());
         // Load params from disk cache, or generate them in the background.
-        thread::spawn(move || public_params(reduction_count));
+        thread::spawn(move || public_params(reduction_count, lang_rc));
 
         Self {
             repl_state: ReplState::new(s, limit, command, lang),
@@ -275,8 +277,8 @@ impl<F: LurkField, C: Coprocessor<F>> ClutchState<F, C> {
 }
 
 impl ClutchState<F, Coproc<F>> {
-    fn lang(&self) -> &Lang<F, Coproc<F>> {
-        &self.repl_state.lang
+    fn lang(&self) -> Arc<Lang<F, Coproc<F>>> {
+        self.repl_state.lang.clone()
     }
     fn commit(&mut self, store: &mut Store<F>, rest: Ptr<F>) -> Result<Option<Ptr<F>>> {
         let (first, rest) = store.car_cdr(&rest)?;
@@ -433,7 +435,7 @@ impl ClutchState<F, Coproc<F>> {
 
         let commitment_expr = self.expression_map.get(&commitment);
         let commitment_ptr = commitment_expr.map(|c| {
-            let ptr = c.expr.ptr(store, self.repl_state.limit, self.lang());
+            let ptr = c.expr.ptr(store, self.repl_state.limit, &self.lang());
 
             if let Some(secret) = c.secret {
                 store.intern_comm(secret, ptr);
@@ -449,7 +451,7 @@ impl ClutchState<F, Coproc<F>> {
 
     fn proof_in_expr(&self, store: &mut Store<F>, rest: Ptr<F>) -> Result<Option<Ptr<F>>> {
         let proof = self.get_proof(store, rest)?;
-        let (input, _output) = proof.io(store, self.lang())?;
+        let (input, _output) = proof.io(store, &self.lang())?;
 
         let mut handle = io::stdout().lock();
         input.expr.fmt(store, &mut handle)?;
@@ -458,7 +460,7 @@ impl ClutchState<F, Coproc<F>> {
     }
     fn proof_out_expr(&self, store: &mut Store<F>, rest: Ptr<F>) -> Result<Option<Ptr<F>>> {
         let proof = self.get_proof(store, rest)?;
-        let (_input, output) = proof.io(store, self.lang())?;
+        let (_input, output) = proof.io(store, &self.lang())?;
 
         let mut handle = io::stdout().lock();
         output.expr.fmt(store, &mut handle)?;
@@ -492,8 +494,8 @@ impl ClutchState<F, Coproc<F>> {
     fn prove(&mut self, store: &mut Store<F>, rest: Ptr<F>) -> Result<Option<Ptr<F>>> {
         let (proof_in_expr, _rest1) = store.car_cdr(&rest)?;
 
-        let prover = NovaProver::<F, Coproc<F>>::new(self.reduction_count, self.lang().clone());
-        let pp = public_params(self.reduction_count)?;
+        let prover = NovaProver::<F, Coproc<F>>::new(self.reduction_count, (*self.lang()).clone());
+        let pp = public_params(self.reduction_count, self.lang())?;
 
         let proof = if rest.is_nil() {
             self.last_claim
@@ -523,7 +525,7 @@ impl ClutchState<F, Coproc<F>> {
             )
         }?;
 
-        if proof.verify(&pp, self.lang())?.verified {
+        if proof.verify(&pp, &self.lang())?.verified {
             let cid_str = proof.claim.cid().to_string();
             match proof.claim {
                 Claim::Evaluation(_) | Claim::Opening(_) => println!("{0:#?}", proof.claim),
@@ -554,8 +556,8 @@ impl ClutchState<F, Coproc<F>> {
             .get(&cid)
             .ok_or_else(|| anyhow!("proof not found: {cid}"))?;
 
-        let pp = public_params(self.reduction_count)?;
-        let result = proof.verify(&pp, self.lang()).unwrap();
+        let pp = public_params(self.reduction_count, self.lang())?;
+        let result = proof.verify(&pp, &self.lang()).unwrap();
 
         if result.verified {
             Ok(Some(store.get_t()))

--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -11,11 +11,13 @@ use bellperson::gadgets::sha256::sha256;
 use bellperson::{ConstraintSystem, SynthesisError};
 use itertools::enumerate;
 use lurk::circuit::gadgets::data::GlobalAllocations;
-use lurk::proof::nova::{public_params, NovaProver};
+use lurk::proof::nova::NovaProver;
+use lurk::public_parameters::public_params;
 // use bellperson::gadgets::Assignment;
 use lurk::tag::{ExprTag, Tag};
 use lurk_macros::Coproc;
 use pasta_curves::pallas::Scalar as Fr;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use lurk::circuit::gadgets::pointer::{AllocatedContPtr, AllocatedPtr};
@@ -32,7 +34,7 @@ use lurk::sym::Sym;
 
 const REDUCTION_COUNT: usize = 10;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct Sha256Coprocessor<F: LurkField> {
     n: usize,
     pub(crate) _p: PhantomData<F>,
@@ -127,7 +129,7 @@ impl<F: LurkField> Sha256Coprocessor<F> {
     }
 }
 
-#[derive(Clone, Debug, Coproc)]
+#[derive(Clone, Debug, Coproc, Serialize, Deserialize)]
 enum Sha256Coproc<F: LurkField> {
     SC(Sha256Coprocessor<F>),
 }
@@ -170,7 +172,7 @@ fn main() {
     println!("Setting up public parameters...");
 
     let pp_start = Instant::now();
-    let pp = public_params(REDUCTION_COUNT, lang_rc.clone());
+    let pp = public_params::<Sha256Coproc<Fr>>(REDUCTION_COUNT, lang_rc.clone()).unwrap();
     let pp_end = pp_start.elapsed();
 
     println!("Public parameters took {:?}", pp_end);

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -39,6 +39,7 @@ use crate::tag::{ContTag, ExprTag, Op1, Op2};
 use num_bigint::BigUint;
 use num_integer::Integer;
 use num_traits::FromPrimitive;
+use std::sync::Arc;
 
 #[derive(Clone, Copy, Debug)]
 pub struct CircuitFrame<'a, F: LurkField, T, W, C: Coprocessor<F>> {
@@ -52,7 +53,7 @@ pub struct CircuitFrame<'a, F: LurkField, T, W, C: Coprocessor<F>> {
 #[derive(Clone)]
 pub struct MultiFrame<'a, F: LurkField, T: Copy, W, C: Coprocessor<F>> {
     pub store: Option<&'a Store<F>>,
-    pub lang: Option<&'a Lang<F, C>>,
+    pub lang: Option<Arc<Lang<F, C>>>,
     pub input: Option<T>,
     pub output: Option<T>,
     pub frames: Option<Vec<CircuitFrame<'a, F, T, W, C>>>,
@@ -84,7 +85,7 @@ impl<'a, F: LurkField, T: Clone + Copy, W: Copy, C: Coprocessor<F>> CircuitFrame
 impl<'a, F: LurkField, T: Clone + Copy + std::cmp::PartialEq, W: Copy, C: Coprocessor<F>>
     MultiFrame<'a, F, T, W, C>
 {
-    pub fn blank(count: usize, lang: &'a Lang<F, C>) -> Self {
+    pub fn blank(count: usize, lang: Arc<Lang<F, C>>) -> Self {
         Self {
             store: None,
             lang: Some(lang),
@@ -103,7 +104,7 @@ impl<'a, F: LurkField, T: Clone + Copy + std::cmp::PartialEq, W: Copy, C: Coproc
         count: usize,
         frames: &[Frame<T, W, C>],
         store: &'a Store<F>,
-        lang: &'a Lang<F, C>,
+        lang: Arc<Lang<F, C>>,
     ) -> Vec<Self> {
         // `count` is the number of `Frames` to include per `MultiFrame`.
         let total_frames = frames.len();
@@ -134,7 +135,7 @@ impl<'a, F: LurkField, T: Clone + Copy + std::cmp::PartialEq, W: Copy, C: Coproc
 
             let mf = MultiFrame {
                 store: Some(store),
-                lang: Some(lang),
+                lang: Some(lang.clone()),
                 input: Some(chunk[0].input),
                 output: Some(output),
                 frames: Some(inner_frames),
@@ -152,7 +153,7 @@ impl<'a, F: LurkField, T: Clone + Copy + std::cmp::PartialEq, W: Copy, C: Coproc
         count: usize,
         circuit_frame: Option<CircuitFrame<'a, F, T, W, C>>,
         store: &'a Store<F>,
-        lang: &'a Lang<F, C>,
+        lang: Arc<Lang<F, C>>,
     ) -> Self {
         let (frames, input, output) = if let Some(circuit_frame) = circuit_frame {
             (
@@ -223,7 +224,13 @@ impl<'a, F: LurkField, T: Clone + Copy + std::cmp::PartialEq, W: Copy, C: Coproc
                 (
                     i + 1,
                     frame
-                        .synthesize(cs, i, allocated_io, self.lang.expect("Lang missing"), g)
+                        .synthesize(
+                            cs,
+                            i,
+                            allocated_io,
+                            self.lang.as_ref().expect("Lang missing"),
+                            g,
+                        )
                         .unwrap(),
                 )
             });
@@ -5345,16 +5352,17 @@ mod tests {
             env,
             cont: store.intern_cont_outermost(),
         };
-        let lang = Lang::<Fr, Coproc<Fr>>::new();
+        let raw_lang = Lang::<Fr, Coproc<Fr>>::new();
+        let lang = Arc::new(raw_lang.clone());
         let (_, witness) = input.reduce(&mut store, &lang).unwrap();
 
         let public_params = Groth16Prover::<Bls12, Coproc<Fr>, Fr>::create_groth_params(
             DEFAULT_REDUCTION_COUNT,
-            &lang,
+            lang.clone(),
         )
         .unwrap();
         let groth_prover =
-            Groth16Prover::<Bls12, Coproc<Fr>, Fr>::new(DEFAULT_REDUCTION_COUNT, lang.clone());
+            Groth16Prover::<Bls12, Coproc<Fr>, Fr>::new(DEFAULT_REDUCTION_COUNT, raw_lang);
         let groth_params = &public_params.0;
 
         let vk = &groth_params.vk;
@@ -5367,7 +5375,7 @@ mod tests {
             let mut cs_blank = MetricCS::<Fr>::new();
             let blank_multiframe = MultiFrame::<<Bls12 as Engine>::Fr, _, _, Coproc<Fr>>::blank(
                 DEFAULT_REDUCTION_COUNT,
-                &lang,
+                lang.clone(),
             );
 
             blank_multiframe
@@ -5384,7 +5392,7 @@ mod tests {
                     _p: Default::default(),
                 }],
                 store,
-                &lang,
+                lang.clone(),
             );
 
             let multiframe = &multiframes[0];
@@ -5481,7 +5489,7 @@ mod tests {
             cont: store.intern_cont_outermost(),
         };
 
-        let lang = Lang::<Fr, Coproc<Fr>>::new();
+        let lang = Arc::new(Lang::<Fr, Coproc<Fr>>::new());
         let (_, witness) = input.reduce(&mut store, &lang).unwrap();
         store.hydrate_scalar_cache();
 
@@ -5500,7 +5508,7 @@ mod tests {
                 DEFAULT_REDUCTION_COUNT,
                 &[frame],
                 store,
-                &lang,
+                lang.clone(),
             )[0]
             .clone()
             .synthesize(&mut cs)
@@ -5562,7 +5570,7 @@ mod tests {
             cont: store.intern_cont_outermost(),
         };
 
-        let lang = Lang::<Fr, Coproc<Fr>>::new();
+        let lang = Arc::new(Lang::<Fr, Coproc<Fr>>::new());
         let (_, witness) = input.reduce(&mut store, &lang).unwrap();
         store.hydrate_scalar_cache();
 
@@ -5581,7 +5589,7 @@ mod tests {
                 DEFAULT_REDUCTION_COUNT,
                 &[frame],
                 store,
-                &lang,
+                lang.clone(),
             )[0]
             .clone()
             .synthesize(&mut cs)
@@ -5643,7 +5651,7 @@ mod tests {
             cont: store.intern_cont_outermost(),
         };
 
-        let lang = Lang::<Fr, Coproc<Fr>>::new();
+        let lang = Arc::new(Lang::<Fr, Coproc<Fr>>::new());
         let (_, witness) = input.reduce(&mut store, &lang).unwrap();
 
         store.hydrate_scalar_cache();
@@ -5663,7 +5671,7 @@ mod tests {
                 DEFAULT_REDUCTION_COUNT,
                 &[frame],
                 store,
-                &lang,
+                lang.clone(),
             )[0]
             .clone()
             .synthesize(&mut cs)
@@ -5726,7 +5734,7 @@ mod tests {
             cont: store.intern_cont_outermost(),
         };
 
-        let lang = Lang::<Fr, Coproc<Fr>>::new();
+        let lang = Arc::new(Lang::<Fr, Coproc<Fr>>::new());
         let (_, witness) = input.reduce(&mut store, &lang).unwrap();
 
         store.hydrate_scalar_cache();
@@ -5746,7 +5754,7 @@ mod tests {
                 DEFAULT_REDUCTION_COUNT,
                 &[frame],
                 store,
-                &lang,
+                lang.clone(),
             )[0]
             .clone()
             .synthesize(&mut cs)

--- a/src/coprocessor.rs
+++ b/src/coprocessor.rs
@@ -2,12 +2,12 @@ use std::fmt::Debug;
 
 use bellperson::{ConstraintSystem, SynthesisError};
 
+use crate::circuit::gadgets::data::GlobalAllocations;
 use crate::circuit::gadgets::pointer::{AllocatedContPtr, AllocatedPtr};
 use crate::eval::IO;
 use crate::field::LurkField;
 use crate::ptr::{ContPtr, Ptr};
 use crate::store::Store;
-use crate::circuit::gadgets::data::GlobalAllocations;
 
 /// `Coprocessor` is a trait that represents a generalized interface for coprocessors.
 /// Coprocessors augment the Lurk circuit and evaluation with additional built-in functionality.
@@ -82,13 +82,15 @@ pub trait CoCircuit<F: LurkField>: Send + Sync + Clone {
 
 #[cfg(test)]
 pub(crate) mod test {
+    use serde::{Deserialize, Serialize};
+
     use super::*;
     use crate::circuit::gadgets::constraints::{add, mul};
     use crate::tag::{ExprTag, Tag};
     use std::marker::PhantomData;
 
     /// A dumb Coprocessor for testing.
-    #[derive(Clone, Debug)]
+    #[derive(Clone, Debug, Serialize, Deserialize)]
     pub(crate) struct DumbCoprocessor<F: LurkField> {
         pub(crate) _p: PhantomData<F>,
     }

--- a/src/eval/lang.rs
+++ b/src/eval/lang.rs
@@ -94,10 +94,11 @@ impl<F: LurkField, C: Coprocessor<F>> Lang<F, C> {
         for coprocessor in &self.coprocessors {
             let name = match coprocessor.0 {
                 Sym::Sym(sym) => &sym.path,
-                Sym::Key(sym) => &sym.path
-            }.join("-");
+                Sym::Key(sym) => &sym.path,
+            }
+            .join("-");
 
-            key = key + name.as_str()
+            key += name.as_str()
         }
         key
     }

--- a/src/eval/reduction.rs
+++ b/src/eval/reduction.rs
@@ -552,7 +552,10 @@ fn reduce_with_witness_inner<F: LurkField, C: Coprocessor<F>>(
                             let IO { expr, env, cont } =
                                 coprocessor.evaluate(store, args, env, cont);
 
-                            return Ok((Control::ApplyContinuation(expr, env, cont), closure_to_extend));
+                            return Ok((
+                                Control::ApplyContinuation(expr, env, cont),
+                                closure_to_extend,
+                            ));
                         };
 
                         // `fun_form` must be a function or potentially evaluate to one.

--- a/src/eval/tests/mod.rs
+++ b/src/eval/tests/mod.rs
@@ -2564,7 +2564,7 @@ pub(crate) mod coproc {
     use super::super::lang::Lang;
     use super::super::*;
     use super::*;
-    use crate::coprocessor::{test::DumbCoprocessor};
+    use crate::coprocessor::test::DumbCoprocessor;
     use crate::store::Store;
     use crate::sym::Sym;
 
@@ -2573,7 +2573,6 @@ pub(crate) mod coproc {
         DC(DumbCoprocessor<F>),
     }
 
-        
     #[test]
     fn test_dumb_lang() {
         let s = &mut Store::<Fr>::new();

--- a/src/proof/groth16.rs
+++ b/src/proof/groth16.rs
@@ -20,6 +20,7 @@ use pairing_lib::{Engine, MultiMillerLoop};
 use rand_core::{RngCore, SeedableRng};
 use rand_xorshift::XorShiftRng;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 use crate::circuit::MultiFrame;
 use crate::coprocessor::Coprocessor;
@@ -102,7 +103,7 @@ impl<C: Coprocessor<Scalar>> Groth16Prover<Bls12, C, Scalar> {
     /// Creates Groth16 parameters using the given reduction count.
     pub fn create_groth_params(
         reduction_count: usize,
-        lang: &Lang<Scalar, C>,
+        lang: Arc<Lang<Scalar, C>>,
     ) -> Result<PublicParams<Bls12>, SynthesisError> {
         let multiframe: MultiFrame<'_, Scalar, IO<Scalar>, Witness<Scalar>, C> =
             MultiFrame::blank(reduction_count, lang);
@@ -138,13 +139,14 @@ impl<C: Coprocessor<Scalar>> Groth16Prover<Bls12, C, Scalar> {
         store: &mut Store<Scalar>,
         limit: usize,
         mut rng: R,
-        lang: &Lang<Scalar, C>,
+        lang: Arc<Lang<Scalar, C>>,
     ) -> Result<(Proof<Bls12>, IO<Scalar>, IO<Scalar>), ProofError> {
         let padding_predicate = |count| self.needs_frame_padding(count);
-        let frames = Evaluator::generate_frames(expr, env, store, limit, padding_predicate, lang)?;
+        let frames = Evaluator::generate_frames(expr, env, store, limit, padding_predicate, &lang)?;
         store.hydrate_scalar_cache();
 
-        let multiframes = MultiFrame::from_frames(self.reduction_count(), &frames, store, lang);
+        let multiframes =
+            MultiFrame::from_frames(self.reduction_count(), &frames, store, lang.clone());
         let mut proofs = Vec::with_capacity(multiframes.len());
         let mut statements = Vec::with_capacity(multiframes.len());
 
@@ -389,8 +391,12 @@ mod tests {
     ) {
         let rng = OsRng;
 
-        let public_params =
-            Groth16Prover::<_, C, Fr>::create_groth_params(DEFAULT_REDUCTION_COUNT, &lang).unwrap();
+        let lang_rc = Arc::new(lang.clone());
+        let public_params = Groth16Prover::<_, C, Fr>::create_groth_params(
+            DEFAULT_REDUCTION_COUNT,
+            lang_rc.clone(),
+        )
+        .unwrap();
         let groth_prover = Groth16Prover::new(DEFAULT_REDUCTION_COUNT, lang.clone());
         let groth_params = &public_params.0;
 
@@ -404,7 +410,8 @@ mod tests {
                 Evaluator::generate_frames(expr, e, s, limit, padding_predicate, &lang).unwrap();
             s.hydrate_scalar_cache();
 
-            let multi_frames = MultiFrame::from_frames(DEFAULT_REDUCTION_COUNT, &frames, s, &lang);
+            let multi_frames =
+                MultiFrame::from_frames(DEFAULT_REDUCTION_COUNT, &frames, s, lang_rc.clone());
 
             let cs = groth_prover.outer_synthesize(&multi_frames).unwrap();
 
@@ -425,7 +432,7 @@ mod tests {
             let constraint_systems_verified = verify_sequential_css::<Scalar, C>(&cs).unwrap();
             assert!(constraint_systems_verified);
 
-            check_cs_deltas(&cs, limit, &lang);
+            check_cs_deltas(&cs, limit, lang_rc.clone());
         }
 
         let proof_results = if check_groth16 {
@@ -439,7 +446,7 @@ mod tests {
                         s,
                         limit,
                         rng,
-                        &lang,
+                        lang_rc,
                     )
                     .unwrap(),
             )
@@ -468,7 +475,7 @@ mod tests {
     fn check_cs_deltas<C: Coprocessor<Fr>>(
         constraint_systems: &SequentialCS<'_, Fr, IO<Fr>, Witness<Fr>, C>,
         limit: usize,
-        lang: &Lang<Fr, C>,
+        lang: Arc<Lang<Fr, C>>,
     ) {
         let mut cs_blank = MetricCS::<Fr>::new();
         let blank_frame = MultiFrame::<Scalar, _, _, C>::blank(DEFAULT_REDUCTION_COUNT, lang);

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -14,6 +14,7 @@ use nova::{
 };
 use pasta_curves::{pallas, vesta};
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 use crate::circuit::{
     gadgets::{
@@ -81,10 +82,10 @@ pub enum Proof<'a, C: Coprocessor<S1>> {
 }
 
 /// Generates the public parameters for the Nova proving system.
-pub fn public_params<C: Coprocessor<S1>>(
+pub fn public_params<'a, C: Coprocessor<S1>>(
     num_iters_per_step: usize,
-    lang: &Lang<S1, C>,
-) -> PublicParams<'_, C> {
+    lang: Arc<Lang<S1, C>>,
+) -> PublicParams<'a, C> {
     let (circuit_primary, circuit_secondary) = C1::circuits(num_iters_per_step, lang);
 
     let pp = nova::PublicParams::setup(circuit_primary, circuit_secondary);
@@ -93,7 +94,7 @@ pub fn public_params<C: Coprocessor<S1>>(
 }
 
 impl<'a, C: Coprocessor<S1>> MultiFrame<'a, S1, IO<S1>, Witness<S1>, C> {
-    fn circuits(count: usize, lang: &'a Lang<S1, C>) -> (C1<'a, C>, C2) {
+    fn circuits(count: usize, lang: Arc<Lang<S1, C>>) -> (C1<'a, C>, C2) {
         (
             MultiFrame::blank(count, lang),
             TrivialTestCircuit::default(),
@@ -155,12 +156,13 @@ impl<C: Coprocessor<S1>> NovaProver<S1, C> {
         env: Ptr<S1>,
         store: &'a mut Store<S1>,
         limit: usize,
-        lang: &'a Lang<S1, C>,
+        lang: Arc<Lang<S1, C>>,
     ) -> Result<(Proof<'_, C>, Vec<S1>, Vec<S1>, usize), ProofError> {
-        let frames = self.get_evaluation_frames(expr, env, store, limit, lang)?;
+        let frames = self.get_evaluation_frames(expr, env, store, limit, &lang)?;
         let z0 = frames[0].input.to_vector(store)?;
         let zi = frames.last().unwrap().output.to_vector(store)?;
-        let circuits = MultiFrame::from_frames(self.reduction_count(), &frames, store, lang);
+        let circuits =
+            MultiFrame::from_frames(self.reduction_count(), &frames, store, lang.clone());
         let num_steps = circuits.len();
         let proof =
             Proof::prove_recursively(pp, store, &circuits, self.reduction_count, z0.clone(), lang)?;
@@ -238,7 +240,7 @@ impl<'a: 'b, 'b, C: Coprocessor<S1>> Proof<'a, C> {
         circuits: &[C1<'a, C>],
         num_iters_per_step: usize,
         z0: Vec<S1>,
-        lang: &'a Lang<S1, C>,
+        lang: Arc<Lang<S1, C>>,
     ) -> Result<Self, ProofError> {
         assert!(!circuits.is_empty());
         assert_eq!(circuits[0].arity(), z0.len());
@@ -371,7 +373,7 @@ pub mod tests {
         expected_cont: Option<ContPtr<Fr>>,
         expected_emitted: Option<Vec<Ptr<Fr>>>,
         expected_iterations: usize,
-        lang: Option<&Lang<Fr, C>>,
+        lang: Option<Arc<Lang<Fr, C>>>,
     ) {
         for chunk_size in REDUCTION_COUNTS_TO_TEST {
             nova_test_full_aux(
@@ -385,7 +387,7 @@ pub mod tests {
                 chunk_size,
                 false,
                 None,
-                lang,
+                lang.clone(),
             )
         }
     }
@@ -401,7 +403,7 @@ pub mod tests {
         reduction_count: usize,
         check_nova: bool,
         limit: Option<usize>,
-        lang: Option<&Lang<Fr, C>>,
+        lang: Option<Arc<Lang<Fr, C>>>,
     ) {
         let expr = s.read(expr).unwrap();
 
@@ -425,7 +427,7 @@ pub mod tests {
             f(l)
         } else {
             let lang = Lang::new();
-            f(&lang)
+            f(Arc::new(lang))
         };
     }
 
@@ -440,18 +442,18 @@ pub mod tests {
         reduction_count: usize,
         check_nova: bool,
         limit: Option<usize>,
-        lang: &Lang<Fr, C>,
+        lang: Arc<Lang<Fr, C>>,
     ) {
         let limit = limit.unwrap_or(10000);
 
         let e = empty_sym_env(s);
 
-        let nova_prover = NovaProver::<Fr, C>::new(reduction_count, lang.clone());
+        let nova_prover = NovaProver::<Fr, C>::new(reduction_count, (*lang).clone());
 
         if check_nova {
-            let pp = public_params(reduction_count, lang);
+            let pp = public_params(reduction_count, lang.clone());
             let (proof, z0, zi, num_steps) = nova_prover
-                .evaluate_and_prove(&pp, expr, empty_sym_env(s), s, limit, &lang)
+                .evaluate_and_prove(&pp, expr, empty_sym_env(s), s, limit, lang.clone())
                 .unwrap();
 
             let res = proof.verify(&pp, num_steps, z0.clone(), &zi);
@@ -470,7 +472,8 @@ pub mod tests {
             .get_evaluation_frames(expr, e, s, limit, &lang)
             .unwrap();
 
-        let multiframes = MultiFrame::from_frames(nova_prover.reduction_count(), &frames, s, &lang);
+        let multiframes =
+            MultiFrame::from_frames(nova_prover.reduction_count(), &frames, s, lang.clone());
         let len = multiframes.len();
 
         let adjusted_iterations = nova_prover.expected_total_iterations(expected_iterations);
@@ -3448,7 +3451,7 @@ pub mod tests {
         let expr = s.list(&[fun, input]);
         let res = s.num(10);
         let terminal = s.get_cont_terminal();
-        let lang: Lang<Fr, Coproc<Fr>> = Lang::new();
+        let lang: Arc<Lang<Fr, Coproc<Fr>>> = Arc::new(Lang::new());
 
         nova_test_full_aux2(
             s,
@@ -3461,7 +3464,7 @@ pub mod tests {
             DEFAULT_REDUCTION_COUNT,
             false,
             None,
-            &lang,
+            lang,
         );
     }
 
@@ -3601,10 +3604,29 @@ pub mod tests {
 
         let res = s.num(89);
         let error = s.get_cont_error();
+        let lang = Arc::new(lang);
 
-        test_aux(s, &expr, Some(res), None, None, None, 1, Some(&lang));
-        test_aux(s, &expr2, Some(res), None, None, None, 3, Some(&lang));
-        test_aux(s, &expr3, None, None, Some(error), None, 1, Some(&lang));
-        test_aux(s, &expr4, None, None, Some(error), None, 1, Some(&lang));
+        test_aux(s, &expr, Some(res), None, None, None, 1, Some(lang.clone()));
+        test_aux(
+            s,
+            &expr2,
+            Some(res),
+            None,
+            None,
+            None,
+            3,
+            Some(lang.clone()),
+        );
+        test_aux(
+            s,
+            &expr3,
+            None,
+            None,
+            Some(error),
+            None,
+            1,
+            Some(lang.clone()),
+        );
+        test_aux(s, &expr4, None, None, Some(error), None, 1, Some(lang));
     }
 }

--- a/src/public_parameters/error.rs
+++ b/src/public_parameters/error.rs
@@ -1,5 +1,5 @@
-use bellperson::SynthesisError;
 use crate::store;
+use bellperson::SynthesisError;
 use std::io;
 use thiserror::Error;
 

--- a/src/public_parameters/file_map.rs
+++ b/src/public_parameters/file_map.rs
@@ -5,10 +5,42 @@ use std::path::{Path, PathBuf};
 
 use crate::public_parameters::FileStore;
 
-pub fn data_dir() -> PathBuf {
+pub(crate) fn data_dir() -> PathBuf {
     match std::env::var("FCOMM_DATA_PATH") {
         Ok(name) => name.into(),
         Err(_) => PathBuf::from("/var/tmp/fcomm_data/"),
+    }
+}
+
+pub(crate) struct FileIndex<K: ToString> {
+    dir: PathBuf,
+    _t: PhantomData<K>,
+}
+
+impl<K: ToString> FileIndex<K> {
+    pub(crate) fn new<P: AsRef<Path>>(name: P) -> Result<Self, Error> {
+        let data_dir = data_dir();
+        let dir = PathBuf::from(&data_dir).join(name.as_ref());
+        create_dir_all(&dir)?;
+
+        Ok(Self {
+            dir,
+            _t: Default::default(),
+        })
+    }
+
+    fn key_path(&self, key: &K) -> PathBuf {
+        self.dir.join(PathBuf::from(key.to_string()))
+    }
+
+    pub(crate) fn get<V: FileStore>(&self, key: &K) -> Option<V> {
+        self.key_path(key);
+        V::read_from_path(self.key_path(key)).ok()
+    }
+
+    pub(crate) fn set<V: FileStore>(&self, key: K, data: &V) -> Result<(), Error> {
+        data.write_to_path(self.key_path(&key));
+        Ok(())
     }
 }
 

--- a/src/public_parameters/mod.rs
+++ b/src/public_parameters/mod.rs
@@ -1,22 +1,12 @@
 use log::info;
-use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fs::File;
 use std::io::{self, BufReader, BufWriter};
 use std::path::Path;
 use std::str::FromStr;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
-use ff::PrimeField;
-use hex::FromHex;
-use libipld::{
-    cbor::DagCborCodec,
-    json::DagJsonCodec,
-    multihash::{Code, MultihashDigest},
-    prelude::Codec,
-    serde::{from_ipld, to_ipld},
-    Cid, Ipld,
-};
+use crate::coprocessor::Coprocessor;
 use crate::{
     circuit::ToInputs,
     eval::{
@@ -33,6 +23,16 @@ use crate::{
     tag::ExprTag,
     writer::Write,
 };
+use ff::PrimeField;
+use hex::FromHex;
+use libipld::{
+    cbor::DagCborCodec,
+    json::DagJsonCodec,
+    multihash::{Code, MultihashDigest},
+    prelude::Codec,
+    serde::{from_ipld, to_ipld},
+    Cid, Ipld,
+};
 use once_cell::sync::OnceCell;
 use pasta_curves::pallas;
 use rand::rngs::OsRng;
@@ -41,6 +41,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub mod error;
 mod file_map;
+mod registry;
 
 use error::Error;
 use file_map::FileMap;
@@ -54,12 +55,12 @@ mod base64 {
     use serde::{Deserialize, Serialize};
     use serde::{Deserializer, Serializer};
 
-    fn serialize<S: Serializer>(v: &Vec<u8>, s: S) -> Result<S::Ok, S::Error> {
+    pub(crate) fn serialize<S: Serializer>(v: &Vec<u8>, s: S) -> Result<S::Ok, S::Error> {
         let base64 = base64::encode(v);
         String::serialize(&base64, s)
     }
 
-    fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
+    pub(crate) fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
         let base64 = String::deserialize(d)?;
         base64::decode(base64.as_bytes()).map_err(serde::de::Error::custom)
     }
@@ -67,7 +68,7 @@ mod base64 {
 
 pub type NovaProofCache = FileMap<Cid, Proof<'static, S1>>;
 pub fn nova_proof_cache(reduction_count: usize) -> NovaProofCache {
-    FileMap::<Cid, Proof<S1>>::new(format!("nova_proofs.{}", reduction_count)).unwrap()
+    FileMap::<Cid, Proof<'_, S1>>::new(format!("nova_proofs.{}", reduction_count)).unwrap()
 }
 
 pub type CommittedExpressionMap = FileMap<Commitment<S1>, CommittedExpression<S1>>;
@@ -75,47 +76,12 @@ pub fn committed_expression_store() -> CommittedExpressionMap {
     FileMap::<Commitment<S1>, CommittedExpression<S1>>::new("committed_expressions").unwrap()
 }
 
-pub type PublicParamMemCache = Mutex<HashMap<usize, Arc<PublicParams<'static, Coproc<S1>>>>>;
-fn public_param_mem_cache() -> &'static PublicParamMemCache {
-    static CACHE: OnceCell<PublicParamMemCache> = OnceCell::new();
-    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
-}
-
-pub type PublicParamDiskCache = FileMap<String, PublicParams<'static, Coproc<S1>>>;
-fn public_param_disk_cache() -> PublicParamDiskCache {
-    FileMap::new("public_params").unwrap()
-}
-
-pub fn lang<'a>() -> &'a Lang<S1, Coproc<S1>> {
-    static LANG: OnceCell<Lang<S1, Coproc<S1>>> = OnceCell::new();
-
-    LANG.get_or_init(Lang::<S1, Coproc<S1>>::new)
-}
-
-pub fn public_params(rc: usize) -> Result<Arc<PublicParams<'static, Coproc<S1>>>, Error> {
-    let mut mem_cache = public_param_mem_cache().lock().unwrap();
-    match mem_cache.get(&rc) {
-        Some(pp) => Ok(pp.clone()),
-        None => {
-            let disk_cache = public_param_disk_cache();
-            // TODO: Add versioning to cache key
-            let lang = lang();
-            let lang_key = lang.key();
-            let key = format!("public-params-rc-{rc}-coproc-{lang_key}");
-            if let Some(pp) = disk_cache.get(&key) {
-                let pp = Arc::new(pp);
-                mem_cache.insert(rc, pp.clone());
-                Ok(pp)
-            } else {
-                let pp = Arc::new(nova::public_params(rc, lang));
-                mem_cache.insert(rc, pp.clone());
-                disk_cache
-                    .set(key, &pp)
-                    .map_err(|e| Error::CacheError(format!("Disk write error: {e}")))?;
-                Ok(pp)
-            }
-        }
-    }
+pub fn public_params<C: Coprocessor<S1> + Serialize + DeserializeOwned + 'static>(
+    rc: usize,
+    lang: Arc<Lang<S1, C>>,
+) -> Result<Arc<PublicParams<'static, C>>, Error> {
+    let f = |lang: Arc<Lang<S1, C>>| Arc::new(nova::public_params(rc, lang));
+    registry::CACHE_REG.get_coprocessor_or_update_with(rc, f, lang)
 }
 
 // Number of circuit reductions per step, equivalent to `chunk_frame_count`
@@ -724,10 +690,10 @@ impl<'a> Opening<S1> {
         chain: bool,
         only_use_cached_proofs: bool,
         nova_prover: &'a NovaProver<S1, Coproc<S1>>,
-        pp: &'a PublicParams<Coproc<S1>>,
-        lang: &'a Lang<S1, Coproc<S1>>,
+        pp: &'a PublicParams<'_, Coproc<S1>>,
+        lang: Arc<Lang<S1, Coproc<S1>>>,
     ) -> Result<Proof<'a, S1>, Error> {
-        let claim = Self::apply(s, input, function, limit, chain, lang)?;
+        let claim = Self::apply(s, input, function, limit, chain, &lang)?;
         Proof::prove_claim(
             s,
             &claim,
@@ -745,10 +711,10 @@ impl<'a> Opening<S1> {
         limit: usize,
         only_use_cached_proofs: bool,
         nova_prover: &'a NovaProver<S1, Coproc<S1>>,
-        pp: &'a PublicParams<Coproc<S1>>,
-        lang: &'a Lang<S1, Coproc<S1>>,
+        pp: &'a PublicParams<'_, Coproc<S1>>,
+        lang: Arc<Lang<S1, Coproc<S1>>>,
     ) -> Result<Proof<'a, S1>, Error> {
-        let input = request.input.expr.ptr(s, limit, lang);
+        let input = request.input.expr.ptr(s, limit, &lang);
         let commitment = request.commitment;
 
         let function_map = committed_expression_store();
@@ -878,8 +844,8 @@ impl<'a> Proof<'a, S1> {
         limit: usize,
         only_use_cached_proofs: bool,
         nova_prover: &'a NovaProver<S1, Coproc<S1>>,
-        pp: &'a PublicParams<Coproc<S1>>,
-        lang: &'a Lang<S1, Coproc<S1>>,
+        pp: &'a PublicParams<'_, Coproc<S1>>,
+        lang: Arc<Lang<S1, Coproc<S1>>>,
     ) -> Result<Self, Error> {
         let env = supplied_env.unwrap_or_else(|| empty_sym_env(s));
         let cont = s.intern_cont_outermost();
@@ -887,7 +853,7 @@ impl<'a> Proof<'a, S1> {
 
         // TODO: It's a little silly that we evaluate here, but evaluation is also repeated in `NovaProver::evaluate_and_prove()`.
         // Refactor to avoid that.
-        let (public_output, _iterations) = evaluate(s, expr, supplied_env, limit, lang)?;
+        let (public_output, _iterations) = evaluate(s, expr, supplied_env, limit, &lang)?;
 
         let claim = if supplied_env.is_some() {
             // This is a bit of a hack, but the idea is that if the env was supplied it's likely to contain a literal function,
@@ -916,8 +882,8 @@ impl<'a> Proof<'a, S1> {
         limit: usize,
         only_use_cached_proofs: bool,
         nova_prover: &'a NovaProver<S1, Coproc<S1>>,
-        pp: &'a PublicParams<Coproc<S1>>,
-        lang: &'a Lang<S1, Coproc<S1>>,
+        pp: &'a PublicParams<'_, Coproc<S1>>,
+        lang: Arc<Lang<S1, Coproc<S1>>>,
     ) -> Result<Self, Error> {
         let reduction_count = nova_prover.reduction_count();
 
@@ -942,7 +908,7 @@ impl<'a> Proof<'a, S1> {
                 s.read(&e.expr).expect("bad expression"),
                 s.read(&e.env).expect("bad env"),
             ),
-            Claim::PtrEvaluation(e) => (e.expr.ptr(s, limit, lang), e.env.ptr(s, limit, lang)),
+            Claim::PtrEvaluation(e) => (e.expr.ptr(s, limit, &lang), e.env.ptr(s, limit, &lang)),
             Claim::Opening(o) => {
                 let commitment = o.commitment;
 
@@ -953,7 +919,7 @@ impl<'a> Proof<'a, S1> {
 
                 let input = s.read(&o.input).expect("bad expression");
                 let (c, expression) =
-                    Commitment::construct_with_fun_application(s, function, input, limit, lang)?;
+                    Commitment::construct_with_fun_application(s, function, input, limit, &lang)?;
 
                 assert_eq!(commitment, c);
                 (expression, empty_sym_env(s))
@@ -961,7 +927,7 @@ impl<'a> Proof<'a, S1> {
         };
 
         let (proof, _public_input, _public_output, num_steps) = nova_prover
-            .evaluate_and_prove(pp, expr, env, s, limit, lang)
+            .evaluate_and_prove(pp, expr, env, s, limit, lang.clone())
             .expect("Nova proof failed");
 
         let proof = Self {
@@ -989,7 +955,7 @@ impl<'a> Proof<'a, S1> {
             }
         };
 
-        proof.verify(pp, lang).expect("Nova verification failed");
+        proof.verify(pp, &lang).expect("Nova verification failed");
 
         proof_map.set(cid, &proof).unwrap();
 
@@ -998,7 +964,7 @@ impl<'a> Proof<'a, S1> {
 
     pub fn verify(
         &self,
-        pp: &PublicParams<Coproc<S1>>,
+        pp: &PublicParams<'_, Coproc<S1>>,
         lang: &Lang<S1, Coproc<S1>>,
     ) -> Result<VerificationResult, Error> {
         let (public_inputs, public_outputs) = self.io_vecs(lang)?;
@@ -1168,7 +1134,11 @@ pub fn evaluate<F: LurkField>(
 
     let (io, iterations, _) = evaluator.eval().map_err(|_| Error::EvaluationFailure)?;
 
-    assert!(<crate::eval::IO<F> as Evaluable<F, Witness<F>, Coproc<F>>>::is_terminal(&io));
+    assert!(<crate::eval::IO<F> as Evaluable<
+        F,
+        Witness<F>,
+        Coproc<F>,
+    >>::is_terminal(&io));
     Ok((io, iterations))
 }
 

--- a/src/public_parameters/registry.rs
+++ b/src/public_parameters/registry.rs
@@ -1,0 +1,92 @@
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    sync::{Arc, Mutex},
+};
+
+use once_cell::sync::Lazy;
+use pasta_curves::pallas;
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::public_parameters::Error;
+use crate::{coprocessor::Coprocessor, eval::lang::Lang, proof::nova::PublicParams};
+
+use super::file_map::FileIndex;
+
+type S1 = pallas::Scalar;
+type AnyMap = anymap::Map<dyn anymap::any::Any + Send + Sync>;
+type PublicParamMemCache<C> = HashMap<usize, Arc<PublicParams<'static, C>>>;
+
+/// This is a global registry for Coproc-specific parameters.
+/// It is used to cache parameters for each Coproc, so that they are not
+/// re-initialized on each call to `eval`.
+/// The use of AnyMap is a workaround for the fact that we need static storage for generic parameters,
+/// noting that this is not possible in Rust.
+#[derive(Clone)]
+pub(crate) struct Registry {
+    registry: Arc<Mutex<AnyMap>>,
+}
+
+pub(crate) static CACHE_REG: Lazy<Registry> = Lazy::new(|| Registry {
+    registry: Arc::new(Mutex::new(AnyMap::new())),
+});
+
+impl Registry {
+    fn get_from_file_cache_or_update_with<
+        C: Coprocessor<S1> + Serialize + DeserializeOwned + 'static,
+        F: FnOnce(Arc<Lang<S1, C>>) -> Arc<PublicParams<'static, C>>,
+    >(
+        &'static self,
+        rc: usize,
+        default: F,
+        lang: Arc<Lang<S1, C>>,
+    ) -> Result<Arc<PublicParams<'static, C>>, Error> {
+        // subdirectory search
+        let disk_cache = FileIndex::new("public_params").unwrap();
+        // use the cached language key
+        let lang_key = lang.key();
+        // Sanity-check: we're about to use a lang-dependent disk cache, which should be specialized
+        // for this lang/coprocessor.
+        debug_assert!(
+            !lang_key.is_empty(),
+            "Lang key is empty, error in coprocessor initialization!"
+        );
+        let key = format!("public-params-rc-{rc}-coproc-{lang_key}");
+        // read the file if it exists, otherwise initialize
+        if let Some(pp) = disk_cache.get::<PublicParams<'static, C>>(&key) {
+            Ok(Arc::new(pp))
+        } else {
+            let pp = default(lang);
+            disk_cache
+                .set(key, &*pp)
+                .map_err(|e| Error::CacheError(format!("Disk write error: {e}")))?;
+            Ok(pp)
+        }
+    }
+
+    /// Check if params for this Coproc are in registry, if so, return them.
+    /// Otherwise, initialize with the passed in function.
+    pub(crate) fn get_coprocessor_or_update_with<
+        C: Coprocessor<S1> + Serialize + DeserializeOwned + 'static,
+        F: FnOnce(Arc<Lang<S1, C>>) -> Arc<PublicParams<'static, C>>,
+    >(
+        &'static self,
+        rc: usize,
+        default: F,
+        lang: Arc<Lang<S1, C>>,
+    ) -> Result<Arc<PublicParams<'static, C>>, Error> {
+        // re-grab the lock
+        let mut registry = self.registry.lock().unwrap();
+        // retrieve the per-Coproc public param table
+        let entry = registry.entry::<PublicParamMemCache<C>>();
+        // deduce the map and populate it if needed
+        let param_entry = entry.or_insert_with(HashMap::new);
+        match param_entry.entry(rc) {
+            Entry::Occupied(o) => Ok(o.into_mut()),
+            Entry::Vacant(v) => {
+                let val = self.get_from_file_cache_or_update_with(rc, default, lang)?;
+                Ok(v.insert(val))
+            }
+        }
+        .cloned()
+    }
+}

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -28,6 +28,7 @@ use std::marker::PhantomData;
 use std::path::Path;
 #[cfg(not(target_arch = "wasm32"))]
 use std::path::PathBuf;
+use std::sync::Arc;
 use tap::TapOptional;
 
 #[derive(Completer, Helper, Highlighter, Hinter)]
@@ -46,7 +47,7 @@ pub struct ReplState<F: LurkField, C: Coprocessor<F>> {
     pub env: Ptr<F>,
     pub limit: usize,
     pub command: Option<Command>,
-    pub lang: Lang<F, C>,
+    pub lang: Arc<Lang<F, C>>,
 }
 
 pub struct Repl<F: LurkField, T: ReplTrait<F, C>, C: Coprocessor<F>> {
@@ -309,7 +310,7 @@ impl<F: LurkField, C: Coprocessor<F>> ReplState<F, C> {
             env: empty_sym_env(s),
             limit,
             command,
-            lang,
+            lang: Arc::new(lang),
         }
     }
     pub fn eval_expr(
@@ -340,7 +341,7 @@ impl<F: LurkField, C: Coprocessor<F>> ReplTrait<F, C> for ReplState<F, C> {
             env: empty_sym_env(s),
             limit,
             command,
-            lang,
+            lang: Arc::new(lang),
         }
     }
 


### PR DESCRIPTION
- adds a Registry for Lang and PublicParams, that is generic in its Coproc parameter,
- makes a singleton instance for it,
- threads the disk-cache probing logic through the Registry,
- Changes static references to the Lang into an Arc,
- corrects tests, warnings and lints..