### PR TITLE
chore: Update 'anymap' dependency and refactor related usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,9 +123,9 @@ checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "anymap"
-version = "0.12.1"
+version = "1.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33954243bd79057c2de7338850b85983a44588021f8a5fee574a8888c6de4344"
+checksum = "8f1f8f5a6f3d50d89e3797d7593a50f96bb2aaa20ca0cc7be1fb673232c91d72"
 
 [[package]]
 name = "arrayref"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.68.2"
 [dependencies]
 ahash = "0.7.6"
 anyhow = { workspace = true }
-anymap = "0.12.1"
+anymap = "1.0.0-beta.2"
 base32ct = { version = "0.2.0", features = ["std"] }
 base64 = { workspace = true }
 base-x = "0.2.11"

--- a/src/public_parameters/registry.rs
+++ b/src/public_parameters/registry.rs
@@ -14,7 +14,7 @@ use crate::{coprocessor::Coprocessor, eval::lang::Lang, proof::nova::PublicParam
 use super::file_map::FileIndex;
 
 type S1 = pallas::Scalar;
-type AnyMap = anymap::Map<dyn anymap::any::Any + Send + Sync>;
+type AnyMap = anymap::Map<dyn core::any::Any + Send + Sync>;
 type PublicParamMemCache<C> = HashMap<usize, Arc<PublicParams<'static, C>>>;
 
 /// This is a global registry for Coproc-specific parameters.


### PR DESCRIPTION
- Upgraded the `anymap` dependency to the latest version.
- Refactored the 'AnyMap' type definition, replacing `anymap::any::Any` with `core::any::Any` in `public_parameters/registry.rs`.
- this will invalidate public params