### PR TITLE
Remove conversion from string to symbol

### DIFF
--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -13,7 +13,7 @@ use lurk::ptr::Ptr;
 use lurk::public_parameters::public_params;
 use lurk::store::Store;
 use lurk::tag::{ExprTag, Tag};
-use lurk::Num;
+use lurk::{sym, Num};
 use lurk_macros::Coproc;
 
 use bellperson::gadgets::boolean::{AllocatedBit, Boolean};
@@ -143,13 +143,14 @@ fn main() {
     let input_size = 64 * num_of_64_bytes;
 
     let store = &mut Store::<Fr>::new();
-    let sym_str = format!(".sha256.hash-{}-zero-bytes", input_size);
+    let sym = sym!("sha256", format!("{}-zero-bytes", input_size));
+
+    let coproc_expr = format!("({})", &sym);
+
     let lang = Lang::<Fr, Sha256Coproc<Fr>>::new_with_bindings(
         store,
-        vec![(sym_str.clone(), Sha256Coprocessor::new(input_size).into())],
+        vec![(sym, Sha256Coprocessor::new(input_size).into())],
     );
-
-    let coproc_expr = format!("({})", sym_str);
 
     let mut u: [u128; 2] = [0u128; 2];
 

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -20,7 +20,7 @@ use std::marker::PhantomData;
 use lurk_macros::Coproc;
 use serde::{Deserialize, Serialize};
 
-use crate as lurk;
+use crate::{self as lurk, sym};
 
 use crate::coprocessor::{CoCircuit, Coprocessor};
 use crate::eval::lang::Lang;
@@ -125,13 +125,25 @@ impl<F: LurkField> CoCircuit<F> for InsertCoprocessor<F> {}
 /// Add the `Trie`-associated functions to a `Lang` with standard bindings.
 // TODO: define standard patterns for such modularity.
 pub fn install<F: LurkField>(s: &mut Store<F>, lang: &mut Lang<F, TrieCoproc<F>>) {
-    lang.add_binding((".lurk.trie.new", NewCoprocessor::default().into()), s);
     lang.add_binding(
-        (".lurk.trie.lookup", LookupCoprocessor::default().into()),
+        (
+            sym!("lurk", "trie", "new"),
+            NewCoprocessor::default().into(),
+        ),
         s,
     );
     lang.add_binding(
-        (".lurk.trie.insert", InsertCoprocessor::default().into()),
+        (
+            sym!("lurk", "trie", "lookup"),
+            LookupCoprocessor::default().into(),
+        ),
+        s,
+    );
+    lang.add_binding(
+        (
+            sym!("lurk", "trie", "insert"),
+            InsertCoprocessor::default().into(),
+        ),
         s,
     );
 }

--- a/src/eval/lang.rs
+++ b/src/eval/lang.rs
@@ -186,6 +186,8 @@ impl<F: LurkField, C: Coprocessor<F>> Binding<F, C> {
 
 #[cfg(test)]
 pub(crate) mod test {
+    use crate::sym;
+
     use super::*;
     use pasta_curves::pallas::Scalar as Fr;
 
@@ -199,7 +201,7 @@ pub(crate) mod test {
         let store = &mut Store::<Fr>::default();
         let _lang = Lang::<Fr, Coproc<Fr>>::new_with_bindings(
             store,
-            vec![(".coproc.dummy", DummyCoprocessor::new().into())],
+            vec![(sym!("coproc", "dummy"), DummyCoprocessor::new().into())],
         );
     }
 }

--- a/src/eval/tests/mod.rs
+++ b/src/eval/tests/mod.rs
@@ -2549,6 +2549,7 @@ pub(crate) mod coproc {
     use super::*;
     use crate::coprocessor::test::DumbCoprocessor;
     use crate::store::Store;
+    use crate::sym;
 
     #[derive(Clone, Debug, Coproc)]
     pub(crate) enum DumbCoproc<F: LurkField> {
@@ -2561,7 +2562,7 @@ pub(crate) mod coproc {
 
         let lang = Lang::<Fr, DumbCoproc<Fr>>::new_with_bindings(
             s,
-            vec![(".cproc.dumb", DumbCoprocessor::new().into())],
+            vec![(sym!("cproc", "dumb"), DumbCoprocessor::new().into())],
         );
 
         // 9^2 + 8 = 89

--- a/src/parser/syntax.rs
+++ b/src/parser/syntax.rs
@@ -337,8 +337,8 @@ pub mod tests {
                 // println!("detected: {} {:?}", x.clone(), x);
                 false
             }
-            (Some(..), Err(e)) => {
-                println!("{}", e);
+            (Some(..), Err(_)) => {
+                // println!("{}", e);
                 false
             }
             (None, Ok(..)) => {

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -231,18 +231,6 @@ impl fmt::Display for Symbol {
     }
 }
 
-impl From<&str> for Symbol {
-    fn from(s: &str) -> Symbol {
-        todo!() // call the parser
-    }
-}
-
-impl From<String> for Symbol {
-    fn from(s: String) -> Symbol {
-        (&s as &str).into()
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Eq, Copy)]
 #[cfg_attr(not(target_arch = "wasm32"), derive(Arbitrary))]
 pub enum LurkSym {
@@ -493,14 +481,5 @@ pub mod test {
         assert!(orange.is_keyword());
         assert_eq!(key_root, orange.direct_parent().unwrap());
         assert!(apple.direct_parent().unwrap() != key_root);
-    }
-
-    #[test]
-    fn test_symbol_from_str() {
-        use std::convert::Into;
-        assert_eq!(Into::<Symbol>::into("arst"), Symbol::new(&["arst"]));
-        assert_eq!(Into::<Symbol>::into(".arst"), Symbol::new(&["arst"]));
-        assert_eq!(Into::<Symbol>::into("|a.b|.s"), Symbol::new(&["a.b", "s"]));
-        assert_eq!(Into::<Symbol>::into(".|a.b|.s"), Symbol::new(&["a.b", "s"]));
     }
 }

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -233,13 +233,7 @@ impl fmt::Display for Symbol {
 
 impl From<&str> for Symbol {
     fn from(s: &str) -> Symbol {
-        let sym_path = &s[1..s.len()]
-            .split(SYM_SEPARATOR)
-            .map(|x| x.to_owned())
-            .collect::<Vec<String>>();
-        Self {
-            path: sym_path.clone(),
-        }
+        todo!() // call the parser
     }
 }
 
@@ -499,5 +493,14 @@ pub mod test {
         assert!(orange.is_keyword());
         assert_eq!(key_root, orange.direct_parent().unwrap());
         assert!(apple.direct_parent().unwrap() != key_root);
+    }
+
+    #[test]
+    fn test_symbol_from_str() {
+        use std::convert::Into;
+        assert_eq!(Into::<Symbol>::into("arst"), Symbol::new(&["arst"]));
+        assert_eq!(Into::<Symbol>::into(".arst"), Symbol::new(&["arst"]));
+        assert_eq!(Into::<Symbol>::into("|a.b|.s"), Symbol::new(&["a.b", "s"]));
+        assert_eq!(Into::<Symbol>::into(".|a.b|.s"), Symbol::new(&["a.b", "s"]));
     }
 }

--- a/src/syntax_macros.rs
+++ b/src/syntax_macros.rs
@@ -64,7 +64,7 @@ macro_rules! sym {
     [$( $x:expr ),*] => {
         {
             let temp_vec = vec![ $( $x.to_string() ),* ];
-            $crate::symbol::Symbol::Sym(temp_vec)
+            $crate::symbol::Symbol::new(&temp_vec)
         }
     };
 }
@@ -75,7 +75,7 @@ macro_rules! lurksym {
     [$( $x:expr ),*] => {
         {
             let temp_vec = vec![ "lurk".to_owned(), $( $x.to_string() ),* ];
-            $crate::symbol::Symbol::Sym(temp_vec)
+            $crate::symbol::Symbol::new(&temp_vec)
         }
     };
 }


### PR DESCRIPTION
Converting from string to symbol would require running the parser, then dealing with errors. Instead, the `sym!` macro forces the user to get it right, avoiding potential panics.

Closes #495 