### PR TITLE
chore: Optimize public parameter serialization with bincode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1367,6 +1367,7 @@ dependencies = [
  "assert_cmd",
  "base64",
  "bellperson",
+ "bincode",
  "blstrs",
  "cid",
  "clap 4.2.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ nom = "7.1.3"
 clap = "4.1.8"
 tap = "1.0.1"
 anymap = "0.12.1"
+bincode = "1.3.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 memmap = { version = "0.5.10", package = "memmap2" }

--- a/src/public_parameters/mod.rs
+++ b/src/public_parameters/mod.rs
@@ -399,13 +399,14 @@ where
         let file = File::create(path).expect("failed to create file");
         let writer = BufWriter::new(&file);
 
-        serde_json::to_writer(writer, &self).expect("failed to write file");
+        bincode::serialize_into(writer, &self).expect("failed to write file");
     }
 
     fn read_from_path<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
         let file = File::open(path)?;
         let reader = BufReader::new(file);
-        Ok(serde_json::from_reader(reader)?)
+        bincode::deserialize_from(reader)
+            .map_err(|e| Error::CacheError(format!("Cache deserialization error: {}", e)))
     }
 
     fn read_from_stdin() -> Result<Self, Error> {


### PR DESCRIPTION
- Introduce `bincode` dependency to replace `serde_json` in serialization and deserialization
- Improve error message for cache deserialization issues in `public_parameters` module

Contributes to #387 : reduces the reading time by ~2x (1000s to 500s on my machine), the cache size by ~2x (2.1GB to 1.1GB). Hopefully this is just the start.
