### PR TITLE
ci: Run Github Actions instead of CircleCI for pushes to master

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,10 @@
+[alias]
+# Collection of project wide clippy lints. This is done via an alias because
+# clippy doesn't currently allow for specifiying project-wide lints in a
+# configuration file. This is a similar workaround to the ones presented here:
+# <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
+xclippy = [
+    "clippy", "--all-targets", "--all-features", "--",
+    "-Wclippy::all",
+    "-Wclippy::disallowed_methods",
+]

--- a/.cargo/config
+++ b/.cargo/config
@@ -4,7 +4,7 @@
 # configuration file. This is a similar workaround to the ones presented here:
 # <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
 xclippy = [
-    "clippy", "--all-targets", "--all-features", "--",
+    "clippy", "--workspace", "--all-targets", "--all-features", "--",
     "-Wclippy::all",
     "-Wclippy::disallowed_methods",
 ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,6 +334,7 @@ workflows:
           filters:
             branches:
                 ignore: 
+                  - master
                   - gh-pages
                   - staging.tmp
                   - trying.tmp
@@ -342,6 +343,7 @@ workflows:
           filters:
             branches:
                 ignore: 
+                  - master
                   - gh-pages
                   - staging.tmp
                   - trying.tmp
@@ -350,6 +352,7 @@ workflows:
           filters:
             branches:
                 ignore: 
+                  - master
                   - gh-pages
                   - staging.tmp
                   - trying.tmp
@@ -360,6 +363,7 @@ workflows:
           filters:
             branches:
                 ignore: 
+                  - master
                   - gh-pages
                   - staging.tmp
                   - trying.tmp
@@ -370,6 +374,7 @@ workflows:
           filters:
             branches:
                 ignore: 
+                  - master
                   - gh-pages
                   - staging.tmp
                   - trying.tmp
@@ -380,6 +385,7 @@ workflows:
           filters:
             branches:
                 ignore: 
+                  - master
                   - gh-pages
                   - staging.tmp
                   - trying.tmp

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,7 +53,7 @@ jobs:
       - name: cargo test
         # TODO: --all-features
         run: |
-          cargo nextest run --release
+          cargo nextest run --profile ci --workspace --cargo-profile dev-ci --run-ignored all -E 'all() - test(groth16::tests::outer_prove_recursion) - test(test_make_fcomm_examples) - test(test_functional_commitments_demo) - test(test_chained_functional_commitments_demo)'
       - name: Doctests
         run: |
           cargo test --doc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,85 @@
+name: Rust
+
+on:
+  merge_group:
+  push:
+    branches:
+      - master
+env:
+  CARGO_TERM_COLOR: always
+  # Disable incremental compilation.
+  #
+  # Incremental compilation is useful as part of an edit-build-test-edit cycle,
+  # as it lets the compiler avoid recompiling code that hasn't changed. However,
+  # on CI, we're not making small edits; we're almost always building the entire
+  # project from scratch. Thus, incremental compilation on CI actually
+  # introduces *additional* overhead to support making future builds
+  # faster...but no future builds will ever occur in any given CI environment.
+  #
+  # See https://matklad.github.io/2021/09/04/fast-rust-builds.html#ci-workflow
+  # for details.
+  CARGO_INCREMENTAL: 0
+  # Allow more retries for network requests in cargo (downloading crates) and
+  # rustup (installing toolchains). This should help to reduce flaky CI failures
+  # from transient network timeouts or other issues.
+  CARGO_NET_RETRY: 10
+  RUSTUP_MAX_RETRIES: 10
+  # Don't emit giant backtraces in the CI logs.
+  RUST_BACKTRACE: short
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+      fail-fast: false
+    env:
+      RUSTFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+      - uses: taiki-e/install-action@nextest
+      - uses: Swatinem/rust-cache@v2
+      # make sure benches don't bit-rot
+      - name: build benches
+        # TODO: --all-features
+        run: cargo build --benches --release
+      - name: cargo test
+        # TODO: --all-features
+        run: |
+          cargo nextest run --release
+      - name: Doctests
+        run: |
+          cargo test --doc
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      # See '.cargo/config' for list of enabled/disabled clippy lints
+      - name: cargo clippy
+        run: cargo xclippy -D warnings
+
+  rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          components: rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - name: rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all --check


### PR DESCRIPTION
- Implement a new Rust workflow for GitHub Actions
- Integrate it for pushes and merges to the `master` branch
- Update CircleCI configuration to ignore 'master' branch for select jobs

The CI run on merged commits to master is not merge-blocking (by definition), and kinda redundant with the work of the merge queue. Here we make sure this is off our CircleCI bill, and get a baseline for how long it takes to run on GH Actions.