### PR TITLE
refactor: Run clippy at rust 1.70

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,7 +1,6 @@
 name: Rust
 
 on:
-  merge_group:
   push:
     branches:
       - master

--- a/src/circuit/gadgets/constraints.rs
+++ b/src/circuit/gadgets/constraints.rs
@@ -808,7 +808,7 @@ mod tests {
                 let mut cs = TestConstraintSystem::<Fr>::new();
                 let a_num = AllocatedNum::alloc(cs.namespace(|| "a_num"), || Ok(a)).unwrap();
                 let b_num = AllocatedNum::alloc(cs.namespace(|| "b_num"), || Ok(b)).unwrap();
-                let _ = enforce_equal(&mut cs, || "enforce equal", &a_num, &b_num);
+                enforce_equal(&mut cs, || "enforce equal", &a_num, &b_num);
                 assert_eq!(cs.is_satisfied(), a==b);
             };
 
@@ -825,7 +825,7 @@ mod tests {
             let test_num = |n: u64| {
                 let mut cs = TestConstraintSystem::<Fr>::new();
                 let num = AllocatedNum::alloc(cs.namespace(|| "zero"), || Ok(Fr::from(n))).unwrap();
-                let _ = enforce_equal_zero(&mut cs, || "enforce equal zero", &num);
+                enforce_equal_zero(&mut cs, || "enforce equal zero", &num);
                 assert_eq!(cs.is_satisfied(), n==0);
 
             };
@@ -869,8 +869,8 @@ mod tests {
 
             let test_a_b = |premise: bool, a, b, result: bool| {
                 let mut cs = TestConstraintSystem::<Fr>::new();
-                let a_num = AllocatedNum::alloc(cs.namespace(|| "a_num"), || Ok(Fr::from(a))).unwrap();
-                let b_num = AllocatedNum::alloc(cs.namespace(|| "b_num"), || Ok(Fr::from(b))).unwrap();
+                let a_num = AllocatedNum::alloc(cs.namespace(|| "a_num"), || Ok(a)).unwrap();
+                let b_num = AllocatedNum::alloc(cs.namespace(|| "b_num"), || Ok(b)).unwrap();
                 let pb = Boolean::constant(premise);
                 let _ = implies_equal(&mut cs.namespace(|| "implies equal"), &pb, &a_num, &b_num);
                 assert_eq!(cs.is_satisfied(), result);
@@ -1077,7 +1077,7 @@ mod tests {
             ).expect("alloc failed"));
 
             // Execute the function under test.
-            let _ = enforce_implication_lc(
+            enforce_implication_lc(
                 cs.namespace(|| "enforce_implication_lc"),
                 &premise,
                 |_| lc,
@@ -1107,7 +1107,7 @@ mod tests {
         );
 
         // Execute the function under test.
-        let _ = enforce_implication_lc(
+        enforce_implication_lc(
             cs.namespace(|| "enforce_implication_lc_big"),
             &premise_true,
             |_| test_lc_big.clone(),
@@ -1127,7 +1127,7 @@ mod tests {
         );
 
         // Execute the function under test.
-        let _ = enforce_implication_lc(
+        enforce_implication_lc(
             cs.namespace(|| "enforce_implication_lc_big_with_false"),
             &premise_false,
             |_| test_lc_big,
@@ -1153,7 +1153,7 @@ mod tests {
         test_lc_arb_num = test_lc_arb_num + (Fr::ONE, anum2.get_variable());
 
         // Execute the function under test.
-        let _ = enforce_implication_lc(
+        enforce_implication_lc(
             cs.namespace(|| "enforce_implication_lc_arb_num"),
             &premise_true,
             |_| test_lc_arb_num,

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -149,7 +149,7 @@ pub(crate) mod test {
             result += *b_num;
             let x = s.intern_num(result);
 
-            return x;
+            x
         }
 
         fn has_circuit(&self) -> bool {

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -675,7 +675,7 @@ mod test {
 
             let fresh_p = PoseidonCache::<Fr>::default();
             let verified = proof.verify(root, key, Fr::zero(), &fresh_p);
-            assert_eq!(true, verified);
+            assert!(verified);
         }
     }
 
@@ -734,38 +734,38 @@ mod test {
 
                 let fresh_p = PoseidonCache::<Fr>::default();
                 let verified = proof.verify(root, key, Fr::zero(), &fresh_p);
-                assert_eq!(true, verified);
+                assert!(verified);
             }
 
             let old_root = t3.root;
             let (insert_proof, inserted) = t3.prove_insert(key, val).unwrap();
 
-            assert_eq!(true, inserted);
+            assert!(inserted);
 
             {
                 let root = t3.root;
                 let fresh_p = PoseidonCache::<Fr>::default();
 
                 let verified = insert_proof.verify(old_root, root, key, None, val, &fresh_p);
-                assert_eq!(true, verified);
+                assert!(verified);
 
                 {
                     let proof = t3.prove_lookup(key).unwrap();
 
                     let verified = proof.verify(root, key, val, &fresh_p);
-                    assert_eq!(true, verified);
+                    assert!(verified);
                 }
                 {
                     let proof2 = t3.prove_lookup(key2).unwrap();
 
                     let verified = proof2.verify(root, key2, Fr::zero(), &fresh_p);
-                    assert_eq!(true, verified);
+                    assert!(verified);
                 }
             }
 
             let old_root = t3.root;
             let (insert_proof2, inserted2) = t3.prove_insert(key2, val2).unwrap();
-            assert_eq!(true, inserted2);
+            assert!(inserted2);
 
             {
                 let root = t3.root;
@@ -773,7 +773,7 @@ mod test {
 
                 {
                     let verified = insert_proof2.verify(old_root, root, key2, None, val2, &fresh_p);
-                    assert_eq!(true, verified);
+                    assert!(verified);
                 }
                 {
                     let proof = t3.prove_lookup(key).unwrap();
@@ -781,7 +781,7 @@ mod test {
 
                     let fresh_p = PoseidonCache::<Fr>::default();
                     let verified = proof.verify(root, key, val, &fresh_p);
-                    assert_eq!(true, verified);
+                    assert!(verified);
                 }
                 {
                     let proof2 = t3.prove_lookup(key2).unwrap();
@@ -789,32 +789,32 @@ mod test {
 
                     let fresh_p = PoseidonCache::<Fr>::default();
                     let verified = proof2.verify(root, key2, val2, &fresh_p);
-                    assert_eq!(true, verified);
+                    assert!(verified);
                 }
             }
             let (_, inserted2a) = t3.prove_insert(key2, val2).unwrap();
-            assert_eq!(false, inserted2a);
+            assert!(!inserted2a);
 
             let old_root = t3.root;
             let (insert_proof3, inserted3) = t3.prove_insert(key2, val3).unwrap();
-            assert_eq!(true, inserted3);
+            assert!(inserted3);
             {
                 let root = t3.root;
                 let fresh_p = PoseidonCache::<Fr>::default();
 
                 let verified =
                     insert_proof3.verify(old_root, root, key2, Some(val2), val3, &fresh_p);
-                assert_eq!(true, verified);
+                assert!(verified);
 
                 {
                     let proof = t3.prove_lookup(key).unwrap();
                     let verified = proof.verify(root, key, val, &fresh_p);
-                    assert_eq!(true, verified);
+                    assert!(verified);
                 }
                 {
                     let proof2 = t3.prove_lookup(key2).unwrap();
                     let verified = proof2.verify(root, key2, val3, &fresh_p);
-                    assert_eq!(true, verified);
+                    assert!(verified);
                 }
             }
         }

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -355,7 +355,7 @@ struct ResultFrame<'a, F: LurkField, C: Coprocessor<F>>(
 impl<'a, F: LurkField, C: Coprocessor<F>> Iterator for ResultFrame<'a, F, C> {
     type Item = Result<Frame<IO<F>, Witness<F>, C>, ReductionError>;
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
-        let mut frame_it = match &mut self.0 {
+        let frame_it = match &mut self.0 {
             Ok(f) => f,
             Err(e) => return Some(Err(e.clone())),
         };

--- a/src/eval/tests/mod.rs
+++ b/src/eval/tests/mod.rs
@@ -70,7 +70,7 @@ fn test_aux2<C: Coprocessor<Fr>>(
         },
         iterations,
         emitted,
-    ) = Evaluator::new(*expr, env, s, limit, &lang).eval().unwrap();
+    ) = Evaluator::new(*expr, env, s, limit, lang).eval().unwrap();
 
     if let Some(expected_result) = expected_result {
         dbg!(expected_result.fmt_to_string(s), &new_expr.fmt_to_string(s));
@@ -2595,8 +2595,8 @@ pub(crate) mod coproc {
         let res = s.num(89);
         let error = s.get_cont_error();
 
-        test_aux(s, &expr, Some(res), None, None, None, 1, Some(&lang));
-        test_aux(s, &expr2, Some(res), None, None, None, 3, Some(&lang));
-        test_aux(s, &expr3, None, None, Some(error), None, 1, Some(&lang));
+        test_aux(s, expr, Some(res), None, None, None, 1, Some(&lang));
+        test_aux(s, expr2, Some(res), None, None, None, 3, Some(&lang));
+        test_aux(s, expr3, None, None, Some(error), None, 1, Some(&lang));
     }
 }

--- a/src/eval/tests/trie.rs
+++ b/src/eval/tests/trie.rs
@@ -16,7 +16,7 @@ fn trie_lang() {
         .read("0x1cc5b90039db85fd519af975afa1de9d2b92960a585a546637b653b115bc3b53")
         .unwrap();
 
-    test_aux(s, &expr, Some(res), None, None, None, 3, Some(&lang));
+    test_aux(s, expr, Some(res), None, None, None, 3, Some(&lang));
 
     // TODO: Coprocessors need to evaluate their arguments for this to work.
     //       See https://github.com/lurk-lab/lurk-rs/issues/398.
@@ -27,17 +27,17 @@ fn trie_lang() {
     let expr2 = "(.lurk.trie.lookup 0x1cc5b90039db85fd519af975afa1de9d2b92960a585a546637b653b115bc3b53 123)";
     let res2 = s.intern_opaque_comm(Fr::zero());
 
-    test_aux(s, &expr2, Some(res2), None, None, None, 1, Some(&lang));
+    test_aux(s, expr2, Some(res2), None, None, None, 1, Some(&lang));
 
     let expr3 = "(.lurk.trie.insert 0x1cc5b90039db85fd519af975afa1de9d2b92960a585a546637b653b115bc3b53 123 456)";
     let res3 = s
         .read("0x1b22dc5a394231c34e4529af674dc56a736fbd07508acfd1d12c0e67c8b4de27")
         .unwrap();
 
-    test_aux(s, &expr3, Some(res3), None, None, None, 1, Some(&lang));
+    test_aux(s, expr3, Some(res3), None, None, None, 1, Some(&lang));
 
     let expr4 = "(.lurk.trie.lookup 0x1b22dc5a394231c34e4529af674dc56a736fbd07508acfd1d12c0e67c8b4de27 123)";
     let res4 = s.intern_opaque_comm(Fr::from(456));
 
-    test_aux(s, &expr4, Some(res4), None, None, None, 1, Some(&lang));
+    test_aux(s, expr4, Some(res4), None, None, None, 1, Some(&lang));
 }

--- a/src/light_data/mod.rs
+++ b/src/light_data/mod.rs
@@ -298,9 +298,9 @@ pub mod tests {
     #[test]
     fn unit_trimmed_bytes() {
         assert_eq!(LightData::to_trimmed_le_bytes(43411), vec![147, 169]);
-        assert_eq!(43411, LightData::read_size_bytes(&vec![147, 169]).unwrap());
+        assert_eq!(43411, LightData::read_size_bytes(&[147, 169]).unwrap());
         assert_eq!(LightData::to_trimmed_le_bytes(37801), vec![169, 147]);
-        assert_eq!(37801, LightData::read_size_bytes(&vec![169, 147]).unwrap());
+        assert_eq!(37801, LightData::read_size_bytes(&[169, 147]).unwrap());
     }
 
     #[test]

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -3608,20 +3608,11 @@ pub mod tests {
         let error = s.get_cont_error();
         let lang = Arc::new(lang);
 
-        test_aux(s, &expr, Some(res), None, None, None, 1, Some(lang.clone()));
+        test_aux(s, expr, Some(res), None, None, None, 1, Some(lang.clone()));
+        test_aux(s, expr2, Some(res), None, None, None, 3, Some(lang.clone()));
         test_aux(
             s,
-            &expr2,
-            Some(res),
-            None,
-            None,
-            None,
-            3,
-            Some(lang.clone()),
-        );
-        test_aux(
-            s,
-            &expr3,
+            expr3,
             None,
             None,
             Some(error),
@@ -3629,6 +3620,6 @@ pub mod tests {
             1,
             Some(lang.clone()),
         );
-        test_aux(s, &expr4, None, None, Some(error), None, 1, Some(lang));
+        test_aux(s, expr4, None, None, Some(error), None, 1, Some(lang));
     }
 }

--- a/src/scalar_store.rs
+++ b/src/scalar_store.rs
@@ -400,7 +400,7 @@ mod test {
 
         #[test]
         fn prop_scalar_cont_ipld(x in any::<ScalarContinuation<Fr>>()) {
-            let to_ipld = to_ipld(x.clone()).unwrap();
+            let to_ipld = to_ipld(x).unwrap();
             let from_ipld = from_ipld(to_ipld).unwrap();
             assert_eq!(x, from_ipld);
         }

--- a/tests/light-data-store.rs
+++ b/tests/light-data-store.rs
@@ -29,17 +29,18 @@ use lurk::{
 fn test_light_store_deserialization() {
     let directory = "tests/ldstores";
 
-    for entry in fs::read_dir(directory).expect("Failed to read directory") {
-        if let Ok(entry) = entry {
-            let path = entry.path();
-            if let Some(extension) = path.extension() {
-                if extension == "ldstore" {
-                    let file_path = path.to_str().unwrap();
-                    let file_bytes = fs::read(file_path).expect("Failed to read file");
-                    let ld = LightData::de(&file_bytes).unwrap();
-                    let ldstore: LightStore<Fr> = Encodable::de(&ld).unwrap();
-                    let _scalar_store: ScalarStore<Fr> = ldstore.try_into().unwrap();
-                }
+    for entry in fs::read_dir(directory)
+        .expect("Failed to read directory")
+        .flatten()
+    {
+        let path = entry.path();
+        if let Some(extension) = path.extension() {
+            if extension == "ldstore" {
+                let file_path = path.to_str().unwrap();
+                let file_bytes = fs::read(file_path).expect("Failed to read file");
+                let ld = LightData::de(&file_bytes).unwrap();
+                let ldstore: LightStore<Fr> = Encodable::de(&ld).unwrap();
+                let _scalar_store: ScalarStore<Fr> = ldstore.try_into().unwrap();
             }
         }
     }


### PR DESCRIPTION
Some of our tooling respects the rust-toolchain file more, and gave us early warning of the issues this fixes.

I'm still chasing the discrepancy between https://github.com/lurk-lab/lurk-rs/actions/runs/5225265251/jobs/9434513894 (up-to-date) and https://app.circleci.com/pipelines/github/lurk-lab/lurk-rs/2626/workflows/5646178f-7b8c-4c84-a6d1-ae2a4c7dc887/jobs/15605 (not)

