### PR TITLE
feat: Refactor file handling methods in fcomm to JSON format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,4 +144,3 @@ harness = false
 [[bench]]
 name = "public_params"
 harness = false
-

--- a/fcomm/examples/Makefile
+++ b/fcomm/examples/Makefile
@@ -40,10 +40,10 @@ chained-opening.json : chained-function.json chained-input.lurk chained-commitme
 	cargo run --release open --function chained-function.json --input chained-input.lurk --proof chained-opening.json --chain
 
 chained2-opening chained2-opening.json : chained-input.lurk chained-opening
-	# NOTE: This concrete commitment (39ceb60c198b6b7c9f1ff98dd83026bd282e32307d8bd10a28f19d637c4d8549) can be found
+	# NOTE: This concrete commitment (0cfd992562045031d7b106df9d697f99a6c7f9035d8cd9af1ad8ea0e6bfb3e8f) can be found
 	# in chained-opening.json, but its identity is determistic based on the secret and 'second return value' (cdr)
 	# of the function specified in chained-function.json.
-	cargo run --release open --commitment 39ceb60c198b6b7c9f1ff98dd83026bd282e32307d8bd10a28f19d637c4d8549 --input chained-input.lurk --proof chained2-opening.json --chain
+	cargo run --release open --commitment 0cfd992562045031d7b106df9d697f99a6c7f9035d8cd9af1ad8ea0e6bfb3e8f --input chained-input.lurk --proof chained2-opening.json --chain
 
-chained2-from_req-opening chained2-from_req-opening.json : chained-opening chained-request.json
+chained2-from_req-opening chained2-from_req-opening.json : chained2-opening chained-request.json
 	cargo run --release open --request chained-request.json --proof chained2-from_req-opening.json

--- a/fcomm/examples/chained-request.json
+++ b/fcomm/examples/chained-request.json
@@ -1,1 +1,1 @@
-{"commitment":"39ceb60c198b6b7c9f1ff98dd83026bd282e32307d8bd10a28f19d637c4d8549","input":{"expr":{"Source":"9"}},"chain":true}
+{"commitment":"0cfd992562045031d7b106df9d697f99a6c7f9035d8cd9af1ad8ea0e6bfb3e8f","input":{"expr":{"Source":"9"}},"chain":true}

--- a/fcomm/src/bin/fcomm.rs
+++ b/fcomm/src/bin/fcomm.rs
@@ -187,7 +187,7 @@ impl Commit {
                 commitment: None,
             }
         } else {
-            CommittedExpression::read_from_path(&self.function)
+            CommittedExpression::read_from_json_path(&self.function)
                 .expect("committed expression read_from_path")
         };
         let fun_ptr = function.expr_ptr(s, limit, lang).expect("fun_ptr");
@@ -205,10 +205,10 @@ impl Commit {
         function_map
             .set(commitment, &function)
             .expect("function_map set");
-        function.write_to_path(&self.function);
+        function.write_to_json_path(&self.function);
 
         if let Some(commitment_path) = &self.commitment {
-            commitment.write_to_path(commitment_path);
+            commitment.write_to_json_path(commitment_path);
         } else {
             serde_json::to_writer(io::stdout(), &commitment).expect("serde_json to_writer");
         }
@@ -230,7 +230,7 @@ impl Open {
         let function_map = committed_expression_store();
 
         let handle_proof = |out_path, proof: Proof<S1>| {
-            proof.write_to_path(out_path);
+            proof.write_to_json_path(out_path);
             proof
                 .verify(&pp, lang)
                 .expect("created opening doesn't verify");
@@ -279,7 +279,7 @@ impl Open {
                         commitment: None,
                     }
                 } else {
-                    CommittedExpression::read_from_path(function_path).unwrap()
+                    CommittedExpression::read_from_json_path(function_path).unwrap()
                 }
             };
 
@@ -315,7 +315,7 @@ impl Eval {
         match &self.claim {
             Some(out_path) => {
                 let claim = Claim::<S1>::Evaluation(evaluation);
-                claim.write_to_path(out_path);
+                claim.write_to_json_path(out_path);
             }
             None => {
                 serde_json::to_writer(io::stdout(), &evaluation).unwrap();
@@ -340,7 +340,7 @@ impl Prove {
                 );
                 Proof::prove_claim(
                     s,
-                    &Claim::read_from_path(claim).unwrap(),
+                    &Claim::read_from_json_path(claim).unwrap(),
                     limit,
                     false,
                     &prover,
@@ -365,7 +365,7 @@ impl Prove {
         };
 
         // Write first, so prover can debug if proof doesn't verify (it should).
-        proof.write_to_path(&self.proof);
+        proof.write_to_json_path(&self.proof);
         proof
             .verify(&pp, lang)
             .expect("created proof doesn't verify");
@@ -477,7 +477,7 @@ fn expression<P: AsRef<Path>, F: LurkField + Serialize + DeserializeOwned>(
     if lurk {
         read_from_path(store, expression_path)
     } else {
-        let expression = Expression::read_from_path(expression_path)?;
+        let expression = Expression::read_from_json_path(expression_path)?;
         let expr = expression.expr.ptr(store, limit, lang);
         Ok(expr)
     }
@@ -486,7 +486,7 @@ fn expression<P: AsRef<Path>, F: LurkField + Serialize + DeserializeOwned>(
 fn opening_request<P: AsRef<Path>, F: LurkField + Serialize + DeserializeOwned>(
     request_path: P,
 ) -> Result<OpeningRequest<F>, Error> {
-    OpeningRequest::read_from_path(request_path)
+    OpeningRequest::read_from_json_path(request_path)
 }
 
 // Get proof from supplied path or else from stdin.
@@ -495,7 +495,7 @@ where
     F: Serialize + for<'de> Deserialize<'de>,
 {
     match proof_path {
-        Some(path) => Proof::read_from_path(path),
+        Some(path) => Proof::read_from_json_path(path),
         None => Proof::read_from_stdin(),
     }
 }

--- a/fcomm/tests/proof_tests.rs
+++ b/fcomm/tests/proof_tests.rs
@@ -126,7 +126,7 @@ fn test_prove_and_verify_expression() {
             &fcomm_data_path,
         );
 
-        let proof = Proof::<S1>::read_from_path(&proof_path).unwrap();
+        let proof = Proof::<S1>::read_from_json_path(&proof_path).unwrap();
 
         assert_eq!(
             proof
@@ -209,12 +209,12 @@ fn test_function_aux(
     let commitment_path = tmp_dir_path.join("commitment.json");
     let fcomm_data_path = tmp_dir_path.join("fcomm_data");
 
-    function.write_to_path(&function_path);
+    function.write_to_json_path(&function_path);
 
     commit(&function_path, &commitment_path, &fcomm_data_path);
 
     let mut commitment: Commitment<S1> =
-        Commitment::read_from_path(&commitment_path).expect("read commitment");
+        Commitment::read_from_json_path(&commitment_path).expect("read commitment");
 
     for (function_input, expected_output) in io {
         let mut input_file = File::create(&input_path).expect("create file");
@@ -230,7 +230,7 @@ fn test_function_aux(
             chained,
         );
 
-        let proof = Proof::<S1>::read_from_path(&proof_path).expect("read proof");
+        let proof = Proof::<S1>::read_from_json_path(&proof_path).expect("read proof");
         let opening = proof.claim.opening().expect("expected opening claim");
 
         let mut store = Store::<S1>::default();


### PR DESCRIPTION
- Implemented the switch from general path read/write methods to JSON specific versions in `fcomm.rs`, impacting `CommittedExpression`, `Commitment`, `Proof`, `Claim` and other structs.
- Extended `FileStore` trait capabilities in `mod.rs` to handle JSON paths, including implementations for `Serialize` types.
- Adjusts `fcomm` test commitment values in function.

Repairs fcomm tests, which were broken in #391 by making them read to/from bincode. Fixes #500 