### PR TITLE
Add trie coprocessor.

### DIFF
--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -9,6 +9,8 @@ use crate::field::LurkField;
 use crate::ptr::{ContPtr, Ptr};
 use crate::store::Store;
 
+pub mod trie;
+
 /// `Coprocessor` is a trait that represents a generalized interface for coprocessors.
 /// Coprocessors augment the Lurk circuit and evaluation with additional built-in functionality.
 /// This trait generalizes over functionality needed in the evaluator, the sibling `CoCircuit` trait,

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -126,7 +126,6 @@ pub struct Trie<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> {
     empty_roots: [F; HEIGHT],
     hash_cache: &'a PoseidonCache<F>,
     children: &'a mut ChildMap<F, ARITY>,
-    count: usize,
 }
 
 pub struct LookupProof<F: LurkField, const ARITY: usize, const HEIGHT: usize> {
@@ -273,7 +272,6 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
                 *elt = hash;
             }
         }
-        self.count = 0;
         self.root = self.empty_roots[HEIGHT - 1]
     }
 
@@ -297,7 +295,6 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
             empty_roots: [F::zero(); HEIGHT],
             hash_cache: poseidon_cache,
             children: inverse_poseidon_cache,
-            count: 0,
         };
         new.init_empty();
 
@@ -436,14 +433,19 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
         let new_root = new_value;
         let inserted = new_root != self.root;
 
-        if inserted {
-            self.count += 1
-        };
         self.root = new_root;
 
         let new_proof = LookupProof::new(proof);
 
         Ok((InsertProof::new(old_proof, new_proof), inserted))
+    }
+}
+
+impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Default
+    for Trie<'a, F, ARITY, HEIGHT>
+{
+    fn default() -> Self {
+        todo!();
     }
 }
 

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -25,7 +25,7 @@ use crate as lurk;
 use crate::coprocessor::{CoCircuit, Coprocessor};
 use crate::eval::lang::Lang;
 use crate::field::{FWrap, LurkField};
-use crate::hash::{InversePoseidonCache, PoseidonCache};
+use crate::hash::{HashArity, InversePoseidonCache, PoseidonCache};
 use crate::num::Num;
 use crate::ptr::Ptr;
 use crate::store::Store;
@@ -304,6 +304,9 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
 
         let poseidon_cache = &store.poseidon_cache;
         let inverse_poseidon_cache = &mut store.inverse_poseidon_cache;
+
+        // This will panic if ARITY is unsupporteed.
+        let _ = HashArity::from(ARITY);
 
         let mut new = Self {
             root: Default::default(),

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -287,7 +287,9 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
 
             self.empty_roots[i] = hash;
 
-            preimage = [hash; ARITY];
+            for elt in preimage.iter_mut().take(ARITY) {
+                *elt = hash;
+            }
         }
         self.root = self.empty_roots[HEIGHT - 1]
     }

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -40,7 +40,7 @@ impl<F: LurkField> Coprocessor<F> for NewCoprocessor<F> {
     }
 
     fn simple_evaluate(&self, s: &mut Store<F>, _args: &[Ptr<F>]) -> Ptr<F> {
-        let trie: Trie<'_, F, 8, 55> = Trie::new(&s.poseidon_cache, &mut s.inverse_poseidon_cache);
+        let trie: Trie<'_, F, 8, 85> = Trie::new(&s.poseidon_cache, &mut s.inverse_poseidon_cache);
 
         let root = trie.root;
 
@@ -66,7 +66,7 @@ impl<F: LurkField> Coprocessor<F> for LookupCoprocessor<F> {
         let key_ptr = args[1];
         let root_scalar = *s.get_expr_hash(&root_ptr).unwrap().value();
         let key_scalar = *s.get_expr_hash(&key_ptr).unwrap().value();
-        let trie: Trie<'_, F, 8, 55> = Trie::new_with_root(s, root_scalar);
+        let trie: Trie<'_, F, 8, 85> = Trie::new_with_root(s, root_scalar);
 
         let found = trie.lookup_aux(key_scalar).unwrap();
 
@@ -93,7 +93,7 @@ impl<F: LurkField> Coprocessor<F> for InsertCoprocessor<F> {
         let root_scalar = *s.get_expr_hash(&root_ptr).unwrap().value();
         let key_scalar = *s.get_expr_hash(&key_ptr).unwrap().value();
         let val_scalar = *s.get_expr_hash(&val_ptr).unwrap().value();
-        let mut trie: Trie<'_, F, 8, 55> = Trie::new_with_root(s, root_scalar);
+        let mut trie: Trie<'_, F, 8, 85> = Trie::new_with_root(s, root_scalar);
         trie.insert(key_scalar, val_scalar).unwrap();
 
         let new_root = trie.root;

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -536,7 +536,6 @@ mod test {
         }
     }
 
-    #[cfg(test)]
     pub(crate) fn scalar_from_u64s(parts: [u64; 4]) -> Fr {
         let mut le_bytes = [0u8; 32];
         le_bytes[0..8].copy_from_slice(&parts[0].to_le_bytes());

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -219,11 +219,9 @@ impl<F: LurkField, const ARITY: usize, const HEIGHT: usize> InsertProof<F, ARITY
                     // This is purely an evaluation-time optimization. Don't try to reproduce in the circuit, which cannot shortcut.
                     return old_verified;
                 }
-                let differing_position_count = a
-                    .iter()
-                    .zip(b)
-                    .map(|(x, y)| x != y)
-                    .fold(0, |acc, are_diff| acc + are_diff as usize);
+                let differing_position_count: usize =
+                    a.iter().zip(b).map(|(x, y)| usize::from(x != y)).sum();
+
                 differing_position_count <= 1
             });
 

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -338,7 +338,7 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
         new
     }
 
-    /// Create a new `Trie` with specified root. The provided `PoseidonCache` must
+    /// Create a new `Trie` with specified root.
     fn new_with_root(store: &'a mut Store<F>, root: F) -> Self {
         let mut new = Self::new(store);
 

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -1,3 +1,20 @@
+//! The `trie` module implements a Trie with the following properties:
+//! Big-endian bits of the (field element) key are taken N at a time, where the underlying hash has arity 2^N. This
+//! forms a fixed-length path whose final element is either zero or some non-zero payload. If the payload is assumed to
+//! be a commitment, then zero can be used as a hash whose preimage is undiscoverable, and hence empty. To optimize
+//! creation of an empty tree, we precompute the empty subtree at each row rather than trying to actually construct the
+//! tree with a vast number of redundant hashes.
+//!
+//! The non-circuit implementation appears to do the unnecessary work of returning not only lookup and insertion results
+//! but also Merkle inclusion *proofs* of correctness. That's because the circuit implementation, which represents a
+//! proof, will actually be a proof *verifying* that the vanilla operation was correctly performed. Therefore, the
+//! vanilla operation needs to provide such a proof so the circuit can verify it.
+
+// TODO:
+//  - Implement circuit (https://github.com/lurk-lab/lurk-rs/issues/421).
+//  - Adapt to ongoing changes to general coprocessor API, most importantly, absorb
+//    https://github.com/lurk-lab/lurk-rs/issues/398. - If #398 is smooth enough, no actual implementation changes
+//    should be required here, but the test in src/eval/tests/trie.rs can and should be updated.
 use std::marker::PhantomData;
 
 use lurk_macros::Coproc;

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -288,9 +288,6 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
             self.empty_roots[i] = hash;
 
             preimage = [hash; ARITY];
-            for elt in preimage.iter_mut().take(ARITY) {
-                *elt = hash;
-            }
         }
         self.root = self.empty_roots[HEIGHT - 1]
     }

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -238,7 +238,7 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
     /// The empty element is specified to be zero. This is a natural choice. Crucially, the chosen value must have no known
     /// preimage.
     fn empty_element() -> F {
-        F::zero()
+        F::ZERO
     }
 
     fn compute_hash(hash_cache: &PoseidonCache<F>, preimage: [F; ARITY]) -> F {

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -212,12 +212,12 @@ impl<F: LurkField, const ARITY: usize, const HEIGHT: usize> InsertProof<F, ARITY
             .iter()
             .zip(&self.new_proof.preimage_path)
             .all(|(a, b)| {
-                let differing_postition_count = a
+                let differing_position_count = a
                     .iter()
                     .zip(b)
                     .map(|(x, y)| x != y)
                     .fold(0, |acc, are_diff| acc + are_diff as usize);
-                differing_postition_count <= 1
+                differing_position_count <= 1
             });
 
         old_verified && new_verified && paths_differ_by_at_most_one
@@ -226,21 +226,7 @@ impl<F: LurkField, const ARITY: usize, const HEIGHT: usize> InsertProof<F, ARITY
 
 impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARITY, HEIGHT> {
     fn compute_hash(hash_cache: &PoseidonCache<F>, preimage: [F; ARITY]) -> F {
-        macro_rules! hash {
-            ($hash_name:ident, $n:expr) => {{
-                let mut buffer = [F::zero(); $n];
-                buffer.copy_from_slice(&preimage);
-
-                hash_cache.$hash_name(&buffer)
-            }};
-        }
-        match ARITY {
-            3 => hash!(hash3, 3),
-            4 => hash!(hash4, 4),
-            6 => hash!(hash6, 6),
-            8 => hash!(hash8, 8),
-            _ => unimplemented!(),
-        }
+        hash_cache.compute_hash(preimage)
     }
 
     pub fn root(&self) -> F {

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -284,6 +284,7 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
     pub fn empty_root(&mut self) -> F {
         self.empty_root_for_height(HEIGHT)
     }
+
     fn new(
         poseidon_cache: &'a PoseidonCache<F>,
         inverse_poseidon_cache: &'a mut InversePoseidonCache<F>,
@@ -350,13 +351,8 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
     // We could alternately return `F::zero()` for missing values, but instead return an `Option` to more clearly
     // signal intent -- since the encoding of 'missing' values as `Fr::zero()` is significant.
     pub fn lookup(&self, key: F) -> Result<Option<F>, Error<F>> {
-        self.lookup_aux(key).map(|payload| {
-            if payload == F::zero() {
-                None
-            } else {
-                Some(payload)
-            }
-        })
+        self.lookup_aux(key)
+            .map(|payload| (payload != F::zero()).then(|| payload))
     }
 
     fn lookup_aux(&self, key: F) -> Result<F, Error<F>> {

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -217,7 +217,7 @@ impl<F: LurkField, const ARITY: usize, const HEIGHT: usize> InsertProof<F, ARITY
                     .zip(b)
                     .map(|(x, y)| x != y)
                     .fold(0, |acc, are_diff| acc + are_diff as usize);
-                differing_postition_count == 1 || differing_postition_count == 0
+                differing_postition_count <= 1
             });
 
         old_verified && new_verified && paths_differ_by_at_most_one

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -1,0 +1,734 @@
+use std::marker::PhantomData;
+
+use lurk_macros::Coproc;
+use serde::{Deserialize, Serialize};
+
+use crate as lurk;
+
+use crate::coprocessor::{CoCircuit, Coprocessor};
+use crate::eval::lang::Lang;
+use crate::field::{FWrap, LurkField};
+use crate::hash::{InversePoseidonCache, PoseidonCache};
+use crate::num::Num;
+use crate::ptr::Ptr;
+use crate::store::Store;
+
+#[derive(Debug)]
+pub enum Error<F> {
+    MissingPreimage(F),
+}
+
+pub type PreimagePath<F, const ARITY: usize> = Vec<[F; ARITY]>;
+
+pub type HashPreimagePath<F, const ARITY: usize> = Vec<(F, [F; ARITY])>;
+
+#[derive(Clone, Coproc, Debug)]
+pub enum TrieCoproc<F: LurkField> {
+    New(NewCoprocessor<F>),
+    Lookup(LookupCoprocessor<F>),
+    Insert(InsertCoprocessor<F>),
+}
+
+#[derive(Clone, Debug, Serialize, Default, Deserialize)]
+pub struct NewCoprocessor<F: LurkField> {
+    _p: PhantomData<F>,
+}
+
+impl<F: LurkField> Coprocessor<F> for NewCoprocessor<F> {
+    fn eval_arity(&self) -> usize {
+        0
+    }
+
+    fn simple_evaluate(&self, s: &mut Store<F>, _args: &[Ptr<F>]) -> Ptr<F> {
+        let trie: Trie<'_, F, 8, 55> = Trie::new(&s.poseidon_cache, &mut s.inverse_poseidon_cache);
+
+        let root = trie.root;
+
+        // FIXME: Use a custom type.
+        s.intern_num(Num::Scalar(root))
+    }
+}
+
+impl<F: LurkField> CoCircuit<F> for NewCoprocessor<F> {}
+
+#[derive(Clone, Debug, Serialize, Default, Deserialize)]
+pub struct LookupCoprocessor<F: LurkField> {
+    _p: PhantomData<F>,
+}
+
+impl<F: LurkField> Coprocessor<F> for LookupCoprocessor<F> {
+    fn eval_arity(&self) -> usize {
+        2
+    }
+
+    fn simple_evaluate(&self, s: &mut Store<F>, args: &[Ptr<F>]) -> Ptr<F> {
+        let root_ptr = args[0];
+        let key_ptr = args[1];
+        let root_scalar = *s.get_expr_hash(&root_ptr).unwrap().value();
+        let key_scalar = *s.get_expr_hash(&key_ptr).unwrap().value();
+        let trie: Trie<'_, F, 8, 55> = Trie::new_with_root(s, root_scalar);
+
+        let found = trie.lookup_aux(key_scalar).unwrap();
+
+        s.intern_maybe_opaque_comm(found)
+    }
+}
+
+impl<F: LurkField> CoCircuit<F> for LookupCoprocessor<F> {}
+
+#[derive(Clone, Debug, Serialize, Default, Deserialize)]
+pub struct InsertCoprocessor<F: LurkField> {
+    _p: PhantomData<F>,
+}
+
+impl<F: LurkField> Coprocessor<F> for InsertCoprocessor<F> {
+    fn eval_arity(&self) -> usize {
+        3
+    }
+
+    fn simple_evaluate(&self, s: &mut Store<F>, args: &[Ptr<F>]) -> Ptr<F> {
+        let root_ptr = args[0];
+        let key_ptr = args[1];
+        let val_ptr = args[2];
+        let root_scalar = *s.get_expr_hash(&root_ptr).unwrap().value();
+        let key_scalar = *s.get_expr_hash(&key_ptr).unwrap().value();
+        let val_scalar = *s.get_expr_hash(&val_ptr).unwrap().value();
+        let mut trie: Trie<'_, F, 8, 55> = Trie::new_with_root(s, root_scalar);
+        trie.insert(key_scalar, val_scalar).unwrap();
+
+        let new_root = trie.root;
+        s.intern_num(Num::Scalar(new_root))
+    }
+}
+
+impl<F: LurkField> CoCircuit<F> for InsertCoprocessor<F> {}
+
+/// Add the `Trie`-associated functions to a `Lang` with standard bindings.
+// TODO: define standard patterns for such modularity.
+pub fn install<F: LurkField>(s: &mut Store<F>, lang: &mut Lang<F, TrieCoproc<F>>) {
+    lang.add_binding((".lurk.trie.new", NewCoprocessor::default().into()), s);
+    lang.add_binding(
+        (".lurk.trie.lookup", LookupCoprocessor::default().into()),
+        s,
+    );
+    lang.add_binding(
+        (".lurk.trie.insert", InsertCoprocessor::default().into()),
+        s,
+    );
+}
+
+//pub type ChildMap<F: LurkField, const ARITY: usize> = HashMap<FWrap<F>, [F; ARITY]>;
+pub type ChildMap<F, const ARITY: usize> = InversePoseidonCache<F>;
+
+/// A sparse Trie.
+pub struct Trie<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> {
+    root: F,
+    empty_roots: [F; HEIGHT],
+    hash_cache: &'a PoseidonCache<F>,
+    children: &'a mut ChildMap<F, ARITY>,
+    count: usize,
+}
+
+pub struct LookupProof<F: LurkField, const ARITY: usize, const HEIGHT: usize> {
+    preimage_path: PreimagePath<F, ARITY>,
+}
+
+impl<F: LurkField, const ARITY: usize, const HEIGHT: usize> LookupProof<F, ARITY, HEIGHT> {
+    fn new(preimage_path: PreimagePath<F, ARITY>) -> Self {
+        Self { preimage_path }
+    }
+
+    /// Verify a `LookupProof`. Note that this verification is exactly what must be proved in the circuit.
+    pub fn verify(&self, root: F, key: F, value: F, hash_cache: &PoseidonCache<F>) -> bool {
+        let path = Trie::<F, ARITY, HEIGHT>::path(key);
+
+        let mut next = root;
+        for (k, preimage) in path.iter().zip(&self.preimage_path) {
+            let computed_hash = Trie::<F, ARITY, HEIGHT>::compute_hash(hash_cache, *preimage);
+
+            if next != computed_hash {
+                return false;
+            }
+            next = preimage[*k];
+        }
+        next == value
+    }
+}
+
+pub struct InsertProof<F: LurkField, const ARITY: usize, const HEIGHT: usize> {
+    old_proof: LookupProof<F, ARITY, HEIGHT>,
+    new_proof: LookupProof<F, ARITY, HEIGHT>,
+}
+
+impl<F: LurkField, const ARITY: usize, const HEIGHT: usize> InsertProof<F, ARITY, HEIGHT> {
+    fn new(
+        old_proof: LookupProof<F, ARITY, HEIGHT>,
+        new_proof: LookupProof<F, ARITY, HEIGHT>,
+    ) -> Self {
+        Self {
+            old_proof,
+            new_proof,
+        }
+    }
+
+    /// Verify an `InsertProof`. Note that this verification is exactly what must be proved in the circuit.
+    pub fn verify(
+        &self,
+        old_root: F,
+        new_root: F,
+        key: F,
+        old_value: Option<F>,
+        new_value: F,
+        hash_cache: &PoseidonCache<F>,
+    ) -> bool {
+        let old_verified = self.old_proof.verify(
+            old_root,
+            key,
+            old_value.unwrap_or_else(|| F::zero()),
+            hash_cache,
+        );
+
+        let new_verified = self.new_proof.verify(new_root, key, new_value, hash_cache);
+
+        let paths_differ_by_at_most_one = self
+            .old_proof
+            .preimage_path
+            .iter()
+            .zip(&self.new_proof.preimage_path)
+            .all(|(a, b)| {
+                let differing_postition_count = a
+                    .iter()
+                    .zip(b)
+                    .map(|(x, y)| x != y)
+                    .fold(0, |acc, are_diff| acc + are_diff as usize);
+                differing_postition_count == 1 || differing_postition_count == 0
+            });
+
+        old_verified && new_verified && paths_differ_by_at_most_one
+    }
+}
+
+impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARITY, HEIGHT> {
+    fn compute_hash(hash_cache: &PoseidonCache<F>, preimage: [F; ARITY]) -> F {
+        macro_rules! hash {
+            ($hash_name:ident, $n:expr) => {{
+                let mut buffer = [F::zero(); $n];
+                buffer.copy_from_slice(&preimage);
+
+                hash_cache.$hash_name(&buffer)
+            }};
+        }
+        match ARITY {
+            3 => hash!(hash3, 3),
+            4 => hash!(hash4, 4),
+            6 => hash!(hash6, 6),
+            8 => hash!(hash8, 8),
+            _ => unimplemented!(),
+        }
+    }
+
+    pub fn root(&self) -> F {
+        self.root
+    }
+
+    /// How many leaves does this `Trie` have?
+    pub const fn leaves(&self) -> usize {
+        self.row_size(HEIGHT)
+    }
+
+    /// How many nodes does the `row`th row have?
+    pub const fn row_size(&self, row: usize) -> usize {
+        debug_assert!(row <= HEIGHT);
+        (ARITY as u32).pow(row as u32) as usize
+    }
+
+    fn register_hash(&mut self, preimage: [F; ARITY]) -> F {
+        let hash = Self::compute_hash(self.hash_cache, preimage);
+
+        self.children.insert(FWrap(hash), preimage);
+        hash
+    }
+
+    fn get_hash_preimage(children: &ChildMap<F, ARITY>, hash: F) -> Option<&[F; ARITY]> {
+        children.get(&FWrap(hash))
+    }
+
+    // TODO: This is expensive and can be cached for the type.
+    fn init_empty(&mut self) {
+        self.empty_roots = [F::zero(); HEIGHT];
+
+        if HEIGHT == 0 {
+            return;
+        };
+
+        let mut preimage = [self.empty_roots[0]; ARITY];
+
+        for i in 0..HEIGHT {
+            let hash = self.register_hash(preimage);
+
+            self.empty_roots[i] = hash;
+
+            preimage = [hash; ARITY];
+            for elt in preimage.iter_mut().take(ARITY) {
+                *elt = hash;
+            }
+        }
+        self.count = 0;
+        self.root = self.empty_roots[HEIGHT - 1]
+    }
+
+    fn empty_root_for_height(&self, height: usize) -> F {
+        self.empty_roots[height - 1]
+    }
+
+    pub fn empty_root(&mut self) -> F {
+        self.empty_root_for_height(HEIGHT)
+    }
+    fn new(
+        poseidon_cache: &'a PoseidonCache<F>,
+        inverse_poseidon_cache: &'a mut InversePoseidonCache<F>,
+    ) -> Self {
+        // ARITY must be a power of two.
+        assert_eq!(1, ARITY.count_ones());
+
+        let mut new = Self {
+            root: Default::default(),
+            empty_roots: [F::zero(); HEIGHT],
+            hash_cache: poseidon_cache,
+            children: inverse_poseidon_cache,
+            count: 0,
+        };
+        new.init_empty();
+
+        new
+    }
+
+    /// Create a new `Trie` with specified root. The provided `PoseidonCache` must
+    fn new_with_root(store: &'a mut Store<F>, root: F) -> Self {
+        let poseidon_cache = &store.poseidon_cache;
+        let inverse_poseidon_cache = &mut store.inverse_poseidon_cache;
+        let mut new = Self::new(poseidon_cache, inverse_poseidon_cache);
+        // FIXME: count is not initialized.
+        new.root = root;
+
+        new
+    }
+
+    const fn arity_bits() -> usize {
+        ARITY.trailing_zeros() as usize
+    }
+
+    /// (arity_bits, path_bits)
+    const fn path_bit_dimensions() -> (usize, usize) {
+        let arity_bits = Self::arity_bits();
+        (arity_bits, arity_bits * HEIGHT)
+    }
+
+    fn path(key: F) -> Vec<usize> {
+        let mut bits = key.to_le_bits();
+        bits.reverse();
+
+        let (arity_bits, bits_needed) = Self::path_bit_dimensions();
+        let path = bits[bits.len() - bits_needed..]
+            .chunks(arity_bits)
+            .map(|chunk| {
+                let mut acc = 0;
+                for bit in chunk {
+                    acc *= 2;
+                    if *bit {
+                        acc += 1
+                    };
+                }
+                acc
+            })
+            .collect::<Vec<_>>();
+        path
+    }
+
+    // Returns a value corresponding to the commitment associated with `key`, if any.
+    // Note that this depends on the impossibility of discovering a value for which the commitment is zero.
+    // We could alternately return `F::zero()` for missing values, but instead return an `Option` to more clearly
+    // signal intent -- since the encoding of 'missing' values as `Fr::zero()` is significant.
+    pub fn lookup(&self, key: F) -> Result<Option<F>, Error<F>> {
+        self.lookup_aux(key).map(|payload| {
+            if payload == F::zero() {
+                None
+            } else {
+                Some(payload)
+            }
+        })
+    }
+
+    fn lookup_aux(&self, key: F) -> Result<F, Error<F>> {
+        let path = Self::path(key);
+        let preimage_path = Self::prove_lookup_aux(self.root, self.children, &path)?.preimage_path;
+
+        assert_eq!(path.len(), preimage_path.len());
+
+        let final_preimage = preimage_path[preimage_path.len() - 1];
+        let final_step = path[path.len() - 1];
+        Ok(final_preimage[final_step])
+    }
+
+    /// Returns a slice of preimages, corresponding to the path.
+    /// Final preimage contains payloads.
+    pub fn prove_lookup(&self, key: F) -> Result<LookupProof<F, ARITY, HEIGHT>, Error<F>> {
+        let path = Self::path(key);
+        Self::prove_lookup_aux(self.root, self.children, &path)
+    }
+
+    /// Returns a slice of preimages, corresponding to the path.
+    /// Final preimage contains payloads.
+    fn prove_lookup_aux(
+        root: F,
+        children: &ChildMap<F, ARITY>,
+        path: &[usize],
+    ) -> Result<LookupProof<F, ARITY, HEIGHT>, Error<F>> {
+        let mut preimages = Vec::with_capacity(path.len());
+
+        path.iter().try_fold(root, |next, k| {
+            if let Some(preimage) = Self::get_hash_preimage(children, next) {
+                preimages.push(*preimage);
+                Ok((*preimage)[*k])
+            } else {
+                Err(Error::MissingPreimage(next))
+            }
+        })?;
+
+        Ok(LookupProof::new(preimages))
+    }
+
+    pub fn insert(&mut self, key: F, value: F) -> Result<bool, Error<F>> {
+        let path = Self::path(key);
+        let (_insert_proof, inserted) = self.prove_insert_aux(&path, value)?;
+
+        Ok(inserted)
+    }
+
+    pub fn prove_insert(
+        &mut self,
+        key: F,
+        value: F,
+    ) -> Result<(InsertProof<F, ARITY, HEIGHT>, bool), Error<F>> {
+        let path = Self::path(key);
+        self.prove_insert_aux(&path, value)
+    }
+
+    fn prove_insert_aux(
+        &mut self,
+        path: &[usize],
+        value: F,
+    ) -> Result<(InsertProof<F, ARITY, HEIGHT>, bool), Error<F>> {
+        let old_proof = Self::prove_lookup_aux(self.root, self.children, path)?;
+
+        let mut new_value = value;
+        let mut proof = path
+            .iter()
+            .zip(&old_proof.preimage_path)
+            .rev()
+            .map(|(path_index, existing_preimage)| {
+                let mut new_preimage = *existing_preimage;
+                new_preimage[*path_index] = new_value;
+                let new_hash = self.register_hash(new_preimage);
+                new_value = new_hash;
+                new_preimage
+            })
+            .collect::<Vec<_>>();
+
+        proof.reverse();
+
+        let new_root = new_value;
+        let inserted = new_root != self.root;
+
+        if inserted {
+            self.count += 1
+        };
+        self.root = new_root;
+
+        let new_proof = LookupProof::new(proof);
+
+        Ok((InsertProof::new(old_proof, new_proof), inserted))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use ff::PrimeField;
+    use pasta_curves::pallas::Scalar as Fr;
+
+    #[test]
+    fn test_sizes() {
+        let p = PoseidonCache::<Fr>::default();
+        let mut p2 = InversePoseidonCache::<Fr>::default();
+        {
+            let t: Trie<'_, Fr, 8, 1> = Trie::new(&p, &mut p2);
+            assert_eq!(8, t.leaves());
+        }
+
+        {
+            let t: Trie<'_, Fr, 8, 2> = Trie::new(&p, &mut p2);
+            assert_eq!(64, t.leaves());
+        }
+
+        {
+            let t: Trie<'_, Fr, 8, 3> = Trie::new(&p, &mut p2);
+            assert_eq!(512, t.leaves());
+        }
+
+        {
+            let t: Trie<'_, Fr, 8, 4> = Trie::new(&p, &mut p2);
+            assert_eq!(1, t.row_size(0));
+            assert_eq!(8, t.row_size(1));
+            assert_eq!(64, t.row_size(2));
+            assert_eq!(512, t.row_size(3));
+            assert_eq!(4096, t.row_size(4));
+            assert_eq!(4096, t.leaves());
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn scalar_from_u64s(parts: [u64; 4]) -> Fr {
+        let mut le_bytes = [0u8; 32];
+        le_bytes[0..8].copy_from_slice(&parts[0].to_le_bytes());
+        le_bytes[8..16].copy_from_slice(&parts[1].to_le_bytes());
+        le_bytes[16..24].copy_from_slice(&parts[2].to_le_bytes());
+        le_bytes[24..32].copy_from_slice(&parts[3].to_le_bytes());
+        let mut repr = <Fr as PrimeField>::Repr::default();
+        repr.as_mut().copy_from_slice(&le_bytes[..]);
+        Fr::from_repr_vartime(repr).expect("u64s exceed scalar field modulus")
+    }
+
+    #[test]
+    fn test_hashes() {
+        let p = PoseidonCache::<Fr>::default();
+        let mut p2 = InversePoseidonCache::<Fr>::default();
+        {
+            let mut t0: Trie<'_, Fr, 8, 1> = Trie::new(&p, &mut p2);
+            assert_eq!(
+                scalar_from_u64s([
+                    0xa81830c13a876b1c,
+                    0x83b4610d346c2a33,
+                    0x528056fe84bb9846,
+                    0x0ef417527046e53c
+                ]),
+                t0.empty_root()
+            );
+            assert_eq!(t0.empty_root(), t0.root());
+        }
+        {
+            let mut t1: Trie<'_, Fr, 8, 2> = Trie::new(&p, &mut p2);
+            assert_eq!(
+                scalar_from_u64s([
+                    0x33ff39660bc554aa,
+                    0xd85d92c9279a65e7,
+                    0x8e0f305f27de3d65,
+                    0x089120e96e4b6dc5
+                ]),
+                t1.empty_root()
+            );
+            assert_eq!(t1.empty_root(), t1.root());
+        }
+        {
+            let mut t2: Trie<'_, Fr, 8, 3> = Trie::new(&p, &mut p2);
+            assert_eq!(
+                scalar_from_u64s([
+                    0xa52e7d0bbbee086b,
+                    0x06e4ba3d56dbd7fa,
+                    0xed7adffde497af73,
+                    0x2fd6f6c5e5d21d60
+                ]),
+                t2.empty_root()
+            );
+            assert_eq!(t2.empty_root(), t2.root());
+        }
+        {
+            let mut t3: Trie<'_, Fr, 8, 4> = Trie::new(&p, &mut p2);
+            assert_eq!(
+                scalar_from_u64s([
+                    0xd95987b58e6c5852,
+                    0x261c08dca064c6c3,
+                    0x191320220a5d5d84,
+                    0x2cdb105f591c0e94
+                ]),
+                t3.empty_root()
+            );
+            assert_eq!(t3.empty_root(), t3.root());
+        }
+    }
+
+    #[test]
+    fn test_path() {
+        assert_eq!(vec![7, 6, 4], Trie::<Fr, 8, 3>::path(Fr::from_u64(500)));
+    }
+
+    #[test]
+    fn test_lookup() {
+        let p = PoseidonCache::<Fr>::default();
+        let mut p2 = InversePoseidonCache::<Fr>::default();
+        {
+            let t3: Trie<'_, Fr, 8, 3> = Trie::new(&p, &mut p2);
+
+            let found = t3.lookup(Fr::from_u64(500)).unwrap();
+            assert_eq!(None, found);
+        }
+    }
+    #[test]
+    fn test_lookup_proof() {
+        let p = PoseidonCache::<Fr>::default();
+        let mut p2 = InversePoseidonCache::<Fr>::default();
+        {
+            let t3: Trie<'_, Fr, 8, 3> = Trie::new(&p, &mut p2);
+            let root = t3.root();
+            let key = Fr::from_u64(500);
+            let proof = t3.prove_lookup(key).unwrap();
+
+            let fresh_p = PoseidonCache::<Fr>::default();
+            let verified = proof.verify(root, key, Fr::zero(), &fresh_p);
+            assert_eq!(true, verified);
+        }
+    }
+
+    #[test]
+    fn test_insert() {
+        // TODO: Use prop tests.
+
+        let p = PoseidonCache::<Fr>::default();
+        let mut p2 = InversePoseidonCache::<Fr>::default();
+        {
+            let mut t3: Trie<'_, Fr, 8, 3> = Trie::new(&p, &mut p2);
+            let key = Fr::from_u64(500);
+            let val = Fr::from_u64(123);
+
+            let key2 = Fr::from_u64(127);
+            let val2 = Fr::from_u64(987);
+
+            {
+                let found = t3.lookup(key).unwrap();
+                assert_eq!(None, found);
+            }
+
+            t3.insert(key, val).unwrap();
+
+            {
+                let found = t3.lookup(key).unwrap();
+                assert_eq!(Some(val), found);
+                let found2 = t3.lookup(key2).unwrap();
+                assert_eq!(None, found2);
+            }
+
+            t3.insert(key2, val2).unwrap();
+            {
+                let found = t3.lookup(key).unwrap();
+                assert_eq!(Some(val), found);
+                let found2 = t3.lookup(key2).unwrap();
+                assert_eq!(Some(val2), found2);
+            }
+        }
+    }
+
+    #[test]
+    fn test_insert_proof() {
+        let p = PoseidonCache::<Fr>::default();
+        let mut p2 = InversePoseidonCache::<Fr>::default();
+        {
+            let mut t3: Trie<'_, Fr, 8, 3> = Trie::new(&p, &mut p2);
+            let key = Fr::from_u64(500);
+            let val = Fr::from_u64(123);
+
+            let key2 = Fr::from_u64(127);
+            let val2 = Fr::from_u64(987);
+            let val3 = Fr::from_u64(444);
+
+            {
+                let proof = t3.prove_lookup(key).unwrap();
+                let root = t3.root;
+
+                let fresh_p = PoseidonCache::<Fr>::default();
+                let verified = proof.verify(root, key, Fr::zero(), &fresh_p);
+                assert_eq!(true, verified);
+            }
+
+            let old_root = t3.root;
+            let (insert_proof, inserted) = t3.prove_insert(key, val).unwrap();
+
+            assert_eq!(true, inserted);
+
+            {
+                let root = t3.root;
+                let fresh_p = PoseidonCache::<Fr>::default();
+
+                let verified = insert_proof.verify(old_root, root, key, None, val, &fresh_p);
+                assert_eq!(true, verified);
+
+                {
+                    let proof = t3.prove_lookup(key).unwrap();
+
+                    let verified = proof.verify(root, key, val, &fresh_p);
+                    assert_eq!(true, verified);
+                }
+                {
+                    let proof2 = t3.prove_lookup(key2).unwrap();
+
+                    let verified = proof2.verify(root, key2, Fr::zero(), &fresh_p);
+                    assert_eq!(true, verified);
+                }
+            }
+
+            let old_root = t3.root;
+            let (insert_proof2, inserted2) = t3.prove_insert(key2, val2).unwrap();
+            assert_eq!(true, inserted2);
+
+            {
+                let root = t3.root;
+                let fresh_p = PoseidonCache::<Fr>::default();
+
+                {
+                    let verified = insert_proof2.verify(old_root, root, key2, None, val2, &fresh_p);
+                    assert_eq!(true, verified);
+                }
+                {
+                    let proof = t3.prove_lookup(key).unwrap();
+                    let root = t3.root;
+
+                    let fresh_p = PoseidonCache::<Fr>::default();
+                    let verified = proof.verify(root, key, val, &fresh_p);
+                    assert_eq!(true, verified);
+                }
+                {
+                    let proof2 = t3.prove_lookup(key2).unwrap();
+                    let root = t3.root;
+
+                    let fresh_p = PoseidonCache::<Fr>::default();
+                    let verified = proof2.verify(root, key2, val2, &fresh_p);
+                    assert_eq!(true, verified);
+                }
+            }
+            let (_, inserted2a) = t3.prove_insert(key2, val2).unwrap();
+            assert_eq!(false, inserted2a);
+
+            let old_root = t3.root;
+            let (insert_proof3, inserted3) = t3.prove_insert(key2, val3).unwrap();
+            assert_eq!(true, inserted3);
+            {
+                let root = t3.root;
+                let fresh_p = PoseidonCache::<Fr>::default();
+
+                let verified =
+                    insert_proof3.verify(old_root, root, key2, Some(val2), val3, &fresh_p);
+                assert_eq!(true, verified);
+
+                {
+                    let proof = t3.prove_lookup(key).unwrap();
+                    let verified = proof.verify(root, key, val, &fresh_p);
+                    assert_eq!(true, verified);
+                }
+                {
+                    let proof2 = t3.prove_lookup(key2).unwrap();
+                    let verified = proof2.verify(root, key2, val3, &fresh_p);
+                    assert_eq!(true, verified);
+                }
+            }
+        }
+    }
+}

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -267,7 +267,6 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
         children.get(&FWrap(hash))
     }
 
-    // TODO: This is expensive and can be cached for the type.
     fn init_empty(&mut self) {
         self.empty_roots = [F::zero(); HEIGHT];
 

--- a/src/eval/tests/mod.rs
+++ b/src/eval/tests/mod.rs
@@ -10,6 +10,7 @@ use lurk_macros::{let_store, lurk, Coproc};
 use pasta_curves::pallas::Scalar as Fr;
 
 use crate as lurk;
+mod trie;
 
 fn test_aux<C: Coprocessor<Fr>>(
     s: &mut Store<Fr>,

--- a/src/eval/tests/trie.rs
+++ b/src/eval/tests/trie.rs
@@ -13,29 +13,30 @@ fn trie_lang() {
     let expr = "(let ((trie (.lurk.trie.new)))
                       trie)";
     let res = s
-        .read("0x1f9e4f688af715843a6878202c0387841d2280b7fbec9a66c7b0aaeb39703bca")
+        .read("0x1cc5b90039db85fd519af975afa1de9d2b92960a585a546637b653b115bc3b53")
         .unwrap();
 
     test_aux(s, &expr, Some(res), None, None, None, 3, Some(&lang));
 
-    // TODO: coprocessors need to evaluate their arguments for this to work.
+    // TODO: Coprocessors need to evaluate their arguments for this to work.
+    //       See https://github.com/lurk-lab/lurk-rs/issues/398.
     // let expr2 = "(let ((trie (.lurk.trie.new))
     //                    (found (.lurk.trie.lookup trie 123)))
     //                   found)";
 
-    let expr2 = "(.lurk.trie.lookup 0x1f9e4f688af715843a6878202c0387841d2280b7fbec9a66c7b0aaeb39703bca 123)";
+    let expr2 = "(.lurk.trie.lookup 0x1cc5b90039db85fd519af975afa1de9d2b92960a585a546637b653b115bc3b53 123)";
     let res2 = s.intern_opaque_comm(Fr::zero());
 
     test_aux(s, &expr2, Some(res2), None, None, None, 1, Some(&lang));
 
-    let expr3 = "(.lurk.trie.insert 0x1f9e4f688af715843a6878202c0387841d2280b7fbec9a66c7b0aaeb39703bca 123 456)";
+    let expr3 = "(.lurk.trie.insert 0x1cc5b90039db85fd519af975afa1de9d2b92960a585a546637b653b115bc3b53 123 456)";
     let res3 = s
-        .read("0x31a82c9a2e7ebfccccc0c02a2e4341c34b0b8b563aa0cb5815d3d8355e262ff9")
+        .read("0x1b22dc5a394231c34e4529af674dc56a736fbd07508acfd1d12c0e67c8b4de27")
         .unwrap();
 
     test_aux(s, &expr3, Some(res3), None, None, None, 1, Some(&lang));
 
-    let expr4 = "(.lurk.trie.lookup 0x31a82c9a2e7ebfccccc0c02a2e4341c34b0b8b563aa0cb5815d3d8355e262ff9 123)";
+    let expr4 = "(.lurk.trie.lookup 0x1b22dc5a394231c34e4529af674dc56a736fbd07508acfd1d12c0e67c8b4de27 123)";
     let res4 = s.intern_opaque_comm(Fr::from(456));
 
     test_aux(s, &expr4, Some(res4), None, None, None, 1, Some(&lang));

--- a/src/eval/tests/trie.rs
+++ b/src/eval/tests/trie.rs
@@ -1,0 +1,42 @@
+use super::*;
+use pasta_curves::pallas::Scalar as Fr;
+
+#[test]
+fn trie_lang() {
+    use crate::coprocessor::trie::{install, TrieCoproc};
+
+    let s = &mut Store::<Fr>::default();
+    let mut lang = Lang::<Fr, TrieCoproc<Fr>>::new();
+
+    install(s, &mut lang);
+
+    let expr = "(let ((trie (.lurk.trie.new)))
+                      trie)";
+    let res = s
+        .read("0x1f9e4f688af715843a6878202c0387841d2280b7fbec9a66c7b0aaeb39703bca")
+        .unwrap();
+
+    test_aux(s, &expr, Some(res), None, None, None, 3, Some(&lang));
+
+    // TODO: coprocessors need to evaluate their arguments for this to work.
+    // let expr2 = "(let ((trie (.lurk.trie.new))
+    //                    (found (.lurk.trie.lookup trie 123)))
+    //                   found)";
+
+    let expr2 = "(.lurk.trie.lookup 0x1f9e4f688af715843a6878202c0387841d2280b7fbec9a66c7b0aaeb39703bca 123)";
+    let res2 = s.intern_opaque_comm(Fr::zero());
+
+    test_aux(s, &expr2, Some(res2), None, None, None, 1, Some(&lang));
+
+    let expr3 = "(.lurk.trie.insert 0x1f9e4f688af715843a6878202c0387841d2280b7fbec9a66c7b0aaeb39703bca 123 456)";
+    let res3 = s
+        .read("0x31a82c9a2e7ebfccccc0c02a2e4341c34b0b8b563aa0cb5815d3d8355e262ff9")
+        .unwrap();
+
+    test_aux(s, &expr3, Some(res3), None, None, None, 1, Some(&lang));
+
+    let expr4 = "(.lurk.trie.lookup 0x31a82c9a2e7ebfccccc0c02a2e4341c34b0b8b563aa0cb5815d3d8355e262ff9 123)";
+    let res4 = s.intern_opaque_comm(Fr::from(456));
+
+    test_aux(s, &expr4, Some(res4), None, None, None, 1, Some(&lang));
+}

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,6 +1,7 @@
+use std::collections::HashMap;
 use std::hash::Hash;
 
-use crate::field::LurkField;
+use crate::field::{FWrap, LurkField};
 use generic_array::typenum::{U3, U4, U6, U8};
 use neptune::{poseidon::PoseidonConstants, Poseidon};
 use once_cell::sync::OnceCell;
@@ -87,6 +88,58 @@ pub struct PoseidonCache<F: LurkField> {
     a8: dashmap::DashMap<CacheKey<F, 8>, F, ahash::RandomState>,
 
     pub constants: HashConstants<F>,
+}
+
+#[derive(Default, Debug)]
+pub struct InversePoseidonCache<F: LurkField> {
+    a3: HashMap<FWrap<F>, [F; 3]>,
+    a4: HashMap<FWrap<F>, [F; 4]>,
+    a6: HashMap<FWrap<F>, [F; 6]>,
+    a8: HashMap<FWrap<F>, [F; 8]>,
+
+    pub constants: HashConstants<F>,
+}
+
+impl<F: LurkField> InversePoseidonCache<F> {
+    pub fn get<const ARITY: usize>(&self, key: &FWrap<F>) -> Option<&[F; ARITY]> {
+        macro_rules! get {
+            ($name:ident, $n: expr) => {{
+                let preimage = self.$name.get(key);
+                if let Some(p) = preimage {
+                    assert_eq!(ARITY, $n);
+                    Some(unsafe { std::mem::transmute::<&[F; $n], &[F; ARITY]>(p) })
+                } else {
+                    None
+                }
+            }};
+        }
+
+        match ARITY {
+            3 => get!(a3, 3),
+            4 => get!(a4, 4),
+            6 => get!(a6, 6),
+            8 => get!(a8, 8),
+            _ => unreachable!(),
+        }
+    }
+    pub fn insert<const ARITY: usize>(&mut self, key: FWrap<F>, preimage: [F; ARITY]) {
+        macro_rules! insert {
+            ($name:ident, $n:expr) => {{
+                let mut buffer = [F::zero(); $n];
+                buffer.copy_from_slice(&preimage);
+
+                self.$name.insert(key, buffer);
+            }};
+        }
+
+        match ARITY {
+            3 => insert!(a3, 3),
+            4 => insert!(a4, 4),
+            6 => insert!(a6, 6),
+            8 => insert!(a8, 8),
+            _ => unreachable!(),
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -90,6 +90,26 @@ pub struct PoseidonCache<F: LurkField> {
     pub constants: HashConstants<F>,
 }
 
+impl<F: LurkField> PoseidonCache<F> {
+    pub fn compute_hash<const ARITY: usize>(&self, preimage: [F; ARITY]) -> F {
+        macro_rules! hash {
+            ($hash_name:ident, $n:expr) => {{
+                assert_eq!(ARITY, $n);
+                // SAFETY: we are just teaching the compiler that the slice has size, ARITY, which is guaranteed by
+                // the assertion above.
+                self.$hash_name(unsafe { std::mem::transmute::<&[F; ARITY], &[F; $n]>(&preimage) })
+            }};
+        }
+        match ARITY {
+            3 => hash!(hash3, 3),
+            4 => hash!(hash4, 4),
+            6 => hash!(hash6, 6),
+            8 => hash!(hash8, 8),
+            _ => unreachable!(),
+        }
+    }
+}
+
 #[derive(Default, Debug)]
 pub struct InversePoseidonCache<F: LurkField> {
     a3: HashMap<FWrap<F>, [F; 3]>,

--- a/src/store.rs
+++ b/src/store.rs
@@ -19,7 +19,7 @@ use crate::sym::Sym;
 use crate::tag::{ContTag, ExprTag, Op1, Op2, Tag};
 use crate::{Num, UInt};
 
-use crate::hash::{HashConstants, IntoHashComponents, PoseidonCache};
+use crate::hash::{HashConstants, IntoHashComponents, InversePoseidonCache, PoseidonCache};
 
 #[derive(Clone, Copy, Debug)]
 pub enum HashScalar {
@@ -87,6 +87,8 @@ pub struct Store<F: LurkField> {
 
     /// Caches poseidon hashes
     pub poseidon_cache: PoseidonCache<F>,
+    /// Caches poseidon preimages
+    pub inverse_poseidon_cache: InversePoseidonCache<F>,
     /// Contains Ptrs which have not yet been hydrated.
     pub dehydrated: Vec<Ptr<F>>,
     pub dehydrated_cont: Vec<ContPtr<F>>,
@@ -142,6 +144,7 @@ impl<F: LurkField> Default for Store<F> {
             scalar_ptr_map: Default::default(),
             scalar_ptr_cont_map: Default::default(),
             poseidon_cache: Default::default(),
+            inverse_poseidon_cache: Default::default(),
             dehydrated: Default::default(),
             dehydrated_cont: Default::default(),
             pointer_scalar_ptr_cache: Default::default(),


### PR DESCRIPTION
This PR adds a trie coprocessor (no circuit yet) theoretically suitable as a key-value store/map. Apart from the lack of a circuit, this implementation is also incomplete due to limitations in coprocessor support generally. One purpose of this work is to uncover such issues.

- The type (tag) of keys is currently ignored. Future work should require that keys all have the same type.
- Arity of the hash used must be a power of two. In practice, this should be 8 for efficiency.
- The value/hash of a key is converted into a bit path and chunked. For example, an 8-ary trie uses paths of 3 bits at a time.
- Values stored are assumed to be commitments. A value of `0` (for which we know no preimage) is used to represent a missing key.

In order for previously-built tries to be readable, hash preimages need to be retained. A general solution might involve allowing individual coprocessor instances to enhance the store. This PR does something simpler and adds a new map of preimages to the store.

The most significant problem with the trie interface is that when coprocessors are invoked, their arguments are not currently evaluated. The tests in `trie_lang` show that, using a store that is aware of the trie's construction, a trie can be successfully queried. However, that currently requires that *its root hash be hard-coded into the source*.

This is an obviously problematic limitation, and that needs to be addressed by extending the coprocessor interface to pass *evaluated* arguments to the coprocessor.