### PR TITLE
Document release mode for sha256 benchmark.

### DIFF
--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -129,7 +129,7 @@ enum Sha256Coproc<F: LurkField> {
 }
 
 /// Run the example in this file with
-/// `cargo run --example sha256 1 f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b false`
+/// `cargo run --release --example sha256 1 f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b false`
 fn main() {
     let args: Vec<String> = env::args().collect();
 


### PR DESCRIPTION
If you thought the sha256 benchmark took 4-5 seconds to prove, I have some 10x good news for you.

```
➜  lurk-rs git:(sha256-release-mode) cargo run --release --example sha256 1 f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b false
   Compiling lurk-macros v0.1.0 (/Users/clwk/fil/lurk-rs/lurk-macros)
   Compiling lurk v0.2.0 (/Users/clwk/fil/lurk-rs)
    Finished release [optimized] target(s) in 26.44s
     Running `target/release/examples/sha256 1 f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b false`
Setting up public parameters...
Using disk-cached public params for lang -SHA256-HASH-64-ZERO-BYTES
Public parameters took 80.586608292s
Beginning proof step...
T
Proofs took 434.543917ms
Verifying proof...
Verify took 274.103041ms
Congratulations! You proved and verified a SHA256 hash calculation in 81.29525525s time!
```
🎉 