### PR TITLE
refactor: Improve error handling using with_context

### DIFF
--- a/src/lem/interpreter.rs
+++ b/src/lem/interpreter.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
-use anyhow::{Result, anyhow, bail};
 use crate::field::{FWrap, LurkField};
+use anyhow::{anyhow, bail, Result};
+use std::collections::HashMap;
 
 use super::{pointers::Ptr, store::Store, symbol::Symbol, tag::Tag, Witness, LEM, LEMOP};
 

--- a/src/lem/mod.rs
+++ b/src/lem/mod.rs
@@ -6,9 +6,9 @@ mod store;
 mod symbol;
 mod tag;
 
-use std::collections::HashMap;
-use anyhow::{Result, anyhow, bail};
 use crate::field::LurkField;
+use anyhow::{anyhow, bail, Result};
+use std::collections::HashMap;
 
 use self::{pointers::Ptr, store::Store, tag::Tag};
 


### PR DESCRIPTION
- Improve error handling by replacing `map_err` with `with_context`
- Reorder import statements in `interpreter.rs` and `mod.rs`