### PR TITLE
Improve coprocessor ergonomics.

### DIFF
--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -12,7 +12,6 @@ use lurk::proof::{nova::NovaProver, Prover};
 use lurk::ptr::Ptr;
 use lurk::public_parameters::public_params;
 use lurk::store::Store;
-use lurk::sym::Sym;
 use lurk::tag::{ExprTag, Tag};
 use lurk::Num;
 use lurk_macros::Coproc;
@@ -105,6 +104,10 @@ impl<F: LurkField> Coprocessor<F> for Sha256Coprocessor<F> {
         let blah = &[u[0], u[1]].map(|x| s.intern_num(u128_into_scalar::<F>(x)));
         s.list(blah)
     }
+
+    fn has_circuit(&self) -> bool {
+        true
+    }
 }
 
 fn u128_into_scalar<F: LurkField>(u: u128) -> Num<F> {
@@ -129,7 +132,7 @@ enum Sha256Coproc<F: LurkField> {
 }
 
 /// Run the example in this file with
-/// `cargo run --example sha256 1 f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b false`
+/// `cargo run --release --example sha256 1 f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b false`
 fn main() {
     let args: Vec<String> = env::args().collect();
 
@@ -140,13 +143,11 @@ fn main() {
     let input_size = 64 * num_of_64_bytes;
 
     let store = &mut Store::<Fr>::new();
-    let mut lang = Lang::<Fr, Sha256Coproc<Fr>>::new();
     let sym_str = format!(".sha256.hash-{}-zero-bytes", input_size);
-    let name = Sym::new(sym_str.clone());
-    let coprocessor: Sha256Coprocessor<Fr> = Sha256Coprocessor::<Fr>::new(input_size);
-    let coproc = Sha256Coproc::SC(coprocessor);
-
-    lang.add_coprocessor(name, coproc, store);
+    let lang = Lang::<Fr, Sha256Coproc<Fr>>::new_with_bindings(
+        store,
+        vec![(sym_str.clone(), Sha256Coprocessor::new(input_size).into())],
+    );
 
     let coproc_expr = format!("({})", sym_str);
 

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -1397,7 +1397,10 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>, C: Coprocessor<F>>(
 
     let mut head_is_coprocessor_bools = Vec::with_capacity(lang.coprocessors().len());
 
-    for (sym, (_coproc, scalar_ptr)) in lang.coprocessors().iter() {
+    for (sym, (coproc, scalar_ptr)) in lang.coprocessors().iter() {
+        if !coproc.has_circuit() {
+            continue;
+        };
         let cs = &mut cs.namespace(|| format!("head is {}", sym.full_name()));
 
         let allocated_boolean = head.alloc_hash_equal(cs, *scalar_ptr.value())?;
@@ -2621,6 +2624,10 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>, C: Coprocessor<F>>(
             )?;
 
             for (sym, (coproc, scalar_ptr)) in lang.coprocessors().iter() {
+                if !coproc.has_circuit() {
+                    continue;
+                };
+
                 let cs = &mut cs.namespace(|| format!("{} coprocessor", sym.full_name()));
 
                 let arity = coproc.arity();

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -22,7 +22,10 @@ use crate::store::Store;
 /// - A trait [`crate::coprocessor::Coprocessor`], which defines the methods and behavior for all coprocessors.
 /// - An enum such as [`crate::eval::lang::Coproc`], which "closes" the hierarchy of possible coprocessor
 ///   implementations we want to instantiate at a particular point in the code.
-pub trait Coprocessor<F: LurkField>: Clone + Debug + Sync + CoCircuit<F> {
+pub trait Coprocessor<F: LurkField>: Clone + Debug + Sync + Send + CoCircuit<F> {
+    fn new() -> Self {
+        unimplemented!();
+    }
     fn eval_arity(&self) -> usize;
 
     fn evaluate(&self, s: &mut Store<F>, args: Ptr<F>, env: Ptr<F>, cont: ContPtr<F>) -> IO<F> {
@@ -53,6 +56,11 @@ pub trait Coprocessor<F: LurkField>: Clone + Debug + Sync + CoCircuit<F> {
 
     /// As with all evaluation, the value returned from `simple_evaluate` must be fully evaluated.
     fn simple_evaluate(&self, s: &mut Store<F>, args: &[Ptr<F>]) -> Ptr<F>;
+
+    /// Returns true if this Coprocessor actually implements a circuit.
+    fn has_circuit(&self) -> bool {
+        false
+    }
 }
 
 /// `CoCircuit` is a trait that represents a generalized interface for coprocessors.
@@ -143,6 +151,10 @@ pub(crate) mod test {
             let x = s.intern_num(result);
 
             return x;
+        }
+
+        fn has_circuit(&self) -> bool {
+            true
         }
     }
 

--- a/src/eval/lang.rs
+++ b/src/eval/lang.rs
@@ -88,6 +88,17 @@ impl<F: LurkField, C: Coprocessor<F>> Lang<F, C> {
         }
     }
 
+    pub fn new_with_bindings<B: Into<Binding<F, C>>>(s: &mut Store<F>, bindings: Vec<B>) -> Self {
+        let mut new = Self {
+            coprocessors: Default::default(),
+        };
+        for b in bindings {
+            new.add_binding(b.into(), s);
+        }
+
+        new
+    }
+
     pub fn key(&self) -> String {
         let mut key = String::new();
 
@@ -103,11 +114,25 @@ impl<F: LurkField, C: Coprocessor<F>> Lang<F, C> {
         key
     }
 
-    pub fn add_coprocessor(&mut self, name: Sym, cproc: C, store: &mut Store<F>) {
+    pub fn add_coprocessor<T: Into<C>, S: Into<Sym>>(
+        &mut self,
+        name: S,
+        cproc: T,
+        store: &mut Store<F>,
+    ) {
+        let name = name.into();
         let ptr = store.intern_sym_and_ancestors(&name).unwrap();
         let scalar_ptr = store.get_expr_hash(&ptr).unwrap();
 
-        self.coprocessors.insert(name, (cproc, scalar_ptr));
+        self.coprocessors.insert(name, (cproc.into(), scalar_ptr));
+    }
+
+    pub fn add_binding<B: Into<Binding<F, C>>>(&mut self, binding: B, store: &mut Store<F>) {
+        let Binding { name, coproc, _p } = binding.into();
+        let ptr = store.intern_sym_and_ancestors(&name).unwrap();
+        let scalar_ptr = store.get_expr_hash(&ptr).unwrap();
+
+        self.coprocessors.insert(name, (coproc, scalar_ptr));
     }
 
     pub fn coprocessors(&self) -> &HashMap<Sym, (C, ScalarPtr<F>)> {
@@ -137,6 +162,28 @@ impl<F: LurkField, C: Coprocessor<F>> Lang<F, C> {
     }
 }
 
+pub struct Binding<F: LurkField, C: Coprocessor<F>> {
+    name: Sym,
+    coproc: C,
+    _p: PhantomData<F>,
+}
+
+impl<F: LurkField, C: Coprocessor<F>, S: Into<Sym>> From<(S, C)> for Binding<F, C> {
+    fn from(pair: (S, C)) -> Self {
+        Self::new(pair.0, pair.1)
+    }
+}
+
+impl<F: LurkField, C: Coprocessor<F>> Binding<F, C> {
+    pub fn new<T: Into<C>, S: Into<Sym>>(name: S, coproc: T) -> Self {
+        Self {
+            name: name.into(),
+            coproc: coproc.into(),
+            _p: Default::default(),
+        }
+    }
+}
+
 #[cfg(test)]
 pub(crate) mod test {
     use super::*;
@@ -150,10 +197,10 @@ pub(crate) mod test {
     #[test]
     fn dummy_lang() {
         let store = &mut Store::<Fr>::default();
-        let mut lang = Lang::<Fr, Coproc<Fr>>::new();
-        let name = Sym::new(".cproc.dummy".to_string());
-        let dummy = DummyCoprocessor::new();
 
-        lang.add_coprocessor(name, Coproc::Dummy(dummy), store);
+        let _lang = Lang::<Fr, Coproc<Fr>>::new_with_bindings(
+            store,
+            vec![(".cproc.dummy", DummyCoprocessor::new().into())],
+        );
     }
 }

--- a/src/eval/tests/mod.rs
+++ b/src/eval/tests/mod.rs
@@ -2566,7 +2566,6 @@ pub(crate) mod coproc {
     use super::*;
     use crate::coprocessor::test::DumbCoprocessor;
     use crate::store::Store;
-    use crate::sym::Sym;
 
     #[derive(Clone, Debug, Coproc)]
     pub(crate) enum DumbCoproc<F: LurkField> {
@@ -2577,12 +2576,10 @@ pub(crate) mod coproc {
     fn test_dumb_lang() {
         let s = &mut Store::<Fr>::new();
 
-        let mut lang = Lang::<Fr, DumbCoproc<Fr>>::new();
-        let name = Sym::new(".cproc.dumb".to_string());
-        let dumb = DumbCoprocessor::new();
-        let coproc = DumbCoproc::DC(dumb);
-
-        lang.add_coprocessor(name, coproc, s);
+        let lang = Lang::<Fr, DumbCoproc<Fr>>::new_with_bindings(
+            s,
+            vec![(".cproc.dumb", DumbCoprocessor::new().into())],
+        );
 
         // 9^2 + 8 = 89
         let expr = "(.cproc.dumb 9 8)";

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -3581,16 +3581,13 @@ pub mod tests {
     fn test_dumb_lang() {
         use crate::coprocessor::test::DumbCoprocessor;
         use crate::eval::tests::coproc::DumbCoproc;
-        use crate::sym::Sym;
 
         let s = &mut Store::<Fr>::new();
 
-        let mut lang = Lang::<Fr, DumbCoproc<Fr>>::new();
-        let name = Sym::new(".cproc.dumb".to_string());
-        let dumb = DumbCoprocessor::new();
-        let coproc = DumbCoproc::DC(dumb);
-
-        lang.add_coprocessor(name, coproc, s);
+        let lang = Lang::<Fr, DumbCoproc<Fr>>::new_with_bindings(
+            s,
+            vec![(".cproc.dumb", DumbCoprocessor::new().into())],
+        );
 
         // 9^2 + 8 = 89
         let expr = "(.cproc.dumb 9 8)";


### PR DESCRIPTION
Improves coprocessor ergonomics:
- macro derives `From` impl for wrapping enums.
- various support for more conveniently creating `Lang` with symbol-coproc bindings.
- support for coprocessors that don't (yet or perhaps ever in the case of meta-lurk) have circuit implementations.