### PR TITLE
Add self-hosted CI for PR tests

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,0 +1,109 @@
+name: Lurk CI tests
+
+on:
+  merge_group:
+  push:
+    branches-ignored: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  # Disable incremental compilation.
+  #
+  # Incremental compilation is useful as part of an edit-build-test-edit cycle,
+  # as it lets the compiler avoid recompiling code that hasn't changed. However,
+  # on CI, we're not making small edits; we're almost always building the entire
+  # project from scratch. Thus, incremental compilation on CI actually
+  # introduces *additional* overhead to support making future builds
+  # faster...but no future builds will ever occur in any given CI environment.
+  #
+  # See https://matklad.github.io/2021/09/04/fast-rust-builds.html#ci-workflow
+  # for details.
+  CARGO_INCREMENTAL: 0
+  # Allow more retries for network requests in cargo (downloading crates) and
+  # rustup (installing toolchains). This should help to reduce flaky CI failures
+  # from transient network timeouts or other issues.
+  CARGO_NET_RETRY: 10
+  RUSTUP_MAX_RETRIES: 10
+  # Don't emit giant backtraces in the CI logs.
+  RUST_BACKTRACE: short
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  linux:
+    runs-on: [self-hosted, test]
+    env:
+      RUSTFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+      - uses: taiki-e/install-action@nextest
+      - uses: Swatinem/rust-cache@v2
+      - name: Linux Tests
+        run: |
+          cargo nextest run --profile ci --workspace --cargo-profile dev-ci
+      - name: Linux Gadget Tests w/o debug assertions
+        run: |
+          cargo nextest run --profile ci --workspace --cargo-profile dev-no-assertions -E 'test(circuit::gadgets)'
+  
+  misc:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+      fail-fast: false
+    env:
+      RUSTFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+      - uses: taiki-e/install-action@nextest
+      - uses: Swatinem/rust-cache@v2
+      - run: rustup target add wasm32-unknown-unknown
+      - name: Wasm build 
+        run: |
+          cargo build --target wasm32-unknown-unknown
+      # make sure benches don't bit-rot
+      - name: build benches
+        # TODO: --all-features
+        run: cargo build --benches
+      - name: Doctests
+        run: |
+          cargo test --doc
+  
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+      # See '.cargo/config' for list of enabled/disabled clippy lints
+      - name: rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all --check
+      - name: cargo clippy
+        run: cargo xclippy -D warnings
+
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install rustup
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+    - name: Install cargo-msrv
+      run: cargo install cargo-msrv
+    - name: Check Rust MSRV
+      run: cargo msrv verify


### PR DESCRIPTION
This PR enables tests to run on self-hosted Linux runners with GitHub Actions, which would pave the way to switch from CircleCI in a future PR. Some notes:
- Only Linux x86_64 is currently supported, as ARM/MacOS runners will require additional server setup on e.g. MacStadium or EC2.
- For cheaper tasks like the Wasm and bench builds, I created a `misc` job that runs on the cloud-hosted runners.
- The self-hosted runners are deployed using Docker-compose in https://github.com/lurk-lab/gh-actions-runner/tree/main/test-runner, but will need some scaling and/or hardware tweaks over time. Currently, there are 8 runners with a minimum of 4 vCPUs and 8 GB RAM each.
- Successful run on my fork: https://github.com/samuelburnham/lurk-rs/actions/runs/5616765892