### PR TITLE
Issue426

### DIFF
--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -3507,6 +3507,8 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             let cont_is_call2_and_not_dummy_and_not_dummy_args =
                 and!(cs, &cont_is_call2_and_not_dummy, &args_is_not_dummy)?;
 
+            let body_t_is_nil = body_t.is_nil(&mut cs.namespace(|| "body_t_is_nil"), g)?;
+
             let (body_form, end) = car_cdr_named(
                 &mut cs.namespace(|| "body_form"),
                 g,
@@ -3517,9 +3519,8 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
                 store,
             )?;
 
-            let body_form_is_nil = body_form.is_nil(&mut cs.namespace(|| "body_form_is_nil"), g)?;
             let end_is_nil = end.is_nil(&mut cs.namespace(|| "end_is_nil"), g)?;
-            let body_is_well_formed = and!(cs, &body_form_is_nil.not(), &end_is_nil)?;
+            let body_is_well_formed = and!(cs, &body_t_is_nil.not(), &end_is_nil)?;
 
             let extend_not_dummy = and!(
                 cs,

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -1328,6 +1328,13 @@ pub mod tests {
     }
 
     #[test]
+    fn test_prove_lambda_empty_error() {
+        let s = &mut Store::<Fr>::default();
+        let error = s.get_cont_error();
+        test_aux::<Coproc<Fr>>(s, "((lambda (x)) 0)", None, None, Some(error), None, 3, None,);
+    }
+
+    #[test]
     fn test_prove_let_empty_error() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
@@ -3633,74 +3640,18 @@ pub mod tests {
     }
 
     #[test]
-    fn test_issue424() {
+    fn test_issue426_minimal() {
         let s = &mut Store::<Fr>::default();
-        let expected = s.num(5);
+        let expected = s.nil();
         let terminal = s.get_cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
-            "(letrec ((char2int (lambda (digit)
-                           (if (eq #\\0 digit) 0 1)))
-         (str2int (letrec ((inner (lambda (acc xs)
-                                          (if (eq xs \"\") acc
-                                              (inner (+ (* 2 acc)
-                                                        (char2int (car xs)))
-                                                     (cdr xs))))))
-                          (inner 0))))
-        (str2int \"101\"))",
+            "((lambda (x) nil) 0)",
             Some(expected),
             None,
             Some(terminal),
             None,
-            147,
-            None,
-        );
-    }
-
-    #[test]
-    fn test_issue424_modified() {
-        let s = &mut Store::<Fr>::default();
-        let expected = s.num(5);
-        let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
-            s,
-            "(letrec ((char2int (lambda (digit)
-                           (if (eq #\\0 digit) 0 1)))
-         (inner (lambda (acc xs)
-                  (if (eq xs \"\") acc
-                    (inner (+ (* 2 acc)
-                              (char2int (car xs)))
-                           (cdr xs)))))
-         (str2int (inner 0)))
-        (str2int \"101\"))",
-            Some(expected),
-            None,
-            Some(terminal),
-            None,
-            147,
-            None,
-        );
-    }
-
-    #[test]
-    fn test_issue426() {
-        let s = &mut Store::<Fr>::default();
-        let nil = s.nil();
-        let strnil = s.str("");
-        let expected = s.cons(nil, strnil);
-        let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
-            s,
-            "(let ((f (lambda (x) nil))
-      (g (lambda (xs)
-                 (cons (f (car xs))
-                       (cdr xs)))))
-     (g \"0\"))",
-            Some(expected),
-            None,
-            Some(terminal),
-            None,
-            21,
+            4,
             None,
         );
     }

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -3644,7 +3644,7 @@ pub mod tests {
             None,
             Some(terminal),
             None,
-            2,
+            4,
             None,
         );
     }

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -3633,13 +3633,42 @@ pub mod tests {
     }
 
     #[test]
+    fn test_issue424() {
+        let s = &mut Store::<Fr>::default();
+        let expected = s.nil();
+        let terminal = s.get_cont_terminal();
+        test_aux::<Coproc<Fr>>(
+            s,
+            "(letrec ((char2int (lambda (digit)
+                           (if (eq #\0 digit) 0 1)))
+         (str2int (letrec ((inner (lambda (acc xs)
+                                          (if (eq xs \"\") acc
+                                              (inner (+ (* 2 acc)
+                                                        (char2int (car xs)))
+                                                     (cdr xs))))))
+                          (inner 0))))
+        (str2int \"101\"))",
+            Some(expected),
+            None,
+            Some(terminal),
+            None,
+            4,
+            None,
+        );
+    }
+
+    #[test]
     fn test_issue426() {
         let s = &mut Store::<Fr>::default();
         let expected = s.nil();
         let terminal = s.get_cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
-            "((lambda (x) nil) 0)",
+            "(let ((f (lambda (x) nil))
+      (g (lambda (xs)
+                 (cons (f (car xs))
+                       (cdr xs)))))
+     (g \"0\"))",
             Some(expected),
             None,
             Some(terminal),

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -1331,7 +1331,16 @@ pub mod tests {
     fn test_prove_lambda_empty_error() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(s, "((lambda (x)) 0)", None, None, Some(error), None, 3, None,);
+        test_aux::<Coproc<Fr>>(
+            s,
+            "((lambda (x)) 0)",
+            None,
+            None,
+            Some(error),
+            None,
+            3,
+            None,
+        );
     }
 
     #[test]

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -3631,4 +3631,25 @@ pub mod tests {
         );
         test_aux(s, &expr4, None, None, Some(error), None, 1, Some(lang));
     }
+
+    #[test]
+    fn test_issue426() {
+        let s = &mut Store::<Fr>::default();
+        let expected = s.num(33);
+        let terminal = s.get_cont_terminal();
+        test_aux::<Coproc<Fr>>(
+            s,
+            "(let ((f (lambda (x) nil))
+                (g (lambda (xs)
+                            (cons (f (car xs))
+                                (cdr xs)))))
+                (g \"0\"))",
+            Some(expected),
+            None,
+            Some(terminal),
+            None,
+            2,
+            None,
+        );
+    }
 }

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -3658,6 +3658,31 @@ pub mod tests {
     }
 
     #[test]
+    fn test_issue424_modified() {
+        let s = &mut Store::<Fr>::default();
+        let expected = s.num(5);
+        let terminal = s.get_cont_terminal();
+        test_aux::<Coproc<Fr>>(
+            s,
+            "(letrec ((char2int (lambda (digit)
+                           (if (eq #\\0 digit) 0 1)))
+         (inner (lambda (acc xs)
+                  (if (eq xs \"\") acc
+                    (inner (+ (* 2 acc)
+                              (char2int (car xs)))
+                           (cdr xs)))))
+         (str2int (inner 0)))
+        (str2int \"101\"))",
+            Some(expected),
+            None,
+            Some(terminal),
+            None,
+            147,
+            None,
+        );
+    }
+
+    #[test]
     fn test_issue426() {
         let s = &mut Store::<Fr>::default();
         let nil = s.nil();

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -3635,15 +3635,11 @@ pub mod tests {
     #[test]
     fn test_issue426() {
         let s = &mut Store::<Fr>::default();
-        let expected = s.num(33);
+        let expected = s.nil();
         let terminal = s.get_cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
-            "(let ((f (lambda (x) nil))
-                (g (lambda (xs)
-                            (cons (f (car xs))
-                                (cdr xs)))))
-                (g \"0\"))",
+            "((lambda (x) nil) 0)",
             Some(expected),
             None,
             Some(terminal),

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -3635,12 +3635,12 @@ pub mod tests {
     #[test]
     fn test_issue424() {
         let s = &mut Store::<Fr>::default();
-        let expected = s.nil();
+        let expected = s.num(5);
         let terminal = s.get_cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
             "(letrec ((char2int (lambda (digit)
-                           (if (eq #\0 digit) 0 1)))
+                           (if (eq #\\0 digit) 0 1)))
          (str2int (letrec ((inner (lambda (acc xs)
                                           (if (eq xs \"\") acc
                                               (inner (+ (* 2 acc)
@@ -3652,7 +3652,7 @@ pub mod tests {
             None,
             Some(terminal),
             None,
-            4,
+            147,
             None,
         );
     }
@@ -3660,7 +3660,9 @@ pub mod tests {
     #[test]
     fn test_issue426() {
         let s = &mut Store::<Fr>::default();
-        let expected = s.nil();
+        let nil = s.nil();
+        let strnil = s.str("");
+        let expected = s.cons(nil, strnil);
         let terminal = s.get_cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
@@ -3673,7 +3675,7 @@ pub mod tests {
             None,
             Some(terminal),
             None,
-            4,
+            21,
             None,
         );
     }


### PR DESCRIPTION
In apply-cont of Call2 we were checking if `body_form` was nil, instead of `body`. 

To solve the problem we did what is done in eval, which returns an error when `body` is nil.  

 Closes #426 