### PR TITLE
refactor: Refactor error handling using anyhow crate

### DIFF
--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -1,8 +1,9 @@
 use super::{shortcuts::*, tag::Tag, LEM, LEMOP};
+use anyhow::Result;
 
 /// This is Lurk's step function encoded as a LEM
 #[allow(dead_code)]
-pub(crate) fn step() -> Result<LEM, String> {
+pub(crate) fn step() -> Result<LEM> {
     let input = ["expr_in", "env_in", "cont_in"];
     let lem_op = match_tag(
         mptr("expr_in"),


### PR DESCRIPTION
- Replace `String` error types with `anyhow::Result` in multiple files for improved error handling
- Implement usage of `anyhow!` and `bail!` macros to replace `format!` in error messages