### PR TITLE
`let` and `letrec` fix

### DIFF
--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -4231,12 +4231,8 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
 
         let cont_is_let =
             cont.alloc_tag_equal(&mut cs.namespace(|| "cont_is_let"), ContTag::Let.to_field())?;
-        let let_cont_is_let = let_cont.alloc_tag_equal(
-            &mut cs.namespace(|| "let_cont_is_let"),
-            ContTag::Let.to_field(),
-        )?;
 
-        let extended_env_not_dummy = and!(cs, &let_cont_is_let, not_dummy, &cont_is_let)?;
+        let extended_env_not_dummy = and!(cs, not_dummy, &cont_is_let)?;
 
         let extended_env = extend_named(
             &mut cs.namespace(|| "extend env"),
@@ -4282,12 +4278,12 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         let body = AllocatedPtr::by_index(1, &continuation_components);
         let letrec_cont = AllocatedContPtr::by_index(3, &continuation_components);
 
-        let letrec_cont_is_letrec_cont = letrec_cont.alloc_tag_equal(
+        let cont_is_letrec_cont = cont.alloc_tag_equal(
             &mut cs.namespace(|| "letrec_cont_is_letrec_cont"),
             ContTag::LetRec.to_field(),
         )?;
 
-        let extend_rec_not_dummy = and!(cs, &letrec_cont_is_letrec_cont, not_dummy)?;
+        let extend_rec_not_dummy = and!(cs, &cont_is_letrec_cont, not_dummy)?;
 
         let extended_env = extend_rec(
             &mut cs.namespace(|| "extend_rec env"),

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -4240,7 +4240,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             env,
             &var,
             result,
-            ConsName::Env,
+            ConsName::ClosedEnv,
             allocated_cons_witness,
             &extended_env_not_dummy,
         )?;
@@ -5030,6 +5030,8 @@ fn extend_rec<F: LurkField, CS: ConstraintSystem<F>>(
         not_dummy,
     )?;
 
+    let cons_branch_not_dummy = and!(cs, &var_or_binding_is_cons, not_dummy)?;
+    let non_cons_branch_not_dummy = and!(cs, &var_or_binding_is_cons.not(), not_dummy)?;
     let list = AllocatedPtr::construct_cons_named(
         &mut cs.namespace(|| "list cons"),
         g,
@@ -5037,7 +5039,7 @@ fn extend_rec<F: LurkField, CS: ConstraintSystem<F>>(
         &g.nil_ptr,
         ConsName::NewRec,
         allocated_cons_witness,
-        not_dummy,
+        &non_cons_branch_not_dummy,
     )?;
 
     let new_env_if_sym_or_nil = AllocatedPtr::construct_cons_named(
@@ -5047,10 +5049,9 @@ fn extend_rec<F: LurkField, CS: ConstraintSystem<F>>(
         env,
         ConsName::ExtendedRec,
         allocated_cons_witness,
-        not_dummy,
+        &non_cons_branch_not_dummy,
     )?;
 
-    let cons_branch_not_dummy = and!(cs, &var_or_binding_is_cons, not_dummy)?;
 
     let cons2 = AllocatedPtr::construct_cons_named(
         &mut cs.namespace(|| "cons cons binding_or_env"),

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -3507,6 +3507,8 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             let cont_is_call2_and_not_dummy_and_not_dummy_args =
                 and!(cs, &cont_is_call2_and_not_dummy, &args_is_not_dummy)?;
 
+            let body_t_is_nil = body_t.is_nil(&mut cs.namespace(|| "body_t_is_nil"), g)?;
+
             let (body_form, end) = car_cdr_named(
                 &mut cs.namespace(|| "body_form"),
                 g,
@@ -3517,9 +3519,8 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
                 store,
             )?;
 
-            let body_form_is_nil = body_form.is_nil(&mut cs.namespace(|| "body_form_is_nil"), g)?;
             let end_is_nil = end.is_nil(&mut cs.namespace(|| "end_is_nil"), g)?;
-            let body_is_well_formed = and!(cs, &body_form_is_nil.not(), &end_is_nil)?;
+            let body_is_well_formed = and!(cs, &body_t_is_nil.not(), &end_is_nil)?;
 
             let extend_not_dummy = and!(
                 cs,

--- a/src/eval/reduction.rs
+++ b/src/eval/reduction.rs
@@ -831,7 +831,7 @@ fn apply_continuation<F: LurkField>(
                 continuation,
             } => {
                 let extended_env =
-                    cons_witness.extend_named(ConsName::Env, env, var, result, store);
+                    cons_witness.extend_named(ConsName::ClosedEnv, env, var, result, store);
                 let c = make_tail_continuation(saved_env, continuation, store, cont_witness);
 
                 Control::Return(body, extended_env, c)
@@ -1312,10 +1312,10 @@ fn extend_rec<F: LurkField>(
     let (binding_or_env, rest) = cons_witness.car_cdr_named(ConsName::Env, store, &env)?;
     let (var_or_binding, _val_or_more_bindings) =
         cons_witness.car_cdr_named(ConsName::EnvCar, store, &binding_or_env)?;
+    let cons = cons_witness.cons_named(ConsName::NewRecCadr, store, var, val);
     match var_or_binding.tag {
         // It's a var, so we are extending a simple env with a recursive env.
         ExprTag::Sym | ExprTag::Nil => {
-            let cons = cons_witness.cons_named(ConsName::NewRecCadr, store, var, val);
             let nil = store.nil();
             let list = cons_witness.cons_named(ConsName::NewRec, store, cons, nil);
             let res = cons_witness.cons_named(ConsName::ExtendedRec, store, list, env);
@@ -1324,7 +1324,6 @@ fn extend_rec<F: LurkField>(
         }
         // It's a binding, so we are extending a recursive env.
         ExprTag::Cons => {
-            let cons = cons_witness.cons_named(ConsName::NewRecCadr, store, var, val);
             let cons2 = cons_witness.cons_named(ConsName::NewRec, store, cons, binding_or_env);
             let res = cons_witness.cons_named(ConsName::ExtendedRec, store, cons2, rest);
 

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -3644,7 +3644,7 @@ pub mod tests {
             None,
             Some(terminal),
             None,
-            2,
+            4,
             None,
         );
     }

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -3633,13 +3633,42 @@ pub mod tests {
     }
 
     #[test]
+    fn test_issue424() {
+        let s = &mut Store::<Fr>::default();
+        let expected = s.nil();
+        let terminal = s.get_cont_terminal();
+        test_aux::<Coproc<Fr>>(
+            s,
+            "(letrec ((char2int (lambda (digit)
+                           (if (eq #\0 digit) 0 1)))
+         (str2int (letrec ((inner (lambda (acc xs)
+                                          (if (eq xs \"\") acc
+                                              (inner (+ (* 2 acc)
+                                                        (char2int (car xs)))
+                                                     (cdr xs))))))
+                          (inner 0))))
+        (str2int \"101\"))",
+            Some(expected),
+            None,
+            Some(terminal),
+            None,
+            4,
+            None,
+        );
+    }
+
+    #[test]
     fn test_issue426() {
         let s = &mut Store::<Fr>::default();
         let expected = s.nil();
         let terminal = s.get_cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
-            "((lambda (x) nil) 0)",
+            "(let ((f (lambda (x) nil))
+      (g (lambda (xs)
+                 (cons (f (car xs))
+                       (cdr xs)))))
+     (g \"0\"))",
             Some(expected),
             None,
             Some(terminal),

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -3631,4 +3631,25 @@ pub mod tests {
         );
         test_aux(s, &expr4, None, None, Some(error), None, 1, Some(lang));
     }
+
+    #[test]
+    fn test_issue426() {
+        let s = &mut Store::<Fr>::default();
+        let expected = s.num(33);
+        let terminal = s.get_cont_terminal();
+        test_aux::<Coproc<Fr>>(
+            s,
+            "(let ((f (lambda (x) nil))
+                (g (lambda (xs)
+                            (cons (f (car xs))
+                                (cdr xs)))))
+                (g \"0\"))",
+            Some(expected),
+            None,
+            Some(terminal),
+            None,
+            2,
+            None,
+        );
+    }
 }

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -3658,6 +3658,31 @@ pub mod tests {
     }
 
     #[test]
+    fn test_issue424_modified() {
+        let s = &mut Store::<Fr>::default();
+        let expected = s.num(5);
+        let terminal = s.get_cont_terminal();
+        test_aux::<Coproc<Fr>>(
+            s,
+            "(letrec ((char2int (lambda (digit)
+                           (if (eq #\\0 digit) 0 1)))
+         (inner (lambda (acc xs)
+                  (if (eq xs \"\") acc
+                    (inner (+ (* 2 acc)
+                              (char2int (car xs)))
+                           (cdr xs)))))
+         (str2int (inner 0)))
+        (str2int \"101\"))",
+            Some(expected),
+            None,
+            Some(terminal),
+            None,
+            147,
+            None,
+        );
+    }
+
+    #[test]
     fn test_issue426() {
         let s = &mut Store::<Fr>::default();
         let nil = s.nil();

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -3635,15 +3635,11 @@ pub mod tests {
     #[test]
     fn test_issue426() {
         let s = &mut Store::<Fr>::default();
-        let expected = s.num(33);
+        let expected = s.nil();
         let terminal = s.get_cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
-            "(let ((f (lambda (x) nil))
-                (g (lambda (xs)
-                            (cons (f (car xs))
-                                (cdr xs)))))
-                (g \"0\"))",
+            "((lambda (x) nil) 0)",
             Some(expected),
             None,
             Some(terminal),

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -3635,12 +3635,12 @@ pub mod tests {
     #[test]
     fn test_issue424() {
         let s = &mut Store::<Fr>::default();
-        let expected = s.nil();
+        let expected = s.num(5);
         let terminal = s.get_cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
             "(letrec ((char2int (lambda (digit)
-                           (if (eq #\0 digit) 0 1)))
+                           (if (eq #\\0 digit) 0 1)))
          (str2int (letrec ((inner (lambda (acc xs)
                                           (if (eq xs \"\") acc
                                               (inner (+ (* 2 acc)
@@ -3652,7 +3652,7 @@ pub mod tests {
             None,
             Some(terminal),
             None,
-            4,
+            147,
             None,
         );
     }
@@ -3660,7 +3660,9 @@ pub mod tests {
     #[test]
     fn test_issue426() {
         let s = &mut Store::<Fr>::default();
-        let expected = s.nil();
+        let nil = s.nil();
+        let strnil = s.str("");
+        let expected = s.cons(nil, strnil);
         let terminal = s.get_cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
@@ -3673,7 +3675,7 @@ pub mod tests {
             None,
             Some(terminal),
             None,
-            4,
+            21,
             None,
         );
     }


### PR DESCRIPTION
This PR fixes the `let` and `letrec` cases in the circuit. The problem was threefold:
1. `not_dummy` for both `let` and `letrec` were wrong: for some reason they were checking whether the NEXT continuation was a let/letrec continuation, not the CURRENT continuation. Because `not_dummy` for let/letrec was almost always `false` when it shouldn't, a lot of errors were being concealed. Only when you had inner lets were these errors able to come up (since then, the NEXT continuation would be a let)
2. `let` was using `ConsName::Env` to extend itself, which is wrong. This caused a conflict in `Env` when you had expressions such as `(let ((x 0) (y x)) y)` or `((lambda (x) (let ((y x)) y)) 0)`, i.e. a symbol in the right side of the let binding that was first in the environment (no need for lookups). Instead, it should use `ConsName::ClosedEnv` exactly like the lambda case, which is disjoint from let. In fact, `(let ((x a)) ...)` should almost be indistinguishable from `((lambda (x) ...) a)`
3. `letrec` case was not properly separating the branch where the car of an environment is a sym/nil vs a cons (i.e. non-recursive vs recursive environment). For some reason, the non-recursive case was always taken, which would conflict with the recursive case when it happened: which is exactly the `(letrec ((x 0) (letrec ((y 0)) 0))` case

As a corollary, this PR fixes issue 424