### PR TITLE
chore: Update sppark dependency to a particular version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2364,7 +2364,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.3"
-source = "git+https://github.com/supranational/sppark#00cc352d257571d9edefdd12deb3d25f760cf665"
+source = "git+https://github.com/supranational/sppark?rev=5fea26f43cc5d12a77776c70815e7c722fd1f8a7#5fea26f43cc5d12a77776c70815e7c722fd1f8a7"
 dependencies = [
  "cc",
  "which",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,4 +147,4 @@ name = "public_params"
 harness = false
 
 [patch.crates-io]
-sppark = { git = "https://github.com/supranational/sppark" }
+sppark = { git = "https://github.com/supranational/sppark", rev="5fea26f43cc5d12a77776c70815e7c722fd1f8a7" }


### PR DESCRIPTION
- Updated the 'sppark' dependency to a specific revision in the project's `Cargo.toml` configuration.
- see https://app.circleci.com/pipelines/github/lurk-lab/lurk-rs/3307/workflows/6d31ca4e-3fa8-49c9-acae-570d38c5e3d0/jobs/19864
- see https://github.com/supranational/sppark/issues/12