### PR TITLE
Streamline serde and zdata round-trip tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,10 +1435,14 @@ dependencies = [
 name = "lurk-macros"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "lurk",
  "pasta_curves",
  "proc-macro2 1.0.63",
+ "proptest",
+ "proptest-derive",
  "quote 1.0.29",
+ "serde",
  "syn 1.0.109",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ base32ct = { version = "0.2.0", features = ["std"] }
 base64 = { workspace = true }
 base-x = "0.2.11"
 bellperson = { workspace = true }
-bincode = "1.3.3"
+bincode = { workspace = true }
 blstrs = { workspace = true }
 clap = "4.1.8"
 dashmap = "5.4.0"
@@ -95,6 +95,7 @@ members = ["clutch",
 anyhow = "1.0.69"
 base64 = "0.13.1"
 bellperson = "0.25"
+bincode = "1.3.3"
 blstrs = "0.7.0"
 # TODO: clap
 ff = "0.13"

--- a/lurk-macros/Cargo.toml
+++ b/lurk-macros/Cargo.toml
@@ -14,7 +14,11 @@ proc-macro = true
 proc-macro2 = "1.0.24"
 quote = "1.0.9"
 syn = { version = "1.0.64", features = ["derive", "extra-traits", "full"] }
+proptest = "1.1.0"
+proptest-derive = "0.3.0"
+serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
+bincode = { workspace = true }
 lurk_crate = { path = "../", package = "lurk" }
 pasta_curves = { workspace = true, features = ["repr-c", "serde"] }

--- a/lurk-macros/src/lib.rs
+++ b/lurk-macros/src/lib.rs
@@ -15,8 +15,12 @@
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
-use quote::quote;
-use syn::{parse_macro_input, Data, DataEnum, DeriveInput, Ident};
+use proc_macro2::Span;
+use quote::{quote, ToTokens};
+use syn::{
+    parse_macro_input, AttributeArgs, Data, DataEnum, DeriveInput, Ident, Item, Lit, Meta,
+    MetaList, NestedMeta, Type,
+};
 
 #[proc_macro_derive(Coproc)]
 pub fn derive_enum_coproc(input: TokenStream) -> TokenStream {
@@ -229,4 +233,112 @@ pub fn let_store(_tokens: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn lurk(tokens: TokenStream) -> TokenStream {
     Lurk::parse_raw(tokens.into()).unwrap().emit()
+}
+
+/// This macro is used to generate round-trip serialization tests.
+///
+/// By appending `serde_test` to a struct or enum definition, you automatically derive
+/// serialization tests that employ Serde for round-trip testing. The procedure in the generated tests is:
+/// 1. Instantiate the type being tested
+/// 2. Serialize the instance, ensuring the operation's success
+/// 3. Deserialize the serialized data, comparing the resulting instance with the original one
+///
+/// The type being tested must meet the following requirements:
+/// * Implementations of `Debug` and `PartialEq` traits
+/// * Implementation of `Arbitrary` trait
+/// * Implementations of `Serialize` and `DeserializeOwned` traits
+///
+/// For testing generic types, use the `types(...)` attribute to list type parameters for testing,
+/// separated by commas. For complex types (e.g., ones where type parameters have their own parameters),
+/// enclose them in quotation marks. To test different combinations of type parameters, `types`
+/// can be used multiple times.
+///
+/// # Example
+/// ```
+/// use proptest_derive::Arbitrary;
+/// use serde::{Serialize, Deserialize};
+/// use lurk_macros::serde_test;
+///
+/// // The macro derives serialization tests using an arbitrary instance.
+/// #[serde_test(types(u64, "Vec<u64>"), types(u32, bool))]
+/// #[derive(Debug, Default, PartialEq, Arbitrary, Serialize, Deserialize)]
+/// struct Generic<T1, T2> {
+///     t1: T1,
+///     t2: T2,
+/// }
+/// ```
+///
+#[proc_macro_attribute]
+pub fn serde_test(args: TokenStream, input: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(args as AttributeArgs);
+    let input = parse_macro_input!(input as Item);
+    let name = match &input {
+        Item::Struct(item) => &item.ident,
+        Item::Enum(item) => &item.ident,
+        _ => panic!("This macro only works on structs and enums"),
+    };
+
+    // Parse arguments.
+    let mut types = Vec::new();
+    for arg in args {
+        match arg {
+            // List arguments (as in #[ser_test(arg(val))])
+            NestedMeta::Meta(Meta::List(MetaList { path, nested, .. })) => match path.get_ident() {
+                Some(id) if *id == "types" => {
+                    let params = nested.iter().map(parse_type).collect::<Vec<_>>();
+                    types.push(quote!(<#name<#(#params),*>>));
+                }
+
+                _ => panic!("invalid attribute {:?}", path),
+            },
+
+            _ => panic!("invalid argument {:?}", arg),
+        }
+    }
+
+    if types.is_empty() {
+        // If no explicit type parameters were given for us to test with, assume the type under test
+        // takes no type parameters.
+        types.push(quote!(<#name>));
+    }
+
+    let mut output = quote! {
+        #input
+    };
+
+    for (i, ty) in types.into_iter().enumerate() {
+        let serde_test = {
+            let test_name = Ident::new(
+                &format!("test_serde_roundtrip_{}_{}", name, i),
+                Span::mixed_site(),
+            );
+            quote! {
+                #[cfg(test)]
+                proptest::proptest!{
+                    #[test]
+                    fn #test_name(obj in proptest::prelude::any::#ty()) {
+                        let buf = bincode::serialize(&obj).unwrap();
+                        assert_eq!(obj, bincode::deserialize(&buf).unwrap());
+                    }
+                }
+            }
+        };
+
+        output = quote! {
+            #output
+            #serde_test
+        };
+    }
+
+    output.into()
+}
+
+fn parse_type(m: &NestedMeta) -> Type {
+    match m {
+        NestedMeta::Lit(Lit::Str(s)) => syn::parse_str(&s.value()).unwrap(),
+        NestedMeta::Meta(Meta::Path(p)) => syn::parse2(p.to_token_stream()).unwrap(),
+        _ => {
+            panic!("expected type");
+        }
+    }
 }

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -12,6 +12,8 @@ use lang::Lang;
 
 use log::info;
 #[cfg(not(target_arch = "wasm32"))]
+use lurk_macros::serde_test;
+#[cfg(not(target_arch = "wasm32"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use std::cmp::PartialEq;
@@ -60,6 +62,7 @@ pub struct Frame<T: Copy, W: Copy, C> {
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), derive(Arbitrary))]
+#[cfg_attr(not(target_arch = "wasm32"), serde_test)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Status {
     Terminal,

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -2,7 +2,10 @@ use std::fmt;
 
 use crate::parser::LURK_WHITESPACE;
 #[cfg(not(target_arch = "wasm32"))]
+use lurk_macros::serde_test;
+#[cfg(not(target_arch = "wasm32"))]
 use proptest_derive::Arbitrary;
+
 /// Module for symbol type, Sym.
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -14,6 +17,7 @@ pub const ESCAPE_CHARS: &str = "|(){}[],.:'\\\"";
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(not(target_arch = "wasm32"), derive(Arbitrary))]
+#[cfg_attr(not(target_arch = "wasm32"), serde_test)]
 /// Type for hierarchical symbol names.
 ///
 /// The symbol path is encoded with a vector of strings. Keywords are symbols

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -1,4 +1,6 @@
 #[cfg(not(target_arch = "wasm32"))]
+use lurk_macros::serde_test;
+#[cfg(not(target_arch = "wasm32"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -9,6 +11,7 @@ use std::{
 /// Unsigned fixed-width integer type for Lurk.
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Serialize, Deserialize)]
 #[cfg_attr(not(target_arch = "wasm32"), derive(Arbitrary))]
+#[cfg_attr(not(target_arch = "wasm32"), serde_test)]
 pub enum UInt {
     U64(u64),
 }

--- a/src/z_data/z_cont.rs
+++ b/src/z_data/z_cont.rs
@@ -1,5 +1,5 @@
 #[cfg(not(target_arch = "wasm32"))]
-use proptest::prelude::BoxedStrategy;
+use lurk_macros::serde_test;
 #[cfg(not(target_arch = "wasm32"))]
 use proptest::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -13,6 +13,10 @@ use crate::tag::Tag;
 use crate::z_ptr::{ZContPtr, ZExprPtr, ZPtr};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(
+    not(target_arch = "wasm32"),
+    serde_test(types(pasta_curves::pallas::Scalar), zdata(true))
+)]
 /// A `ZCont` is the content-addressed representation of a Lurk continuation, which enables
 /// efficient serialization and sharing of hashed Lurk data via associated `ZContPtr`s.
 pub enum ZCont<F: LurkField> {
@@ -364,25 +368,5 @@ impl<F: LurkField> Arbitrary for ZCont<F> {
             Just(ZCont::Terminal),
         ]
         .boxed()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::z_data::{from_z_data, to_z_data};
-    use pasta_curves::pallas::Scalar;
-
-    proptest! {
-          #[test]
-          fn prop_serde_z_cont(x in any::<ZCont<Scalar>>()) {
-              let ser = to_z_data(&x).expect("write ZCont");
-              let de: ZCont<Scalar> = from_z_data(&ser).expect("read ZCont");
-              assert_eq!(x, de);
-
-              let ser: Vec<u8> = bincode::serialize(&x).expect("write ZCont");
-              let de: ZCont<Scalar> = bincode::deserialize(&ser).expect("read ZCont");
-              assert_eq!(x, de);
-          }
     }
 }

--- a/src/z_data/z_store.rs
+++ b/src/z_data/z_store.rs
@@ -1,4 +1,6 @@
 #[cfg(not(target_arch = "wasm32"))]
+use lurk_macros::serde_test;
+#[cfg(not(target_arch = "wasm32"))]
 use proptest::prelude::*;
 #[cfg(not(target_arch = "wasm32"))]
 use proptest_derive::Arbitrary;
@@ -23,6 +25,10 @@ use crate::field::LurkField;
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
 #[cfg_attr(not(target_arch = "wasm32"), derive(Arbitrary))]
 #[cfg_attr(not(target_arch = "wasm32"), proptest(no_bound))]
+#[cfg_attr(
+    not(target_arch = "wasm32"),
+    serde_test(types(pasta_curves::pallas::Scalar), zdata(true))
+)]
 /// A `ZStore` is a content-addressed, serializable representation of a Lurk store
 ///
 /// Whereas a `Store` contains caches of each type of Lurk data, a `ZStore`
@@ -166,25 +172,5 @@ impl<F: LurkField> ZStore<F> {
         }
         self.insert_z_expr(&ptr, Some(expr.clone()));
         (ptr, expr)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::z_data::{from_z_data, to_z_data};
-    use pasta_curves::pallas::Scalar;
-
-    proptest! {
-        #[test]
-        fn prop_serde_z_store(s in any::<ZStore<Scalar>>()) {
-            let ser = to_z_data(&s).expect("write ZStore");
-            let de: ZStore<Scalar> = from_z_data(&ser).expect("read ZStore");
-            assert_eq!(s, de);
-
-            let ser: Vec<u8> = bincode::serialize(&s).expect("write ZStore");
-            let de: ZStore<Scalar> = bincode::deserialize(&ser).expect("read ZStore");
-            assert_eq!(s, de);
-        }
     }
 }


### PR DESCRIPTION
This implements a `serde_test` macro that can generate round-trip serialization tests pegged on an implementation of `proptest::prelude::Arbitrary`. This macro:
- supports generic arguments passed as attributes,
- supports, optionally, a zdata argument to also generate roundtrips through to_z_data / from_z_data.

=> no more boilerplate tests! (and future tests are easier to define)