### PR TITLE
Cleanup and optimize implication constraints.

### DIFF
--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -5314,9 +5314,9 @@ mod tests {
             assert!(delta == Delta::Equal);
 
             //println!("{}", print_cs(&cs));
-            assert_eq!(12096, cs.num_constraints());
+            assert_eq!(12035, cs.num_constraints());
             assert_eq!(13, cs.num_inputs());
-            assert_eq!(11751, cs.aux().len());
+            assert_eq!(11690, cs.aux().len());
 
             let public_inputs = multiframe.public_inputs();
             let mut rng = rand::thread_rng();

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -5230,7 +5230,7 @@ pub(crate) fn print_cs<F: LurkField, C: Comparable<F>>(this: &C) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::circuit::circuit_frame::constraints::{popcount, sub};
+    use crate::circuit::circuit_frame::constraints::{popcount_equal, sub};
     use crate::eval::{
         empty_sym_env,
         lang::{Coproc, Lang},
@@ -5857,28 +5857,24 @@ mod tests {
     #[test]
     fn test_enforce_popcount() {
         let mut cs = TestConstraintSystem::<Fr>::new();
-        let s = &mut Store::<Fr>::default();
 
         for x in 0..128 {
-            let a = s.num(x);
             let alloc_a =
-                AllocatedPtr::alloc_ptr(&mut cs.namespace(|| x.to_string()), s, || Ok(&a)).unwrap();
+                AllocatedNum::alloc(&mut cs.namespace(|| x.to_string()), || Ok(Fr::from(x)))
+                    .unwrap();
             let bits = alloc_a
-                .hash()
                 .to_bits_le(&mut cs.namespace(|| format!("bits_{x}")))
                 .unwrap();
-            let popcount_result = s.num(x.count_ones() as u64);
-            let alloc_popcount = AllocatedPtr::alloc_ptr(
-                &mut cs.namespace(|| format!("alloc popcount {x}")),
-                s,
-                || Ok(&popcount_result),
-            )
-            .unwrap();
+            let popcount_result =
+                AllocatedNum::alloc(&mut cs.namespace(|| format!("alloc popcount {x}")), || {
+                    Ok(Fr::from(x.count_ones() as u64))
+                })
+                .unwrap();
 
-            popcount(
+            popcount_equal(
                 &mut cs.namespace(|| format!("popcount {x}")),
                 &bits,
-                alloc_popcount.hash(),
+                popcount_result.get_variable(),
             )
             .unwrap();
         }

--- a/src/circuit/gadgets/constraints.rs
+++ b/src/circuit/gadgets/constraints.rs
@@ -106,7 +106,6 @@ pub(crate) fn popcount_lc<F: PrimeField, CS: ConstraintSystem<F>>(
 
 /// Adds a constraint to CS, enforcing that the addition of the allocated numbers in vector `v`
 /// is equal to the value of the variable, `sum`.
-#[allow(dead_code)]
 pub(crate) fn popcount_equal<F: PrimeField, CS: ConstraintSystem<F>>(
     cs: &mut CS,
     v: &[Boolean],
@@ -129,7 +128,7 @@ pub(crate) fn popcount_equal<F: PrimeField, CS: ConstraintSystem<F>>(
 /// is equal to `one`.
 ///
 /// summation(v) = one
-#[allow(dead_code)]
+#[inline]
 pub(crate) fn enforce_popcount_one<F: PrimeField, CS: ConstraintSystem<F>>(
     cs: &mut CS,
     v: &[Boolean],

--- a/src/lem/constrainer.rs
+++ b/src/lem/constrainer.rs
@@ -7,8 +7,8 @@ use bellperson::{
 
 use crate::circuit::gadgets::{
     constraints::{
-        alloc_equal_const, and, enforce_equal, enforce_equal_zero, enforce_selector_with_premise,
-        implies_equal, implies_equal_zero, popcount_one,
+        alloc_equal_const, and, enforce_equal, enforce_equal_zero, enforce_popcount_one,
+        enforce_selector_with_premise, implies_equal, implies_equal_zero,
     },
     pointer::AllocatedPtr,
 };
@@ -276,7 +276,7 @@ impl LEM {
                         };
                     } else {
                         // If `concrete_path` is None, we just do regular constraining
-                        let Ok(_) = popcount_one(
+                        let Ok(_) = enforce_popcount_one(
                             &mut cs.namespace(|| format!("{}.enforce exactly one selected", &path)),
                             &concrete_path_vec[..],
                         ) else {

--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -28,11 +28,12 @@ mod tests {
     use super::*;
     use crate::field::LurkField;
     use crate::lem::{pointers::Ptr, store::Store};
-    use bellperson::util_cs::test_cs::TestConstraintSystem;
+    use bellperson::util_cs::{test_cs::TestConstraintSystem, Comparable};
     use blstrs::Scalar as Fr;
 
     const NUM_INPUTS: usize = 13;
-    const NUM_CONSTRAINTS: usize = 68;
+    const NUM_AUX: usize = 20;
+    const NUM_CONSTRAINTS: usize = 29;
 
     fn test_eval_and_constrain_aux(store: &mut Store<Fr>, pairs: Vec<(Ptr<Fr>, Ptr<Fr>)>) {
         let lem = step().unwrap();
@@ -51,6 +52,7 @@ mod tests {
                 lem.constrain(&mut cs, store, &witness).unwrap();
                 assert!(cs.is_satisfied());
                 assert_eq!(cs.num_inputs(), NUM_INPUTS);
+                assert_eq!(cs.aux().len(), NUM_AUX);
                 assert_eq!(cs.num_constraints(), NUM_CONSTRAINTS);
             }
         }

--- a/src/lem/store.rs
+++ b/src/lem/store.rs
@@ -218,7 +218,7 @@ impl<F: LurkField> Store<F> {
             components.push(head);
             self.vec_str_cache.insert(components.clone(), ptr);
             self.sym_path_cache
-                .insert(ptr, components.iter().rev().cloned().collect_vec());
+                .insert(ptr, components.iter().rev().cloned().collect());
         }
         ptr
     }

--- a/src/lem/store.rs
+++ b/src/lem/store.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 
 use dashmap::DashMap;
 use indexmap::IndexSet;
-use itertools::Itertools;
 
 use crate::{
     field::{FWrap, LurkField},
@@ -41,7 +40,7 @@ pub struct Store<F: LurkField> {
     ptrs3: IndexSet<(Ptr<F>, Ptr<F>, Ptr<F>)>,
     ptrs4: IndexSet<(Ptr<F>, Ptr<F>, Ptr<F>, Ptr<F>)>,
 
-    vec_char_cache: HashMap<Vec<char>, Ptr<F>>,
+    vec_char_cache: HashMap<String, Ptr<F>>,
     vec_str_cache: HashMap<Vec<String>, Ptr<F>>,
 
     pub poseidon_cache: PoseidonCache<F>,
@@ -155,7 +154,7 @@ impl<F: LurkField> Store<F> {
     /// `"c"`, `"bc"` and `"abc"` stored in `vec_char_cache` as `['c']`,
     /// `['c', 'b']` and `['c', 'b', 'a']` respectively.
     pub fn intern_string(&mut self, s: &String) -> Ptr<F> {
-        let mut chars = s.chars().rev().collect_vec();
+        let mut chars = s.chars().rev().collect::<String>();
         let mut ptr;
         let mut heads = vec![];
         loop {


### PR DESCRIPTION
While reviewing #402, I noticed that the idea for implication constraints there could be propagated more broadly. This represents a low-hanging optimization to existing code, which obtains implication constraints through composition in a way that incurs unnecessary constraints.

This PR
- cleans up some of the linear-combination construction from #402.
- factors all implication-related functions for clarity and to encourage the economical construction.
- removes 61 constraints from the current circuit.
- cuts the constraints in #402's example by more than half (68 -> 29).

Since the LEM approach will lean heavily on implication, it's a good idea to finally ensure our basic construct for implementing it is efficient. That will help us maintain a relatively accurate sense of costs as we continue to epxlore.

TODO:
- all the implication gadgets need tests. This would be a good exercise for @arthurpaulino, @gabriel-barrett, with guidance from @emmorais.

Of course, my work here should also be reviewed for correctness (cc: @emmorais).