### PR TITLE
More clippy tuning

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,6 @@
+too-many-arguments-threshold = 20
+disallowed-methods = [
+    # we use strict naming for pasta fields
+    { path = "pasta_curves::Fp", reason = "use pasta_curves::pallas::Base or pasta_curves::vesta::Scalar instead to communicate your intent" },
+    { path = "pasta_curves::Fq", reason = "use pasta_curves::pallas::Scalar or pasta_curves::vesta::Base instead to communicate your intent" },
+]

--- a/clutch/.clippy.toml
+++ b/clutch/.clippy.toml
@@ -1,0 +1,1 @@
+../.clippy.toml

--- a/fcomm/.clippy.toml
+++ b/fcomm/.clippy.toml
@@ -1,0 +1,1 @@
+../.clippy.toml

--- a/lurk-macros/.clippy.toml
+++ b/lurk-macros/.clippy.toml
@@ -1,0 +1,1 @@
+../.clippy.toml

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -147,9 +147,8 @@ pub(crate) mod test {
             let mut result = *a_num;
             result *= *a_num;
             result += *b_num;
-            let x = s.intern_num(result);
 
-            x
+            s.intern_num(result)
         }
 
         fn has_circuit(&self) -> bool {

--- a/tests/light-data-exprs.rs
+++ b/tests/light-data-exprs.rs
@@ -22,16 +22,17 @@ use lurk::light_data::{Encodable, LightData, LightExpr};
 fn test_light_exprs_deserialization() {
     let directory = "tests/exprs";
 
-    for entry in fs::read_dir(directory).expect("Failed to read directory") {
-        if let Ok(entry) = entry {
-            let path = entry.path();
-            if let Some(extension) = path.extension() {
-                if extension == "expr" {
-                    let file_path = path.to_str().unwrap();
-                    let file_bytes = fs::read(file_path).expect("Failed to read file");
-                    let ld = LightData::de(&file_bytes).unwrap();
-                    let _expr: LightExpr<Fr> = Encodable::de(&ld).unwrap();
-                }
+    for entry in fs::read_dir(directory)
+        .expect("Failed to read directory")
+        .flatten()
+    {
+        let path = entry.path();
+        if let Some(extension) = path.extension() {
+            if extension == "expr" {
+                let file_path = path.to_str().unwrap();
+                let file_bytes = fs::read(file_path).expect("Failed to read file");
+                let ld = LightData::de(&file_bytes).unwrap();
+                let _expr: LightExpr<Fr> = Encodable::de(&ld).unwrap();
             }
         }
     }


### PR DESCRIPTION
- installs a .clippy.toml on the heels of #437,
- uses disallowed-methods lint as suggested in #423 