### PR TITLE
ci: Ignore `linux_release` tests covered by `linux` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,7 @@ jobs:
       - restore-sccache-cache
       - run:
           name: Linux Tests
-          command: cargo nextest run --profile ci --workspace --cargo-profile dev-ci --run-ignored all -E 'all() - test(groth16::tests::outer_prove_recursion) - test(test_make_fcomm_examples) - test(test_functional_commitments_demo) - test(test_chained_functional_commitments_demo)'
+          command: cargo nextest run --profile ci --workspace --cargo-profile dev-ci --run-ignored ignored-only -E 'all() - test(groth16::tests::outer_prove_recursion) - test(test_make_fcomm_examples) - test(test_functional_commitments_demo) - test(test_chained_functional_commitments_demo)'
       - run:
           name: Benches build successfully
           command: cargo bench --no-run --profile dev-ci


### PR DESCRIPTION
This PR makes the `linux_release` job only run tests marked `#[ignore]`, as it currently duplicates the non-ignored tests run on the `linux` job. We will thus get a nice reduction in total CI time, as the `linux_release` job is the main bottleneck after #493.