### PR TITLE
Rectify language fields

### DIFF
--- a/benches/end2end.rs
+++ b/benches/end2end.rs
@@ -15,6 +15,7 @@ use lurk::{
     public_parameters,
     store::Store,
 };
+use pasta_curves::pallas;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -46,8 +47,7 @@ fn end2end_benchmark(c: &mut Criterion) {
         .sample_size(10);
 
     let limit = 1_000_000_000;
-    let lang_pallas =
-        Lang::<pasta_curves::pallas::Scalar, Coproc<pasta_curves::pallas::Scalar>>::new();
+    let lang_pallas = Lang::<pallas::Scalar, Coproc<pallas::Scalar>>::new();
     let lang_pallas_rc = Arc::new(lang_pallas.clone());
     let reduction_count = DEFAULT_REDUCTION_COUNT;
 
@@ -64,7 +64,7 @@ fn end2end_benchmark(c: &mut Criterion) {
 
     group.bench_with_input(benchmark_id, &size, |b, &s| {
         b.iter(|| {
-            let ptr = go_base::<pasta_curves::pallas::Scalar>(&mut store, s.0, s.1);
+            let ptr = go_base::<pallas::Scalar>(&mut store, s.0, s.1);
             let _result = prover
                 .evaluate_and_prove(&pp, ptr, env, &mut store, limit, lang_pallas_rc.clone())
                 .unwrap();
@@ -81,7 +81,7 @@ fn store_benchmark(c: &mut Criterion) {
         .sample_size(60);
 
     let mut bls12_store = Store::<Fr>::default();
-    let mut pallas_store = Store::<pasta_curves::Fp>::default();
+    let mut pallas_store = Store::<pallas::Scalar>::default();
 
     // todo!() rfc out into more flexible test cases
     let sizes = vec![(10, 16), (10, 160)];
@@ -99,7 +99,7 @@ fn store_benchmark(c: &mut Criterion) {
         let pasta_id = BenchmarkId::new("store_go_base_pallas", &parameter_string);
         group.bench_with_input(pasta_id, &size, |b, &s| {
             b.iter(|| {
-                let result = go_base::<pasta_curves::Fp>(&mut pallas_store, s.0, s.1);
+                let result = go_base::<pallas::Scalar>(&mut pallas_store, s.0, s.1);
                 black_box(result)
             })
         });
@@ -115,7 +115,7 @@ fn hydration_benchmark(c: &mut Criterion) {
         .sample_size(60);
 
     let mut bls12_store = Store::<Fr>::default();
-    let mut pallas_store = Store::<pasta_curves::Fp>::default();
+    let mut pallas_store = Store::<pallas::Scalar>::default();
 
     // todo!() rfc out into more flexible test cases
     let sizes = vec![(10, 16), (10, 160)];
@@ -133,7 +133,7 @@ fn hydration_benchmark(c: &mut Criterion) {
         {
             let benchmark_id = BenchmarkId::new("hydration_go_base_pallas", &parameter_string);
             group.bench_with_input(benchmark_id, &size, |b, &s| {
-                let _ptr = go_base::<pasta_curves::Fp>(&mut pallas_store, s.0, s.1);
+                let _ptr = go_base::<pallas::Scalar>(&mut pallas_store, s.0, s.1);
                 b.iter(|| pallas_store.hydrate_scalar_cache())
             });
         }
@@ -150,9 +150,9 @@ fn eval_benchmark(c: &mut Criterion) {
 
     let limit = 1_000_000_000;
     let lang_bls12 = Lang::<Fr, Coproc<Fr>>::new();
-    let lang_pallas = Lang::<pasta_curves::Fp, Coproc<pasta_curves::Fp>>::new();
+    let lang_pallas = Lang::<pallas::Scalar, Coproc<pallas::Scalar>>::new();
     let mut bls12_store = Store::<Fr>::default();
-    let mut pallas_store = Store::<pasta_curves::Fp>::default();
+    let mut pallas_store = Store::<pallas::Scalar>::default();
 
     // todo!() rfc out into more flexible test cases
     let sizes = vec![(10, 16), (10, 160)];
@@ -179,7 +179,7 @@ fn eval_benchmark(c: &mut Criterion) {
         {
             let benchmark_id = BenchmarkId::new("eval_go_base_pallas", &parameter_string);
             group.bench_with_input(benchmark_id, &size, |b, &s| {
-                let ptr = go_base::<pasta_curves::Fp>(&mut pallas_store, s.0, s.1);
+                let ptr = go_base::<pallas::Scalar>(&mut pallas_store, s.0, s.1);
                 b.iter(|| {
                     Evaluator::new(
                         ptr,
@@ -205,15 +205,15 @@ fn eval_benchmark(c: &mut Criterion) {
 
 //     let limit = 1_000_000_000;
 //     let _lang_bls = Lang::<Fr, Coproc<Fr>>::new();
-//     let _lang_pallas = Lang::<pasta_curves::Fp, Coproc<pasta_curves::Fp>>::new();
-//     let lang_pallas = Lang::<pasta_curves::pallas::Scalar, Coproc<pasta_curves::pallas::Scalar>>::new();
+//     let _lang_pallas = Lang::<pallas::Scalar, Coproc<pallas::Scalar>>::new();
+//     let lang_pallas = Lang::<pallas::Scalar, Coproc<pallas::Scalar>>::new();
 
 //     let reduction_count = DEFAULT_REDUCTION_COUNT;
 
 //     group.bench_function("circuit_generation_go_base_10_16_nova", |b| {
 //         let mut store = Store::default();
 //         let env = empty_sym_env(&store);
-//         let ptr = go_base::<pasta_curves::pallas::Scalar>(&mut store, black_box(10), black_box(16));
+//         let ptr = go_base::<pallas::Scalar>(&mut store, black_box(10), black_box(16));
 //         let prover = NovaProver::new(reduction_count, lang_pallas.clone());
 
 //         let pp = public_parameters::public_params(reduction_count).unwrap();
@@ -238,8 +238,7 @@ fn prove_benchmark(c: &mut Criterion) {
         .sample_size(10);
 
     let limit = 1_000_000_000;
-    let lang_pallas =
-        Lang::<pasta_curves::pallas::Scalar, Coproc<pasta_curves::pallas::Scalar>>::new();
+    let lang_pallas = Lang::<pallas::Scalar, Coproc<pallas::Scalar>>::new();
     let lang_pallas_rc = Arc::new(lang_pallas.clone());
     let mut store = Store::default();
     let reduction_count = DEFAULT_REDUCTION_COUNT;
@@ -248,7 +247,7 @@ fn prove_benchmark(c: &mut Criterion) {
     let benchmark_id = BenchmarkId::new("prove_go_base_nova", format!("_{}_{}", size.0, size.1));
 
     group.bench_with_input(benchmark_id, &size, |b, &s| {
-        let ptr = go_base::<pasta_curves::pallas::Scalar>(&mut store, s.0, s.1);
+        let ptr = go_base::<pallas::Scalar>(&mut store, s.0, s.1);
         let prover = NovaProver::new(reduction_count, lang_pallas.clone());
         let pp = public_parameters::public_params(reduction_count, lang_pallas_rc.clone()).unwrap();
         let frames = prover
@@ -271,8 +270,7 @@ fn verify_benchmark(c: &mut Criterion) {
         .sample_size(10);
 
     let limit = 1_000_000_000;
-    let lang_pallas =
-        Lang::<pasta_curves::pallas::Scalar, Coproc<pasta_curves::pallas::Scalar>>::new();
+    let lang_pallas = Lang::<pallas::Scalar, Coproc<pallas::Scalar>>::new();
     let lang_pallas_rc = Arc::new(lang_pallas.clone());
     let mut store = Store::default();
     let reduction_count = DEFAULT_REDUCTION_COUNT;
@@ -314,8 +312,7 @@ fn verify_compressed_benchmark(c: &mut Criterion) {
         .sample_size(10);
 
     let limit = 1_000_000_000;
-    let lang_pallas =
-        Lang::<pasta_curves::pallas::Scalar, Coproc<pasta_curves::pallas::Scalar>>::new();
+    let lang_pallas = Lang::<pallas::Scalar, Coproc<pallas::Scalar>>::new();
     let lang_pallas_rc = Arc::new(lang_pallas.clone());
     let mut store = Store::default();
     let reduction_count = DEFAULT_REDUCTION_COUNT;

--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -5,6 +5,8 @@ use criterion::{
     BenchmarkId, Criterion, SamplingMode,
 };
 
+use pasta_curves::pallas;
+
 use lurk::{
     eval::{
         empty_sym_env,
@@ -41,8 +43,7 @@ fn fib<F: LurkField>(store: &mut Store<F>, a: u64) -> Ptr<F> {
 #[allow(dead_code)]
 fn fibo_total<M: measurement::Measurement>(name: &str, iterations: u64, c: &mut BenchmarkGroup<M>) {
     let limit: usize = 10_000_000_000;
-    let lang_pallas =
-        Lang::<pasta_curves::pallas::Scalar, Coproc<pasta_curves::pallas::Scalar>>::new();
+    let lang_pallas = Lang::<pallas::Scalar, Coproc<pallas::Scalar>>::new();
     let lang_rc = Arc::new(lang_pallas.clone());
     let reduction_count = DEFAULT_REDUCTION_COUNT;
 
@@ -55,7 +56,7 @@ fn fibo_total<M: measurement::Measurement>(name: &str, iterations: u64, c: &mut 
         |b, iterations| {
             let mut store = Store::default();
             let env = empty_sym_env(&store);
-            let ptr = fib::<pasta_curves::pallas::Scalar>(&mut store, black_box(*iterations));
+            let ptr = fib::<pallas::Scalar>(&mut store, black_box(*iterations));
             let prover = NovaProver::new(reduction_count, lang_pallas.clone());
 
             b.iter_batched(
@@ -75,14 +76,14 @@ fn fibo_total<M: measurement::Measurement>(name: &str, iterations: u64, c: &mut 
 #[allow(dead_code)]
 fn fibo_eval<M: measurement::Measurement>(name: &str, iterations: u64, c: &mut BenchmarkGroup<M>) {
     let limit = 10_000_000_000;
-    let lang_pallas = Lang::<pasta_curves::Fp, Coproc<pasta_curves::Fp>>::new();
+    let lang_pallas = Lang::<pallas::Scalar, Coproc<pallas::Scalar>>::new();
 
     c.bench_with_input(
         BenchmarkId::new(name.to_string(), iterations),
         &(iterations),
         |b, iterations| {
             let mut store = Store::default();
-            let ptr = fib::<pasta_curves::Fp>(&mut store, black_box(*iterations));
+            let ptr = fib::<pallas::Scalar>(&mut store, black_box(*iterations));
             b.iter(|| {
                 let result =
                     Evaluator::new(ptr, empty_sym_env(&store), &mut store, limit, &lang_pallas)
@@ -95,8 +96,7 @@ fn fibo_eval<M: measurement::Measurement>(name: &str, iterations: u64, c: &mut B
 
 fn fibo_prove<M: measurement::Measurement>(name: &str, iterations: u64, c: &mut BenchmarkGroup<M>) {
     let limit = 10_000_000_000;
-    let lang_pallas =
-        Lang::<pasta_curves::pallas::Scalar, Coproc<pasta_curves::pallas::Scalar>>::new();
+    let lang_pallas = Lang::<pallas::Scalar, Coproc<pallas::Scalar>>::new();
     let lang_rc = Arc::new(lang_pallas.clone());
     let reduction_count = DEFAULT_REDUCTION_COUNT;
     let pp = public_params(reduction_count, lang_rc.clone()).unwrap();
@@ -107,7 +107,7 @@ fn fibo_prove<M: measurement::Measurement>(name: &str, iterations: u64, c: &mut 
         |b, iterations| {
             let mut store = Store::default();
             let env = empty_sym_env(&store);
-            let ptr = fib::<pasta_curves::pallas::Scalar>(&mut store, black_box(*iterations));
+            let ptr = fib::<pallas::Scalar>(&mut store, black_box(*iterations));
             let prover = NovaProver::new(reduction_count, lang_pallas.clone());
 
             let frames = prover

--- a/clutch/src/main.rs
+++ b/clutch/src/main.rs
@@ -4,8 +4,8 @@ use clutch::ClutchState;
 
 use lurk::eval::lang::{Coproc, Lang};
 use lurk::field::LanguageField;
-use lurk::proof::nova;
 use lurk::repl::repl_cli;
+use pasta_curves::pallas;
 
 fn main() -> Result<()> {
     pretty_env_logger::init();
@@ -24,10 +24,21 @@ fn main() -> Result<()> {
 
     match field {
         LanguageField::Pallas => repl_cli::<
-            nova::S1,
-            ClutchState<nova::S1, Coproc<nova::S1>>,
-            Coproc<nova::S1>,
-        >(Lang::<nova::S1, Coproc<nova::S1>>::new()),
+            pallas::Scalar,
+            ClutchState<pallas::Scalar, Coproc<pallas::Scalar>>,
+            Coproc<pallas::Scalar>,
+        >(Lang::<pallas::Scalar, Coproc<pallas::Scalar>>::new()),
+        // TODO: Support all LanguageFields.
+        // LanguageField::BLS12_381 => repl_cli::<
+        //     blstrs::Scalar,
+        //     ClutchState<blstrs::Scalar, Coproc<blstrs::Scalar>>,
+        //     Coproc<blstrs::Scalar>,
+        // >(Lang::<blstrs::Scalar, Coproc<blstrs::Scalar>>::new()),
+        // LanguageField::Vesta => repl_cli::<
+        //     vesta::Scalar,
+        //     ClutchState<vesta::Scalar, Coproc<vesta::Scalar>>,
+        //     Coproc<vesta::Scalar>,
+        // >(Lang::<vesta::Scalar, Coproc<vesta::Scalar>>::new()),
         _ => panic!("unsupported field"),
     }
 }

--- a/src/field.rs
+++ b/src/field.rs
@@ -22,6 +22,14 @@ use crate::tag::{ContTag, ExprTag, Op1, Op2};
 
 /// The type of finite fields used in the language
 /// For Pallas/Vesta see https://electriccoin.co/blog/the-pasta-curves-for-halo-2-and-beyond/
+///
+/// Please note:
+/// - pasta_curves::pallas::Scalar = pasta_curves::Fq
+/// - pasta_curves::vesta::Scalar = pasta_curves::Fp
+///
+/// Because confusion on this point, perhaps combined with cargo-cult copying of incorrect previous usage has led to
+/// inconsistencies and inaccuracies in the code base, please prefer the named Scalar forms when correspondence to a
+/// named `LanguageField` is important.
 pub enum LanguageField {
     /// The Pallas field,
     Pallas,

--- a/src/field.rs
+++ b/src/field.rs
@@ -215,11 +215,11 @@ impl LurkField for blstrs::Scalar {
     const FIELD: LanguageField = LanguageField::BLS12_381;
 }
 
-impl LurkField for pasta_curves::Fp {
+impl LurkField for pasta_curves::pallas::Scalar {
     const FIELD: LanguageField = LanguageField::Pallas;
 }
 
-impl LurkField for pasta_curves::Fq {
+impl LurkField for pasta_curves::vesta::Scalar {
     const FIELD: LanguageField = LanguageField::Vesta;
 }
 
@@ -332,6 +332,7 @@ impl<'de, F: LurkField> Deserialize<'de> for FWrap<F> {
 pub mod tests {
     use crate::light_data::Encodable;
     use blstrs::Scalar as Fr;
+    use pasta_curves::{pallas, vesta};
 
     use super::*;
 
@@ -347,11 +348,11 @@ pub mod tests {
         repr_bytes_consistency(f1)
       }
       #[test]
-      fn prop_pallas_repr_bytes_consistency(f1 in any::<FWrap<pasta_curves::Fp>>()) {
+      fn prop_pallas_repr_bytes_consistency(f1 in any::<FWrap<pallas::Scalar>>()) {
           repr_bytes_consistency(f1)
       }
       #[test]
-      fn prop_vesta_repr_bytes_consistency(f1 in any::<FWrap<pasta_curves::Fq>>()) {
+      fn prop_vesta_repr_bytes_consistency(f1 in any::<FWrap<vesta::Scalar>>()) {
           repr_bytes_consistency(f1)
       }
     }
@@ -406,11 +407,11 @@ pub mod tests {
         repr_canonicity(f1)
       }
       #[test]
-      fn prop_pallas_repr_canonicity(f1 in any::<FWrap<pasta_curves::Fp>>()) {
+      fn prop_pallas_repr_canonicity(f1 in any::<FWrap<pallas::Scalar>>()) {
           repr_canonicity(f1)
       }
       #[test]
-      fn prop_vesta_repr_canonicity(f1 in any::<FWrap<pasta_curves::Fq>>()) {
+      fn prop_vesta_repr_canonicity(f1 in any::<FWrap<vesta::Scalar>>()) {
           repr_canonicity(f1)
       }
       #[test]
@@ -437,7 +438,7 @@ pub mod tests {
     proptest! {
         #[test]
         fn prop_pallas_tag_roundtrip(x in any::<u64>()){
-            let f1 = pasta_curves::Fp::from(x);
+            let f1 = pallas::Scalar::from(x);
             let bytes = f1.to_repr().as_ref().to_vec();
             let mut bytes_from_u64 = [0u8; 32];
             bytes_from_u64[..8].copy_from_slice(&x.to_le_bytes());
@@ -446,7 +447,7 @@ pub mod tests {
 
         #[test]
         fn prop_vesta_tag_roundtrip(x in any::<u64>()){
-            let f1 = pasta_curves::Fq::from(x);
+            let f1 = vesta::Scalar::from(x);
             let bytes = f1.to_repr().as_ref().to_vec();
             let mut bytes_from_u64 = [0u8; 32];
             bytes_from_u64[..8].copy_from_slice(&x.to_le_bytes());

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,8 @@ use anyhow::Result;
 
 use lurk::eval::lang::{Coproc, Lang};
 use lurk::field::LanguageField;
-use lurk::proof::nova;
 use lurk::repl::{repl_cli, ReplState};
+use pasta_curves::{pallas, vesta};
 
 fn main() -> Result<()> {
     pretty_env_logger::init();
@@ -27,14 +27,14 @@ fn main() -> Result<()> {
             Coproc<blstrs::Scalar>,
         >(Lang::<blstrs::Scalar, Coproc<blstrs::Scalar>>::new()),
         LanguageField::Pallas => repl_cli::<
-            nova::S1,
-            ReplState<nova::S1, Coproc<nova::S1>>,
-            Coproc<nova::S1>,
-        >(Lang::<nova::S1, Coproc<nova::S1>>::new()),
+            pallas::Scalar,
+            ReplState<pallas::Scalar, Coproc<pallas::Scalar>>,
+            Coproc<pallas::Scalar>,
+        >(Lang::<pallas::Scalar, Coproc<pallas::Scalar>>::new()),
         LanguageField::Vesta => repl_cli::<
-            nova::S2,
-            ReplState<nova::S2, Coproc<nova::S2>>,
-            Coproc<nova::S2>,
-        >(Lang::<nova::S2, Coproc<nova::S2>>::new()),
+            vesta::Scalar,
+            ReplState<vesta::Scalar, Coproc<vesta::Scalar>>,
+            Coproc<vesta::Scalar>,
+        >(Lang::<vesta::Scalar, Coproc<vesta::Scalar>>::new()),
     }
 }


### PR DESCRIPTION
This PR attempts to rectify confusion and inaccuracy wreaking havoc in our naming of fields. This is really important for multiple reasons. The worst-case situation is one in which we accidentally instantiate a Lurk language on the wrong field. This would lead to incompatible data and great confusion. The less bad cases involve conceptual incoherence, false labeling, and general mayhem in the vicinity of our efforts to produce an evidently correct code base.

Please see individual commits for details. Problems fixed here:
- In some places, the *wrong scalar field* was being used. I believe this problem was introduced in #239, then either independently 'discovered' or else cargo-culted by reference in new benchmarks.
- In some places, type aliases which do not *obviously* match the intended `LanguageField` were used. This would be fine if the actual correspondences between the pasta_curves named fields (`Fq` and `Fp`) were well-known, but apparently it's not. In any case, using the explicative aliases eliminates the need for it to (usually) be. The same goes for use of `nova::S1` and `nova::S2`.
- The finer points of this (while *all* discoverable by reading code whose base case are the named aliases in `pasta_curves`) were not explicitly documented outside of code.

If you contribute to `lurk-rs`, please take note.