### PR TITLE
ci: Use correct head ref in benchmark

### DIFF
--- a/.github/workflows/pr-bench.yml
+++ b/.github/workflows/pr-bench.yml
@@ -16,11 +16,18 @@ jobs:
     runs-on: [self-hosted, bench]
     if:
       github.event.issue.pull_request
+      && github.event.issue.state == 'open'
       && contains(github.event.comment.body, '!benchmark')
       && (github.event.comment.author_association == 'MEMBER'
       || github.event.comment.author_association == 'OWNER')
     steps:
+      - uses: xt0rted/pull-request-comment-branch@v2
+        id: comment-branch
+
       - uses: actions/checkout@v3
+        if: success()
+        with:
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
       # Set the Rust env vars
       - uses: actions-rs/toolchain@v1
       - uses: Swatinem/rust-cache@v2
@@ -28,5 +35,5 @@ jobs:
         with:
           # Optional. Compare only this benchmark target
           benchName: "end2end"
-          # Needed. The name of the branch to compare with. This default uses the branch which is being pulled against
-          branchName: ${{ github.ref }}
+          # Needed. The name of the branch to compare with
+          branchName: ${{ github.ref_name }}


### PR DESCRIPTION
Gets the comment's PR branch for comparison, rather than the current behavior of comparing master against itself. Also checks the PR is still open, as per https://github.com/xt0rted/pull-request-comment-branch/issues/213#issuecomment-1014442741