### PR TITLE
Prove/verify API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
+dependencies = [
+ "proc-macro2 1.0.63",
+ "quote 1.0.29",
+ "syn 2.0.23",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +633,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "config"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d379af7f68bfc21714c6c7dea883544201741d2ce8274bb12fa54f89507f52a7"
+dependencies = [
+ "async-trait",
+ "json5",
+ "lazy_static",
+ "nom",
+ "pathdiff",
+ "ron",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "toml",
+ "yaml-rust",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,6 +843,12 @@ dependencies = [
  "block-buffer 0.10.4",
  "crypto-common",
 ]
+
+[[package]]
+name = "dlv-list"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
 name = "doc-comment"
@@ -1171,6 +1207,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.6",
+]
 
 [[package]]
 name = "heck"
@@ -1332,6 +1371,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,6 +1410,12 @@ name = "libm"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1405,6 +1461,7 @@ dependencies = [
  "blstrs",
  "cfg-if",
  "clap 4.3.11",
+ "config",
  "criterion",
  "dashmap",
  "ff",
@@ -1707,6 +1764,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-multimap"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
+dependencies = [
+ "dlv-list",
+ "hashbrown",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,10 +1849,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4b27ab7be369122c218afc2079489cdcb4b517c0a3fc386ff11e1fedfcc2b35"
 
 [[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
 name = "peekmore"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9163e1259760e83d528d1b3171e5100c1767f10c52e1c4d6afad26e63d47d758"
+
+[[package]]
+name = "pest"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73935e4d55e2abf7f130186537b19e7a4abc886a0252380b59248af473a3fc9"
+dependencies = [
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef623c9bbfa0eedf5a0efba11a5ee83209c326653ca31ff019bec3a95bfff2b"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3e8cba4ec22bada7fc55ffe51e2deb6a0e0db2d0b7ab0b103acc80d2510c190"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2 1.0.63",
+ "quote 1.0.29",
+ "syn 2.0.23",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01f71cb40bd8bb94232df14b946909e14660e33fc05db3e50ae2a82d7ea0ca0"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "plotters"
@@ -2122,6 +2239,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ron"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
+dependencies = [
+ "base64",
+ "bitflags 1.3.2",
+ "serde",
+]
+
+[[package]]
 name = "rust-gpu-tools"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2136,6 +2264,16 @@ dependencies = [
  "sha2",
  "temp-env",
  "thiserror",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -2590,6 +2728,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "trait-set"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2605,6 +2752,12 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unarray"
@@ -2858,6 +3011,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ bellperson = { workspace = true }
 bincode = { workspace = true }
 blstrs = { workspace = true }
 clap = { version = "4.3.10", features = ["derive"] }
+config = "0.13.3"
 dashmap = "5.4.0"
 ff = { workspace = true }
 generic-array = "0.14.6"

--- a/benches/end2end.rs
+++ b/benches/end2end.rs
@@ -272,7 +272,7 @@ fn prove_benchmark(c: &mut Criterion) {
 
         b.iter(|| {
             let result = prover
-                .prove(&pp, frames.clone(), &mut store, lang_pallas_rc.clone())
+                .prove(&pp, &frames, &mut store, lang_pallas_rc.clone())
                 .unwrap();
             black_box(result);
         })
@@ -307,13 +307,13 @@ fn verify_benchmark(c: &mut Criterion) {
                 .get_evaluation_frames(ptr, empty_sym_env(&store), &mut store, limit, &lang_pallas)
                 .unwrap();
             let (proof, z0, zi, num_steps) = prover
-                .prove(&pp, frames, &mut store, lang_pallas_rc.clone())
+                .prove(&pp, &frames, &mut store, lang_pallas_rc.clone())
                 .unwrap();
 
             b.iter_batched(
                 || z0.clone(),
                 |z0| {
-                    let result = proof.verify(&pp, num_steps, z0, &zi[..]).unwrap();
+                    let result = proof.verify(&pp, num_steps, &z0, &zi[..]).unwrap();
                     black_box(result);
                 },
                 BatchSize::LargeInput,
@@ -352,7 +352,7 @@ fn verify_compressed_benchmark(c: &mut Criterion) {
                 .get_evaluation_frames(ptr, empty_sym_env(&store), &mut store, limit, &lang_pallas)
                 .unwrap();
             let (proof, z0, zi, num_steps) = prover
-                .prove(&pp, frames, &mut store, lang_pallas_rc.clone())
+                .prove(&pp, &frames, &mut store, lang_pallas_rc.clone())
                 .unwrap();
 
             let compressed_proof = proof.compress(&pp).unwrap();
@@ -361,7 +361,7 @@ fn verify_compressed_benchmark(c: &mut Criterion) {
                 || z0.clone(),
                 |z0| {
                     let result = compressed_proof
-                        .verify(&pp, num_steps, z0, &zi[..])
+                        .verify(&pp, num_steps, &z0, &zi[..])
                         .unwrap();
                     black_box(result);
                 },

--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -117,7 +117,7 @@ fn fibo_prove<M: measurement::Measurement>(name: &str, iterations: u64, c: &mut 
             b.iter_batched(
                 || (frames.clone(), lang_rc.clone()), // avoid cloning the frames in the benchmark
                 |(frames, lang_rc)| {
-                    let result = prover.prove(&pp, frames, &mut store, lang_rc).unwrap();
+                    let result = prover.prove(&pp, &frames, &mut store, lang_rc).unwrap();
                     black_box(result);
                 },
                 BatchSize::LargeInput,

--- a/deny.toml
+++ b/deny.toml
@@ -109,6 +109,7 @@ allow = [
     "CC0-1.0",
     "Apache-2.0",
     "Unicode-DFS-2016",
+    "ISC",
 ]
 # List of explicitly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses

--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -190,7 +190,7 @@ fn main() {
     println!("Verifying proof...");
 
     let verify_start = Instant::now();
-    let res = proof.verify(&pp, num_steps, z0, &zi).unwrap();
+    let res = proof.verify(&pp, num_steps, &z0, &zi).unwrap();
     let verify_end = verify_start.elapsed();
 
     println!("Verify took {:?}", verify_end);

--- a/fcomm/src/lib.rs
+++ b/fcomm/src/lib.rs
@@ -931,7 +931,7 @@ impl<'a> Proof<'a, S1> {
         let verified = claim_iterations_and_num_steps_are_consistent
             && self
                 .proof
-                .verify(pp, self.num_steps, public_inputs, &public_outputs)
+                .verify(pp, self.num_steps, &public_inputs, &public_outputs)
                 .expect("error verifying");
 
         let result = VerificationResult::new(verified);

--- a/src/cli/lurk_proof.rs
+++ b/src/cli/lurk_proof.rs
@@ -1,0 +1,108 @@
+use serde::{Deserialize, Serialize};
+
+use anyhow::Result;
+
+use lurk::{
+    eval::{
+        lang::{Coproc, Lang},
+        Status,
+    },
+    field::{LanguageField, LurkField},
+    proof::nova,
+    public_parameters::public_params,
+    z_ptr::ZExprPtr,
+    z_store::ZStore,
+};
+
+/// A wrapper for data whose deserialization depends on a certain LurkField
+#[derive(Serialize, Deserialize)]
+pub struct FieldData {
+    field: LanguageField,
+    data: Vec<u8>,
+}
+
+#[allow(dead_code)]
+impl FieldData {
+    #[inline]
+    pub fn wrap<F: LurkField, T: Serialize>(t: &T) -> Result<Self> {
+        Ok(Self {
+            field: F::FIELD,
+            data: bincode::serialize(t)?,
+        })
+    }
+
+    #[inline]
+    pub fn open<'a, T: Deserialize<'a>>(&'a self) -> Result<T> {
+        Ok(bincode::deserialize(&self.data)?)
+    }
+}
+
+/// Carries extra information to help with visualization, experiments etc
+#[derive(Serialize, Deserialize)]
+pub struct LurkProofMeta<F: LurkField> {
+    pub iterations: usize,
+    pub evaluation_cost: u128,
+    pub generation_cost: u128,
+    pub compression_cost: u128,
+    pub status: Status,
+    pub expression: ZExprPtr<F>,
+    pub environment: ZExprPtr<F>,
+    pub result: ZExprPtr<F>,
+    pub zstore: ZStore<F>,
+}
+
+type F = pasta_curves::pallas::Scalar; // TODO: generalize this
+
+/// Minimal data structure containing just enough for proof verification
+#[derive(Serialize, Deserialize)]
+pub enum LurkProof<'a> {
+    Nova {
+        proof: nova::Proof<'a, Coproc<F>>,
+        public_inputs: Vec<F>,
+        public_outputs: Vec<F>,
+        num_steps: usize,
+        rc: usize,
+        lang: Lang<F, Coproc<F>>,
+    },
+}
+
+impl<'a> LurkProof<'a> {
+    #[allow(dead_code)]
+    fn verify(self) -> Result<bool> {
+        match self {
+            Self::Nova {
+                proof,
+                public_inputs,
+                public_outputs,
+                num_steps,
+                rc,
+                lang,
+            } => {
+                log::info!("Loading public parameters");
+                let pp = public_params(rc, std::sync::Arc::new(lang))?;
+                Ok(proof.verify(&pp, num_steps, &public_inputs, &public_outputs)?)
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    fn print_verification(proof_id: &str, success: bool) {
+        if success {
+            println!("✓ Proof \"{proof_id}\" verified");
+        } else {
+            println!("✗ Proof \"{proof_id}\" failed on verification");
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn verify_proof(proof_id: &str) -> Result<()> {
+        use super::paths::proof_path;
+        use std::{fs::File, io::BufReader};
+
+        let file = File::open(proof_path(proof_id))?;
+        let fd: FieldData = bincode::deserialize_from(BufReader::new(file))?;
+        let lurk_proof: LurkProof = fd.open()?;
+        Self::print_verification(proof_id, lurk_proof.verify()?);
+        Ok(())
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,26 +1,27 @@
+mod lurk_proof;
 mod paths;
 mod repl;
 
-use std::fs;
-use std::path::PathBuf;
-
 use anyhow::{bail, Context, Result};
-
-use lurk::eval::lang::Coproc;
-use lurk::field::{LanguageField, LurkField};
-use lurk::store::Store;
-use lurk::z_data::{from_z_data, ZData};
-use lurk::z_store::ZStore;
-use pasta_curves::{pallas, vesta};
-
 use clap::{Args, Parser, Subcommand};
+use config::{Config, Environment, File};
+use pasta_curves::pallas;
+use std::{collections::HashMap, fs, path::PathBuf};
 
-// use self::prove_and_verify::verify_proof;
-use self::repl::Repl;
+use lurk::{
+    field::{LanguageField, LurkField},
+    store::Store,
+    z_data::{from_z_data, ZData},
+    z_store::ZStore,
+};
 
-const DEFAULT_FIELD: LanguageField = LanguageField::Pallas;
+use crate::cli::repl::validate_non_zero;
+
+use self::repl::{Backend, Repl};
+
 const DEFAULT_LIMIT: usize = 100_000_000;
 const DEFAULT_RC: usize = 10;
+const DEFAULT_BACKEND: Backend = Backend::Nova;
 
 #[derive(Parser, Debug)]
 #[clap(version)]
@@ -35,8 +36,8 @@ enum Command {
     Load(LoadArgs),
     /// Enters Lurk's REPL environment ("repl" can be elided)
     Repl(ReplArgs),
-    // /// Verifies a Lurk proof
-    // Verify(VerifyArgs),
+    /// Verifies a Lurk proof
+    Verify(VerifyArgs),
 }
 
 #[derive(Args, Debug)]
@@ -49,16 +50,29 @@ struct LoadArgs {
     #[clap(long, value_parser)]
     zstore: Option<PathBuf>,
 
+    /// Flag to prove the last evaluation
+    #[arg(long)]
+    prove: bool,
+
+    /// Config file, containing the lowest precedence parameters
+    #[clap(long, value_parser)]
+    config: Option<PathBuf>,
+
     /// Maximum number of iterations allowed (defaults to 100_000_000)
     #[clap(long, value_parser)]
     limit: Option<usize>,
-    // /// Reduction count used for proofs (defaults to 10)
-    // #[clap(long, value_parser)]
-    // rc: Option<usize>,
 
-    // /// Flag to prove the last evaluation
-    // #[arg(long)]
-    // prove: bool,
+    /// Reduction count used for proofs (defaults to 10)
+    #[clap(long, value_parser)]
+    rc: Option<usize>,
+
+    /// Prover backend (defaults to "Nova")
+    #[clap(long, value_parser)]
+    backend: Option<String>,
+
+    /// Arithmetic field (defaults to the backend's standard field)
+    #[clap(long, value_parser)]
+    field: Option<String>,
 }
 
 #[derive(Parser, Debug)]
@@ -69,13 +83,23 @@ struct LoadCli {
     #[clap(long, value_parser)]
     zstore: Option<PathBuf>,
 
+    #[arg(long)]
+    prove: bool,
+
+    #[clap(long, value_parser)]
+    config: Option<PathBuf>,
+
     #[clap(long, value_parser)]
     limit: Option<usize>,
-    // #[arg(long)]
-    // prove: bool,
 
-    // #[clap(long, value_parser)]
-    // rc: Option<usize>,
+    #[clap(long, value_parser)]
+    rc: Option<usize>,
+
+    #[clap(long, value_parser)]
+    backend: Option<String>,
+
+    #[clap(long, value_parser)]
+    field: Option<String>,
 }
 
 impl LoadArgs {
@@ -83,9 +107,12 @@ impl LoadArgs {
         LoadCli {
             lurk_file: self.lurk_file,
             zstore: self.zstore,
+            prove: self.prove,
+            config: self.config,
             limit: self.limit,
-            // prove: self.prove,
-            // rc: self.rc,
+            rc: self.rc,
+            backend: self.backend,
+            field: self.field,
         }
     }
 }
@@ -100,12 +127,25 @@ struct ReplArgs {
     #[clap(long, value_parser)]
     load: Option<PathBuf>,
 
+    /// Config file, containing the lowest precedence parameters
+    #[clap(long, value_parser)]
+    config: Option<PathBuf>,
+
     /// Maximum number of iterations allowed (defaults to 100_000_000)
     #[clap(long, value_parser)]
     limit: Option<usize>,
-    // /// Reduction count used for proofs (defaults to 10)
-    // #[clap(long, value_parser)]
-    // rc: Option<usize>,
+
+    /// Reduction count used for proofs (defaults to 10)
+    #[clap(long, value_parser)]
+    rc: Option<usize>,
+
+    /// Prover backend (defaults to "Nova")
+    #[clap(long, value_parser)]
+    backend: Option<String>,
+
+    /// Arithmetic field (defaults to the backend's standard field)
+    #[clap(long, value_parser)]
+    field: Option<String>,
 }
 
 #[derive(Parser, Debug)]
@@ -117,9 +157,19 @@ struct ReplCli {
     zstore: Option<PathBuf>,
 
     #[clap(long, value_parser)]
+    config: Option<PathBuf>,
+
+    #[clap(long, value_parser)]
     limit: Option<usize>,
-    // #[clap(long, value_parser)]
-    // rc: Option<usize>,
+
+    #[clap(long, value_parser)]
+    rc: Option<usize>,
+
+    #[clap(long, value_parser)]
+    backend: Option<String>,
+
+    #[clap(long, value_parser)]
+    field: Option<String>,
 }
 
 impl ReplArgs {
@@ -127,23 +177,72 @@ impl ReplArgs {
         ReplCli {
             load: self.load,
             zstore: self.zstore,
+            config: self.config,
             limit: self.limit,
-            // rc: self.rc,
+            rc: self.rc,
+            backend: self.backend,
+            field: self.field,
         }
     }
 }
 
-fn get_field() -> Result<LanguageField> {
-    if let Ok(lurk_field) = std::env::var("LURK_FIELD") {
-        match lurk_field.to_lowercase().as_str() {
-            "bls12-381" => Ok(LanguageField::BLS12_381),
-            "pallas" => Ok(LanguageField::Pallas),
-            "vesta" => Ok(LanguageField::Vesta),
-            _ => bail!("Field not supported: {lurk_field}"),
-        }
-    } else {
-        Ok(DEFAULT_FIELD)
+fn parse_backend(backend_str: &String) -> Result<Backend> {
+    match backend_str.to_lowercase().as_str() {
+        "nova" => Ok(Backend::Nova),
+        "snarkpack+" => Ok(Backend::SnarkPackPlus),
+        _ => bail!("Backend not supported: {backend_str}"),
     }
+}
+
+fn parse_field(field_str: &String) -> Result<LanguageField> {
+    match field_str.to_lowercase().as_str() {
+        "pallas" => Ok(LanguageField::Pallas),
+        "vesta" => Ok(LanguageField::Vesta),
+        "bls12-381" => Ok(LanguageField::BLS12_381),
+        _ => bail!("Field not supported: {field_str}"),
+    }
+}
+
+fn get_parsed_usize(
+    param_name: &str,
+    arg: &Option<usize>,
+    config: &HashMap<String, String>,
+    default: usize,
+) -> Result<usize> {
+    match arg {
+        Some(arg) => Ok(*arg),
+        None => match config.get(param_name) {
+            None => Ok(default),
+            Some(arg_str) => Ok(arg_str.parse::<usize>()?),
+        },
+    }
+}
+
+fn get_parsed<T>(
+    param_name: &str,
+    arg: &Option<String>,
+    config: &HashMap<String, String>,
+    parse_fn: fn(&String) -> Result<T>,
+    default: T,
+) -> Result<T> {
+    match arg {
+        Some(arg) => parse_fn(arg),
+        None => match config.get(param_name) {
+            None => Ok(default),
+            Some(arg) => parse_fn(arg),
+        },
+    }
+}
+
+fn get_config(config_path: &Option<PathBuf>) -> Result<HashMap<String, String>> {
+    // First load from the config file
+    let builder = match config_path {
+        Some(config_path) => Config::builder().add_source(File::from(config_path.to_owned())),
+        None => Config::builder(),
+    };
+    // Then potentially overwrite with environment variables
+    let builder = builder.add_source(Environment::with_prefix("LURK"));
+    Ok(builder.build()?.try_deserialize()?)
 }
 
 fn get_store<F: LurkField + for<'a> serde::de::Deserialize<'a>>(
@@ -161,31 +260,50 @@ fn get_store<F: LurkField + for<'a> serde::de::Deserialize<'a>>(
 }
 
 macro_rules! new_repl {
-    ( $cli: expr, $field: path ) => {{
-        let limit = $cli.limit.unwrap_or(DEFAULT_LIMIT);
-        // let rc = $cli.rc.unwrap_or(DEFAULT_RC);
+    ( $cli: expr, $limit: expr, $rc: expr, $field: path, $backend: expr ) => {{
         let mut store = get_store(&$cli.zstore).with_context(|| "reading store from file")?;
         let env = store.nil();
-        // Repl::<$field, Coproc<$field>>::new(store, env, limit, rc)?
-        Repl::<$field, Coproc<$field>>::new(store, env, limit, DEFAULT_RC)?
+        Repl::<$field>::new(store, env, $limit, $rc, $backend)
     }};
 }
 
 impl ReplCli {
     pub fn run(&self) -> Result<()> {
         macro_rules! repl {
-            ( $field: path ) => {{
-                let mut repl = new_repl!(self, $field);
+            ( $limit: expr, $rc: expr, $field: path, $backend: expr ) => {{
+                let mut repl = new_repl!(self, $limit, $rc, $field, $backend);
                 if let Some(lurk_file) = &self.load {
                     repl.load_file(lurk_file)?;
                 }
                 repl.start()
             }};
         }
-        match get_field()? {
-            LanguageField::Pallas => repl!(pallas::Scalar),
-            LanguageField::Vesta => repl!(vesta::Scalar),
-            LanguageField::BLS12_381 => repl!(blstrs::Scalar),
+        let config = get_config(&self.config)?;
+        let limit = get_parsed_usize("limit", &self.limit, &config, DEFAULT_LIMIT)?;
+        let rc = get_parsed_usize("rc", &self.rc, &config, DEFAULT_RC)?;
+        let backend = get_parsed(
+            "backend",
+            &self.backend,
+            &config,
+            parse_backend,
+            DEFAULT_BACKEND,
+        )?;
+        let field = get_parsed(
+            "field",
+            &self.field,
+            &config,
+            parse_field,
+            backend.default_field(),
+        )?;
+        validate_non_zero("limit", limit)?;
+        validate_non_zero("rc", rc)?;
+        backend.validate_field(&field)?;
+        match field {
+            LanguageField::Pallas => repl!(limit, rc, pallas::Scalar, backend),
+            // LanguageField::Vesta => repl!(limit, rc, vesta::Scalar, backend),
+            // LanguageField::BLS12_381 => repl!(limit, rc, blstrs::Scalar, backend),
+            LanguageField::Vesta => todo!(),
+            LanguageField::BLS12_381 => todo!(),
         }
     }
 }
@@ -193,33 +311,58 @@ impl ReplCli {
 impl LoadCli {
     pub fn run(&self) -> Result<()> {
         macro_rules! load {
-            ( $field: path ) => {{
-                let mut repl = new_repl!(self, $field);
+            ( $limit: expr, $rc: expr, $field: path, $backend: expr ) => {{
+                let mut repl = new_repl!(self, $limit, $rc, $field, $backend);
                 repl.load_file(&self.lurk_file)?;
-                // if self.prove {
-                //     repl.prove_last_claim()?;
-                // }
+                if self.prove {
+                    #[cfg(not(target_arch = "wasm32"))]
+                    repl.prove_last_frames()?;
+                }
                 Ok(())
             }};
         }
-        match get_field()? {
-            LanguageField::Pallas => load!(pallas::Scalar),
-            LanguageField::Vesta => load!(vesta::Scalar),
-            LanguageField::BLS12_381 => load!(blstrs::Scalar),
+        let config = get_config(&self.config)?;
+        let limit = get_parsed_usize("limit", &self.limit, &config, DEFAULT_LIMIT)?;
+        let rc = get_parsed_usize("rc", &self.rc, &config, DEFAULT_RC)?;
+        let backend = get_parsed(
+            "backend",
+            &self.backend,
+            &config,
+            parse_backend,
+            DEFAULT_BACKEND,
+        )?;
+        let field = get_parsed(
+            "field",
+            &self.field,
+            &config,
+            parse_field,
+            backend.default_field(),
+        )?;
+        validate_non_zero("limit", limit)?;
+        validate_non_zero("rc", rc)?;
+        backend.validate_field(&field)?;
+        match field {
+            LanguageField::Pallas => load!(limit, rc, pallas::Scalar, backend),
+            // LanguageField::Vesta => load!(limit, rc, vesta::Scalar, backend),
+            // LanguageField::BLS12_381 => load!(limit, rc, blstrs::Scalar, backend),
+            LanguageField::Vesta => todo!(),
+            LanguageField::BLS12_381 => todo!(),
         }
     }
 }
 
-// #[derive(Args, Debug)]
-// struct VerifyArgs {
-//     #[clap(value_parser)]
-//     proof_file: PathBuf,
-// }
+#[derive(Args, Debug)]
+struct VerifyArgs {
+    /// ID of the proof to be verified
+    #[clap(value_parser)]
+    proof_id: String,
+}
 
 /// Parses CLI arguments and continues the program flow accordingly
 pub fn parse_and_run() -> Result<()> {
     #[cfg(not(target_arch = "wasm32"))]
-    paths::create_lurk_dir()?;
+    paths::create_lurk_dirs()?;
+
     if let Ok(repl_cli) = ReplCli::try_parse() {
         repl_cli.run()
     } else if let Ok(load_cli) = LoadCli::try_parse() {
@@ -228,7 +371,15 @@ pub fn parse_and_run() -> Result<()> {
         match Cli::parse().command {
             Command::Repl(repl_args) => repl_args.into_cli().run(),
             Command::Load(load_args) => load_args.into_cli().run(),
-            // Command::Verify(verify_args) => verify_proof(&verify_args.proof_file),
+            #[allow(unused_variables)]
+            Command::Verify(verify_args) => {
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    use crate::cli::lurk_proof::LurkProof;
+                    LurkProof::verify_proof(&verify_args.proof_id)?;
+                }
+                Ok(())
+            }
         }
     }
 }

--- a/src/cli/paths.rs
+++ b/src/cli/paths.rs
@@ -18,9 +18,31 @@ pub fn lurk_dir() -> PathBuf {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub fn create_lurk_dir() -> Result<()> {
-    let dir_path = lurk_dir();
-    Ok(fs::create_dir_all(dir_path)?)
+pub fn proofs_dir() -> PathBuf {
+    lurk_dir().join(Path::new("proofs"))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn lurk_leaf_dirs() -> [PathBuf; 1] {
+    [proofs_dir()]
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn create_lurk_dirs() -> Result<()> {
+    for dir in lurk_leaf_dirs() {
+        fs::create_dir_all(dir)?;
+    }
+    Ok(())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn proof_path(name: &str) -> PathBuf {
+    proofs_dir().join(Path::new(name)).with_extension("proof")
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn proof_meta_path(name: &str) -> PathBuf {
+    proofs_dir().join(Path::new(name)).with_extension("meta")
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/src/eval/lang.rs
+++ b/src/eval/lang.rs
@@ -76,7 +76,7 @@ pub enum Coproc<F: LurkField> {
 ///   exact set of coprocessors to be allowed in the `Lang` struct.
 ///
 // TODO: Define a trait for the Hash and parameterize on that also.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct Lang<F: LurkField, C: Coprocessor<F>> {
     //  A HashMap that stores coprocessors with their associated `Sym` keys.
     coprocessors: HashMap<Symbol, (C, ZExprPtr<F>)>,

--- a/src/field.rs
+++ b/src/field.rs
@@ -10,7 +10,11 @@ use std::convert::TryFrom;
 use std::hash::Hash;
 
 #[cfg(not(target_arch = "wasm32"))]
+use lurk_macros::serde_test;
+#[cfg(not(target_arch = "wasm32"))]
 use proptest::prelude::*;
+#[cfg(not(target_arch = "wasm32"))]
+use proptest_derive::Arbitrary;
 #[cfg(not(target_arch = "wasm32"))]
 use rand::{rngs::StdRng, SeedableRng};
 
@@ -26,6 +30,9 @@ use crate::tag::{ContTag, ExprTag, Op1, Op2};
 /// Because confusion on this point, perhaps combined with cargo-cult copying of incorrect previous usage has led to
 /// inconsistencies and inaccuracies in the code base, please prefer the named Scalar forms when correspondence to a
 /// named `LanguageField` is important.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Arbitrary))]
+#[cfg_attr(not(target_arch = "wasm32"), serde_test)]
 pub enum LanguageField {
     /// The Pallas field,
     Pallas,
@@ -33,6 +40,16 @@ pub enum LanguageField {
     Vesta,
     /// The BLS12-381 scalar field,
     BLS12_381,
+}
+
+impl std::fmt::Display for LanguageField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pallas => write!(f, "Pallas"),
+            Self::Vesta => write!(f, "Vesta"),
+            Self::BLS12_381 => write!(f, "BLS12-381"),
+        }
+    }
 }
 
 /// Trait implemented by finite fields used in the language

--- a/src/public_parameters/registry.rs
+++ b/src/public_parameters/registry.rs
@@ -3,6 +3,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use log::info;
 use once_cell::sync::Lazy;
 use pasta_curves::pallas;
 use serde::{de::DeserializeOwned, Serialize};
@@ -50,13 +51,13 @@ impl Registry {
         let key = format!("public-params-rc-{rc}-coproc-{lang_key}");
         // read the file if it exists, otherwise initialize
         if let Some(pp) = disk_cache.get::<PublicParams<'static, C>>(&key) {
-            eprintln!("Using disk-cached public params for lang {}", lang_key);
+            info!("Using disk-cached public params for lang {lang_key}");
             Ok(Arc::new(pp))
         } else {
             let pp = default(lang);
             disk_cache
                 .set(&key, &*pp)
-                .tap_ok(|_| eprintln!("Writing public params to disk-cache: {}", lang_key))
+                .tap_ok(|_| info!("Writing public params to disk-cache for lang {lang_key}"))
                 .map_err(|e| Error::CacheError(format!("Disk write error: {e}")))?;
             Ok(pp)
         }


### PR DESCRIPTION
This PR implements proving and verification for the `lurk` CLI.

* Only the Pallas field and the Nova backend are supported for now
* I avoided reusing the APIs that were built for `fcomm` and `clutch` on purpose. This avoids conflicts and makes the CLI code more self-contained and easy to change. A future refactor might serve the purpose of unifying the underlying code base so `fcomm`, `clutch` and the CLI can sit on top of the same common code
* I've set the code to get configuration parameters from config file, env vars and CLI args (in that order of precedence, with CLI args having the highest priority)

This PR doesn't implement commitments/openings. We'll leave that for a next unit of improvement.

Closes #366 