### PR TITLE
Adapt to upstream nova

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1652,7 +1652,7 @@ dependencies = [
 [[package]]
 name = "neptune"
 version = "10.0.0"
-source = "git+https://github.com/lurk-lab/neptune?branch=dev#79d1b84c2d8ef8e593ad912bcb3b21408fe697c9"
+source = "git+https://github.com/lurk-lab/neptune?branch=dev#cc094453b1752bf0edb8837facf8114c87061303"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -1702,7 +1702,7 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 [[package]]
 name = "nova-snark"
 version = "0.21.0"
-source = "git+https://github.com/lurk-lab/nova?branch=dev#2c0f1afa821550c9ecbd2b4ac9cfa11ec1ce8c81"
+source = "git+https://github.com/lurk-lab/nova?branch=dev#cb378bd3dcde76730bf9dc7214c91f48a691b4ab"
 dependencies = [
  "abomonation",
  "abomonation_derive",

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -291,17 +291,25 @@ impl<'a: 'b, 'b, C: Coprocessor<S1>> Proof<'a, C> {
 
                 assert!(cs.is_satisfied());
             }
-
-            let res = RecursiveSNARK::prove_step(
-                &pp.pp,
-                recursive_snark,
-                circuit_primary.clone(),
-                circuit_secondary.clone(),
-                z0_primary.clone(),
-                z0_secondary.clone(),
-            );
-            assert!(res.is_ok());
-            recursive_snark = Some(res?);
+            let mut r_snark = recursive_snark.unwrap_or_else(|| {
+                RecursiveSNARK::new(
+                    &pp.pp,
+                    circuit_primary,
+                    &circuit_secondary,
+                    z0_primary.clone(),
+                    z0_secondary.clone(),
+                )
+            });
+            r_snark
+                .prove_step(
+                    &pp.pp,
+                    circuit_primary,
+                    &circuit_secondary,
+                    z0_primary.clone(),
+                    z0_secondary.clone(),
+                )
+                .expect("failure to prove Nova step");
+            recursive_snark = Some(r_snark);
         }
 
         Ok(Self::Recursive(Box::new(recursive_snark.unwrap())))
@@ -339,7 +347,7 @@ impl<'a: 'b, 'b, C: Coprocessor<S1>> Proof<'a, C> {
         let zi_secondary = z0_secondary.clone();
 
         let (zi_primary_verified, zi_secondary_verified) = match self {
-            Self::Recursive(p) => p.verify(&pp.pp, num_steps, z0_primary, z0_secondary),
+            Self::Recursive(p) => p.verify(&pp.pp, num_steps, &z0_primary, &z0_secondary),
             Self::Compressed(p) => p.verify(&pp.vk, num_steps, z0_primary, z0_secondary),
         }?;
 


### PR DESCRIPTION
This PR (to *dev*) adapts to recent changes in upstream Nova. Of note: https://github.com/microsoft/Nova/pull/163