### PR TITLE
Adjust sha256 example

### DIFF
--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -177,6 +177,7 @@ enum Sha256Coproc<F: LurkField> {
 /// Run the example in this file with
 /// `cargo run --release --example sha256 1 f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b false`
 fn main() {
+    pretty_env_logger::init();
     let args: Vec<String> = env::args().collect();
 
     let num_of_64_bytes = args[1].parse::<usize>().unwrap();

--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -48,10 +48,10 @@ impl<F: LurkField> CoCircuit<F> for Sha256Coprocessor<F> {
         input_env: &AllocatedPtr<F>,
         input_cont: &AllocatedContPtr<F>,
     ) -> Result<(AllocatedPtr<F>, AllocatedPtr<F>, AllocatedContPtr<F>), SynthesisError> {
-        // // TODO: Maybe fix this
-        let false_bool = Boolean::from(AllocatedBit::alloc(cs.namespace(|| "false"), Some(false))?);
-
-        let preimage = vec![false_bool; self.n * 8];
+        let preimage = (0..self.n * 8)
+            .map(|i| AllocatedBit::alloc(cs.namespace(|| format!("preimage bit {i}")), Some(false)))
+            .map(|b| b.map(Boolean::from))
+            .collect::<Result<Vec<_>, _>>()?;
 
         let mut bits = sha256(cs.namespace(|| "SHAhash"), &preimage)?;
 

--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -127,9 +127,7 @@ impl<F: LurkField> Coprocessor<F> for Sha256Coprocessor<F> {
 
         u.reverse();
 
-        let result = s.as_lurk_boolean(u == self.expected);
-
-        result
+        s.as_lurk_boolean(u == self.expected)
     }
 
     fn has_circuit(&self) -> bool {

--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -86,9 +86,9 @@ impl<F: LurkField> CoCircuit<F> for Sha256Coprocessor<F> {
             })
             .collect();
 
-        let both = Boolean::and(cs.namespace(|| "both equal"), &eqs[0], &eqs[1])?;
+        let both_eq = Boolean::and(cs.namespace(|| "both equal"), &eqs[0], &eqs[1])?;
 
-        let result_ptr = AllocatedPtr::as_lurk_boolean(cs, store, &both)?;
+        let result_ptr = AllocatedPtr::as_lurk_boolean(cs, store, &both_eq)?;
 
         Ok((result_ptr, input_env.clone(), input_cont.clone()))
     }

--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -80,6 +80,14 @@ impl<F: LurkField> CoCircuit<F> for Sha256Coprocessor<F> {
             |_| BNum::from(nums[0].clone()).lc(F::from(1)),
             |_| BNum::from(expected_nums[0].clone()).lc(F::from(1)),
         );
+
+        cs.enforce(
+            || "enforce num 2",
+            |lc| lc + CS::one(),
+            |_| BNum::from(nums[1].clone()).lc(F::from(1)),
+            |_| BNum::from(expected_nums[1].clone()).lc(F::from(1)),
+        );
+
         let result_ptr = g.t_ptr.clone();
 
         Ok((result_ptr, input_env.clone(), input_cont.clone()))

--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -13,6 +13,7 @@ use lurk::proof::{nova::NovaProver, Prover};
 use lurk::ptr::Ptr;
 use lurk::public_parameters::public_params;
 use lurk::store::Store;
+use lurk::sym;
 use lurk_macros::Coproc;
 
 use bellperson::gadgets::boolean::{AllocatedBit, Boolean};
@@ -160,9 +161,7 @@ fn main() {
     u.reverse();
 
     let store = &mut Store::<Fr>::new();
-    let sym = sym!("sha256", format!("{}-zero-bytes", input_size));
-
-    let coproc_expr = format!("({})", &sym);
+    let sym_str = sym!("sha256", format!("{}-zero-bytes", input_size));
 
     let lang = Lang::<Fr, Sha256Coproc<Fr>>::new_with_bindings(
         store,
@@ -172,7 +171,7 @@ fn main() {
         )],
     );
 
-    let coproc_expr = format!("({})", sym_str);
+    let coproc_expr = format!("{}", sym_str);
 
     let expr = format!("{coproc_expr}");
     let ptr = store.read(&expr).unwrap();

--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -174,7 +174,7 @@ fn main() {
 
     let coproc_expr = format!("({})", sym_str);
 
-    let expr = format!("({coproc_expr})");
+    let expr = format!("{coproc_expr}");
     let ptr = store.read(&expr).unwrap();
 
     let nova_prover = NovaProver::<Fr, Sha256Coproc<Fr>>::new(REDUCTION_COUNT, lang.clone());

--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Instant;
 
-use lurk::circuit::gadgets::constraints::{alloc_equal, as_lurk_boolean};
+use lurk::circuit::gadgets::constraints::alloc_equal;
 use lurk::circuit::gadgets::data::{allocate_constant, GlobalAllocations};
 use lurk::circuit::gadgets::pointer::{AllocatedContPtr, AllocatedPtr};
 use lurk::coprocessor::{CoCircuit, Coprocessor};
@@ -88,7 +88,7 @@ impl<F: LurkField> CoCircuit<F> for Sha256Coprocessor<F> {
 
         let both = Boolean::and(cs.namespace(|| "both equal"), &eqs[0], &eqs[1])?;
 
-        let result_ptr = as_lurk_boolean(cs, store, &both)?;
+        let result_ptr = AllocatedPtr::as_lurk_boolean(cs, store, &both)?;
 
         Ok((result_ptr, input_env.clone(), input_cont.clone()))
     }

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -21,7 +21,7 @@ use crate::{
 
 use super::gadgets::constraints::{
     self, alloc_equal, alloc_equal_const, alloc_is_zero, and_v, div, enforce_implication, or, or_v,
-    pick, pick_const, sub, as_lurk_boolean,
+    pick, pick_const, sub,
 };
 use crate::circuit::circuit_frame::constraints::{
     add, allocate_is_negative, boolean_to_num, enforce_pack, linear, mul,
@@ -3754,11 +3754,11 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
 
         let args_equal = arg1_final.alloc_equal(&mut cs.namespace(|| "args_equal"), &arg2_final)?;
 
-        let args_equal_ptr = as_lurk_boolean(
+        let args_equal_ptr = AllocatedPtr::as_lurk_boolean(
             &mut cs.namespace(|| "args_equal_ptr"),
             store,
             &args_equal,
-        );
+        )?;
 
         let not_dummy = cont.alloc_tag_equal(
             &mut cs.namespace(|| "Binop2 not dummy"),

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -21,7 +21,7 @@ use crate::{
 
 use super::gadgets::constraints::{
     self, alloc_equal, alloc_equal_const, alloc_is_zero, and_v, div, enforce_implication, or, or_v,
-    pick, pick_const, sub,
+    pick, pick_const, sub, as_lurk_boolean,
 };
 use crate::circuit::circuit_frame::constraints::{
     add, allocate_is_negative, boolean_to_num, enforce_pack, linear, mul,
@@ -3754,12 +3754,11 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
 
         let args_equal = arg1_final.alloc_equal(&mut cs.namespace(|| "args_equal"), &arg2_final)?;
 
-        let args_equal_ptr = AllocatedPtr::pick_const(
+        let args_equal_ptr = as_lurk_boolean(
             &mut cs.namespace(|| "args_equal_ptr"),
+            store,
             &args_equal,
-            &c.t.z_ptr(),
-            &c.nil.z_ptr(),
-        )?;
+        );
 
         let not_dummy = cont.alloc_tag_equal(
             &mut cs.namespace(|| "Binop2 not dummy"),

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -2913,7 +2913,6 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
     ),
     SynthesisError,
 > {
-    let c = store.get_constants();
     let mut hash_default_results = HashInputResults::default();
     let mut results = Results::default();
 

--- a/src/circuit/gadgets/constraints.rs
+++ b/src/circuit/gadgets/constraints.rs
@@ -1,8 +1,6 @@
 // Initially taken from: rust-fil-proofs/storage-proofs-core/src/gadgets/
 
-use super::pointer::AllocatedPtr;
 use crate::field::LurkField;
-use crate::store::Store;
 use bellperson::LinearCombination;
 use bellperson::{
     gadgets::{
@@ -405,21 +403,6 @@ where
     );
 
     Ok(c)
-}
-
-/// Takes a boolean and returns an allocated pointer corresponding to the Boolean's value.
-pub fn as_lurk_boolean<F: LurkField, CS: ConstraintSystem<F>>(
-    mut cs: CS,
-    store: &Store<F>,
-    boolean: &Boolean,
-) -> Result<AllocatedPtr<F>, SynthesisError> {
-    let c = store.get_constants();
-    AllocatedPtr::pick_const(
-        cs.namespace(|| "blah"),
-        boolean,
-        &c.t.z_ptr(),
-        &c.nil.z_ptr(),
-    )
 }
 
 /// Convert from Boolean to AllocatedNum

--- a/src/circuit/gadgets/constraints.rs
+++ b/src/circuit/gadgets/constraints.rs
@@ -1,6 +1,8 @@
 // Initially taken from: rust-fil-proofs/storage-proofs-core/src/gadgets/
 
+use super::pointer::AllocatedPtr;
 use crate::field::LurkField;
+use crate::store::Store;
 use bellperson::LinearCombination;
 use bellperson::{
     gadgets::{
@@ -405,6 +407,21 @@ where
     Ok(c)
 }
 
+/// Takes a boolean and returns an allocated pointer corresponding to the Boolean's value.
+pub fn as_lurk_boolean<F: LurkField, CS: ConstraintSystem<F>>(
+    mut cs: CS,
+    store: &Store<F>,
+    boolean: &Boolean,
+) -> Result<AllocatedPtr<F>, SynthesisError> {
+    let c = store.get_constants();
+    AllocatedPtr::pick_const(
+        cs.namespace(|| "blah"),
+        boolean,
+        &c.t.z_ptr(),
+        &c.nil.z_ptr(),
+    )
+}
+
 /// Convert from Boolean to AllocatedNum
 pub(crate) fn boolean_to_num<F: PrimeField, CS: ConstraintSystem<F>>(
     mut cs: CS,
@@ -433,7 +450,7 @@ where
 }
 
 // This could now use alloc_is_zero to avoid duplication.
-pub(crate) fn alloc_equal<CS: ConstraintSystem<F>, F: PrimeField>(
+pub fn alloc_equal<CS: ConstraintSystem<F>, F: PrimeField>(
     mut cs: CS,
     a: &AllocatedNum<F>,
     b: &AllocatedNum<F>,

--- a/src/circuit/gadgets/data.rs
+++ b/src/circuit/gadgets/data.rs
@@ -384,7 +384,7 @@ impl<F: LurkField> Ptr<F> {
     }
 }
 
-pub(crate) fn allocate_constant<F: LurkField, CS: ConstraintSystem<F>>(
+pub fn allocate_constant<F: LurkField, CS: ConstraintSystem<F>>(
     cs: &mut CS,
     val: F,
 ) -> Result<AllocatedNum<F>, SynthesisError> {

--- a/src/circuit/gadgets/mod.rs
+++ b/src/circuit/gadgets/mod.rs
@@ -2,7 +2,7 @@
 pub(crate) mod macros;
 
 pub(crate) mod case;
-pub(crate) mod constraints;
+pub mod constraints;
 pub mod data;
 pub(crate) mod hashes;
 pub mod pointer;

--- a/src/circuit/gadgets/pointer.rs
+++ b/src/circuit/gadgets/pointer.rs
@@ -496,6 +496,21 @@ impl<F: LurkField> AllocatedPtr<F> {
         Ok(AllocatedPtr { tag, hash })
     }
 
+    /// Takes a boolean and returns an allocated pointer corresponding to the Boolean's value.
+    pub fn as_lurk_boolean<CS: ConstraintSystem<F>>(
+        mut cs: CS,
+        store: &Store<F>,
+        boolean: &Boolean,
+    ) -> Result<AllocatedPtr<F>, SynthesisError> {
+        let c = store.get_constants();
+        AllocatedPtr::pick_const(
+            cs.namespace(|| "blah"),
+            boolean,
+            &c.t.z_ptr(),
+            &c.nil.z_ptr(),
+        )
+    }
+
     pub fn by_index(n: usize, ptr_vec: &[AllocatedNum<F>]) -> Self {
         AllocatedPtr {
             tag: ptr_vec[n * 2].clone(),

--- a/src/circuit/gadgets/pointer.rs
+++ b/src/circuit/gadgets/pointer.rs
@@ -504,7 +504,7 @@ impl<F: LurkField> AllocatedPtr<F> {
     ) -> Result<AllocatedPtr<F>, SynthesisError> {
         let c = store.get_constants();
         AllocatedPtr::pick_const(
-            cs.namespace(|| "blah"),
+            cs.namespace(|| "allocated lurk bool"),
             boolean,
             &c.t.z_ptr(),
             &c.nil.z_ptr(),

--- a/src/eval/reduction.rs
+++ b/src/eval/reduction.rs
@@ -1366,7 +1366,7 @@ fn extend_closure<F: LurkField>(
 }
 
 impl<F: LurkField> Store<F> {
-    fn as_lurk_boolean(&mut self, x: bool) -> Ptr<F> {
+    pub fn as_lurk_boolean(&mut self, x: bool) -> Ptr<F> {
         if x {
             self.t()
         } else {


### PR DESCRIPTION
This PR changes the semantics of the SHA 256 coprocessor example and closes #475. 

The original benchmark evaluated the expression
```
(emit (eq sha_coprocessor (quote expected_result)))
```

The new example changes the coprocessor semantics to take in the expected result as non-deterministic advice and constrains the output of the SHA gadget. The new evaluated expression is:
```
(sha_coprocessor)
```

This should eliminate the 7x overhead from the original example. 