### PR TITLE
Claim hash is no longer the proof id

### DIFF
--- a/src/cli/commitment.rs
+++ b/src/cli/commitment.rs
@@ -30,19 +30,15 @@ mod non_wasm {
     use super::Commitment;
 
     impl<F: LurkField> Commitment<F> {
-        pub fn hide(secret: F, payload: Ptr<F>, store: &mut Store<F>) -> Result<Self> {
-            let comm_ptr = &store.hide(secret, payload);
+        pub fn new(secret: Option<F>, payload: Ptr<F>, store: &mut Store<F>) -> Result<Self> {
+            let comm_ptr = match secret {
+                Some(secret) => store.hide(secret, payload),
+                None => store.commit(payload),
+            };
             let mut zstore = Some(ZStore::<F>::default());
-            let hash = *store.get_z_expr(comm_ptr, &mut zstore)?.0.value();
-            Ok(Self {
-                hash,
-                zstore: zstore.unwrap(),
-            })
-        }
-
-        #[inline]
-        pub fn commit(payload: Ptr<F>, store: &mut Store<F>) -> Result<Self> {
-            Self::hide(F::ZERO, payload, store)
+            let hash = *store.get_z_expr(&comm_ptr, &mut zstore)?.0.value();
+            let zstore = zstore.unwrap();
+            Ok(Self { hash, zstore })
         }
     }
 

--- a/src/cli/commitment.rs
+++ b/src/cli/commitment.rs
@@ -30,7 +30,7 @@ mod non_wasm {
     use super::Commitment;
 
     impl<F: LurkField> Commitment<F> {
-        pub fn new(secret: F, payload: Ptr<F>, store: &mut Store<F>) -> Result<Self> {
+        pub fn hide(secret: F, payload: Ptr<F>, store: &mut Store<F>) -> Result<Self> {
             let comm_ptr = &store.hide(secret, payload);
             let mut zstore = Some(ZStore::<F>::default());
             let hash = *store.get_z_expr(comm_ptr, &mut zstore)?.0.value();
@@ -38,6 +38,11 @@ mod non_wasm {
                 hash,
                 zstore: zstore.unwrap(),
             })
+        }
+
+        #[inline]
+        pub fn commit(payload: Ptr<F>, store: &mut Store<F>) -> Result<Self> {
+            Self::hide(F::ZERO, payload, store)
         }
     }
 

--- a/src/cli/lurk_proof.rs
+++ b/src/cli/lurk_proof.rs
@@ -64,6 +64,8 @@ where
 
 #[cfg(not(target_arch = "wasm32"))]
 mod non_wasm {
+    use std::path::PathBuf;
+
     use crate::cli::{
         field_data::non_wasm::{dump, load},
         paths::non_wasm::{proof_meta_path, proof_path},
@@ -89,8 +91,14 @@ mod non_wasm {
         Coproc<F>: Coprocessor<Pallas>,
     {
         #[inline]
+        #[allow(dead_code)]
         pub fn persist(self, id: &str) -> Result<()> {
             dump(self, proof_path(id))
+        }
+
+        #[inline]
+        pub fn persist_at(self, path: PathBuf) -> Result<()> {
+            dump(self, path)
         }
     }
 

--- a/src/cli/lurk_proof.rs
+++ b/src/cli/lurk_proof.rs
@@ -91,12 +91,6 @@ mod non_wasm {
         Coproc<F>: Coprocessor<Pallas>,
     {
         #[inline]
-        #[allow(dead_code)]
-        pub fn persist(self, id: &str) -> Result<()> {
-            dump(self, proof_path(id))
-        }
-
-        #[inline]
         pub fn persist_at(self, path: PathBuf) -> Result<()> {
             dump(self, path)
         }

--- a/src/cli/lurk_proof.rs
+++ b/src/cli/lurk_proof.rs
@@ -64,8 +64,6 @@ where
 
 #[cfg(not(target_arch = "wasm32"))]
 mod non_wasm {
-    use std::path::PathBuf;
-
     use crate::cli::{
         field_data::non_wasm::{dump, load},
         paths::non_wasm::{proof_meta_path, proof_path},
@@ -81,8 +79,8 @@ mod non_wasm {
 
     impl<F: LurkField + Serialize> LurkProofMeta<F> {
         #[inline]
-        pub fn persist(self, id: &str) -> Result<()> {
-            dump(self, proof_meta_path(id))
+        pub fn persist(self, proof_key: &str) -> Result<()> {
+            dump(self, proof_meta_path(proof_key))
         }
     }
 
@@ -91,8 +89,8 @@ mod non_wasm {
         Coproc<F>: Coprocessor<Pallas>,
     {
         #[inline]
-        pub fn persist_at(self, path: PathBuf) -> Result<()> {
-            dump(self, path)
+        pub fn persist(self, proof_key: &str) -> Result<()> {
+            dump(self, proof_path(proof_key))
         }
     }
 
@@ -114,12 +112,12 @@ mod non_wasm {
             }
         }
 
-        pub fn verify_proof(proof_id: &str) -> Result<()> {
-            let lurk_proof: LurkProof<'_, Pallas> = load(proof_path(proof_id))?;
+        pub fn verify_proof(proof_key: &str) -> Result<()> {
+            let lurk_proof: LurkProof<'_, Pallas> = load(proof_path(proof_key))?;
             if lurk_proof.verify()? {
-                println!("✓ Proof \"{proof_id}\" verified");
+                println!("✓ Proof \"{proof_key}\" verified");
             } else {
-                println!("✗ Proof \"{proof_id}\" failed on verification");
+                println!("✗ Proof \"{proof_key}\" failed on verification");
             }
             Ok(())
         }

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -270,7 +270,7 @@ impl Repl<F> {
                             zstore: zstore.unwrap(),
                         };
 
-                        lurk_proof.persist_at(proof_path)?;
+                        lurk_proof.persist(proof_key)?;
                         lurk_proof_meta.persist(proof_key)?;
                         claim_comm.persist()?;
                     }

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -191,8 +191,6 @@ impl Repl<F> {
 
     #[cfg(not(target_arch = "wasm32"))]
     pub fn prove_last_frames(&mut self) -> Result<()> {
-        use ff::Field;
-
         use crate::cli::{commitment::Commitment, paths::non_wasm::proof_path};
 
         match self.evaluation.as_mut() {
@@ -220,7 +218,7 @@ impl Repl<F> {
                         (cont.parts(), cont_out.parts()),
                     );
 
-                    let claim_comm = Commitment::new(F::ZERO, claim, &mut self.store)?;
+                    let claim_comm = Commitment::commit(claim, &mut self.store)?;
                     let claim_hash = &claim_comm.hash.hex_digits();
                     let proof_key = &Self::proof_key(&self.backend, &self.rc, claim_hash);
                     let proof_path = proof_path(proof_key);
@@ -287,7 +285,7 @@ impl Repl<F> {
     fn hide(&mut self, secret: F, payload: Ptr<F>) -> Result<()> {
         use super::commitment::Commitment;
 
-        let commitment = Commitment::new(secret, payload, &mut self.store)?;
+        let commitment = Commitment::hide(secret, payload, &mut self.store)?;
         let hash_str = &commitment.hash.hex_digits();
         commitment.persist()?;
         println!(

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -218,7 +218,7 @@ impl Repl<F> {
                         (cont.parts(), cont_out.parts()),
                     );
 
-                    let claim_comm = Commitment::commit(claim, &mut self.store)?;
+                    let claim_comm = Commitment::new(None, claim, &mut self.store)?;
                     let claim_hash = &claim_comm.hash.hex_digits();
                     let proof_key = &Self::proof_key(&self.backend, &self.rc, claim_hash);
                     let proof_path = proof_path(proof_key);
@@ -285,7 +285,7 @@ impl Repl<F> {
     fn hide(&mut self, secret: F, payload: Ptr<F>) -> Result<()> {
         use super::commitment::Commitment;
 
-        let commitment = Commitment::hide(secret, payload, &mut self.store)?;
+        let commitment = Commitment::new(Some(secret), payload, &mut self.store)?;
         let hash_str = &commitment.hash.hex_digits();
         commitment.persist()?;
         println!(

--- a/src/eval/reduction.rs
+++ b/src/eval/reduction.rs
@@ -903,7 +903,7 @@ fn apply_continuation<F: LurkField>(
                         ExprTag::Num | ExprTag::Comm => store.secret_mut(result)?,
                         _ => return Ok(Control::Error(result, env)),
                     },
-                    Op1::Commit => store.hide(F::ZERO, result),
+                    Op1::Commit => store.commit(result),
                     Op1::Num => match result.tag {
                         ExprTag::Num | ExprTag::Comm | ExprTag::Char | ExprTag::U64 => {
                             let z_ptr = store

--- a/src/field.rs
+++ b/src/field.rs
@@ -57,6 +57,9 @@ pub trait LurkField: PrimeField + PrimeFieldBits {
     /// The type of the field element's representation
     const FIELD: LanguageField;
 
+    /// The default secret for non-hiding commitments
+    const NON_HIDING_COMMITMENT_SECRET: Self = Self::ZERO;
+
     /// Converts the field element to a byte vector
     fn to_bytes(self) -> Vec<u8> {
         let repr = self.to_repr();

--- a/src/store.rs
+++ b/src/store.rs
@@ -174,6 +174,10 @@ impl<F: LurkField> Store<F> {
         self.intern_comm(secret, payload)
     }
 
+    pub fn commit(&mut self, payload: Ptr<F>) -> Ptr<F> {
+        self.hide(F::NON_HIDING_COMMITMENT_SECRET, payload)
+    }
+
     pub fn open(&self, ptr: Ptr<F>) -> Option<(F, Ptr<F>)> {
         let p = match ptr.tag {
             ExprTag::Comm => ptr,


### PR DESCRIPTION
This PR creates proper proof keys - not IDs (yet) - that should uniquely identify proofs based on the backend, the field, the rc and the claim.