### PR TITLE
Fix PR bench branch comparison

### DIFF
--- a/.github/workflows/pr-bench.yml
+++ b/.github/workflows/pr-bench.yml
@@ -3,9 +3,6 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  contents: read
-
 env:
   CARGO_TERM_COLOR: always
 
@@ -16,8 +13,6 @@ concurrency:
 jobs:
   runBenchmark:
     name: run benchmark
-    permissions:
-      pull-requests: read
     runs-on: [self-hosted, bench]
     if:
       github.event.issue.pull_request
@@ -34,4 +29,4 @@ jobs:
           # Optional. Compare only this benchmark target
           benchName: "end2end"
           # Needed. The name of the branch to compare with. This default uses the branch which is being pulled against
-          branchName: ${{ github.base_ref }}
+          branchName: ${{ github.ref }}


### PR DESCRIPTION
The current version is getting skipped, and also doesn't have access to `github.base_ref` because it isn't triggered by a `pull_request` event. This should fix both issues.