### PR TITLE
fix: remove uneeded Serialization bounds on Coprocessors

### DIFF
--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -61,6 +61,7 @@ pub type NovaPublicParams<'a, C> = nova::PublicParams<G1, G2, C1<'a, C>, C2>;
 
 /// A struct that contains public parameters for the Nova proving system.
 #[derive(Serialize, Deserialize)]
+#[serde(bound = "")]
 pub struct PublicParams<'a, C: Coprocessor<S1>> {
     pp: NovaPublicParams<'a, C>,
     pk: ProverKey<G1, G2, C1<'a, C>, C2, SS1, SS2>,

--- a/src/public_parameters/mod.rs
+++ b/src/public_parameters/mod.rs
@@ -9,7 +9,6 @@ use crate::{
     proof::nova::{self, PublicParams},
 };
 use pasta_curves::pallas;
-use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 pub mod error;
@@ -20,7 +19,7 @@ use crate::public_parameters::error::Error;
 
 pub type S1 = pallas::Scalar;
 
-pub fn public_params<C: Coprocessor<S1> + Serialize + DeserializeOwned + 'static>(
+pub fn public_params<C: Coprocessor<S1> + 'static>(
     rc: usize,
     lang: Arc<Lang<S1, C>>,
 ) -> Result<Arc<PublicParams<'static, C>>, Error> {

--- a/src/public_parameters/registry.rs
+++ b/src/public_parameters/registry.rs
@@ -6,7 +6,6 @@ use std::{
 use log::info;
 use once_cell::sync::Lazy;
 use pasta_curves::pallas;
-use serde::{de::DeserializeOwned, Serialize};
 use tap::TapFallible;
 
 use crate::public_parameters::error::Error;
@@ -34,7 +33,7 @@ pub(crate) static CACHE_REG: Lazy<Registry> = Lazy::new(|| Registry {
 
 impl Registry {
     fn get_from_file_cache_or_update_with<
-        C: Coprocessor<S1> + Serialize + DeserializeOwned + 'static,
+        C: Coprocessor<S1> + 'static,
         F: FnOnce(Arc<Lang<S1, C>>) -> Arc<PublicParams<'static, C>>,
     >(
         &'static self,
@@ -66,7 +65,7 @@ impl Registry {
     /// Check if params for this Coproc are in registry, if so, return them.
     /// Otherwise, initialize with the passed in function.
     pub(crate) fn get_coprocessor_or_update_with<
-        C: Coprocessor<S1> + Serialize + DeserializeOwned + 'static,
+        C: Coprocessor<S1> + 'static,
         F: FnOnce(Arc<Lang<S1, C>>) -> Arc<PublicParams<'static, C>>,
     >(
         &'static self,


### PR DESCRIPTION
Added in #88

@winston-h-zhang very rightly notices they are not needed in https://github.com/lurk-lab/lurk-rs/tree/circom-integration