### PR TITLE
Run PR benchmarking workflow manually

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -4,7 +4,7 @@
 # configuration file. This is a similar workaround to the ones presented here:
 # <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
 xclippy = [
-    "clippy", "--workspace", "--all-targets", "--all-features", "--",
+    "clippy", "--workspace", "--all-targets", "--",
     "-Wclippy::all",
     "-Wclippy::disallowed_methods",
 ]

--- a/.github/workflows/pr_bench.yml
+++ b/.github/workflows/pr_bench.yml
@@ -3,6 +3,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -13,12 +16,14 @@ concurrency:
 jobs:
   runBenchmark:
     name: run benchmark
+    permissions:
+      pull-requests: read
     runs-on: [self-hosted, bench]
     if:
-      (github.event.comment.author_association = 'MEMBER'
-      || github.event.comment.author_association = 'OWNER')
-      && github.event.issue.pull_request
+      github.event.issue.pull_request
       && contains(github.event.comment.body, '!benchmark')
+      && (github.event.comment.author_association = 'MEMBER'
+      || github.event.comment.author_association = 'OWNER')
     steps:
       - uses: actions/checkout@v3
       # Set the Rust env vars

--- a/.github/workflows/pr_bench.yml
+++ b/.github/workflows/pr_bench.yml
@@ -1,8 +1,6 @@
 name: Benchmark pull requests
 on:
-  pull_request:
-   types: [opened, synchronize, reopened, ready_for_review]
-
+  workflow_dispatch
 env:
   CARGO_TERM_COLOR: always
 
@@ -16,12 +14,8 @@ jobs:
     runs-on: [self-hosted, bench]
     steps:
       - uses: actions/checkout@v3
-      # Sets the Rust env vars
+      # Set the Rust env vars
       - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      # Correct the toolchain version if needed
-      - run: rustup show
       - uses: Swatinem/rust-cache@v2
       - uses: boa-dev/criterion-compare-action@v3
         with:

--- a/.github/workflows/pr_bench.yml
+++ b/.github/workflows/pr_bench.yml
@@ -1,6 +1,8 @@
 name: Benchmark pull requests
 on:
-  workflow_dispatch
+  issue_comment:
+    types: [created]
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -12,6 +14,11 @@ jobs:
   runBenchmark:
     name: run benchmark
     runs-on: [self-hosted, bench]
+    if:
+      (github.event.comment.author_association = 'MEMBER'
+      || github.event.comment.author_association = 'OWNER')
+      && github.event.issue.pull_request
+      && contains(github.event.comment.body, '!benchmark')
     steps:
       - uses: actions/checkout@v3
       # Set the Rust env vars


### PR DESCRIPTION
This enables running the PR benchmarking workflow with a `!benchmark` comment, in order to remove noise during PR development and skip benches for PRs that wouldn't benefit from it, such as CI or documentation.

Also updates the toolchain action to use the new `rust-toolchain` file in #435