### PR TITLE
fix: Improve macro handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::single_match, clippy::type_complexity)]
 #![allow(clippy::uninlined_format_args)]
 #![warn(rust_2018_idioms, unreachable_pub)]
+#![feature(trace_macros)]
 
 #[macro_use]
 extern crate alloc;


### PR DESCRIPTION
- Use `trace_macros` feature flag in `src/lib.rs`
- Resolve macro conflicts in `src/lem/mod.rs` by fixing lemop rules

CI is 100% expected to fail with 
```
error[E0554]: `#![feature]` may not be used on the stable release channel

```