### PR TITLE
chore: Patch `sppark` to unreleased version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2346,8 +2346,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfb9486baeb35ca1197c4df27451d4df5bd321e15da94c1ddb89670f9e94896a"
+source = "git+https://github.com/supranational/sppark#00cc352d257571d9edefdd12deb3d25f760cf665"
 dependencies = [
  "cc",
  "which",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,3 +144,6 @@ harness = false
 [[bench]]
 name = "public_params"
 harness = false
+
+[patch.crates-io]
+sppark = { git = "https://github.com/supranational/sppark" }


### PR DESCRIPTION
This is a workaround until sppark / pasta-msm releases.

- Added the `sppark` library to the project dependencies.
- Imported the library from its git repository (https://github.com/supranational/sppark).
- Updated the `Cargo.toml` file to include the new dependency.