### PR TITLE
refactor: Nova structs become generic on their field type (+ update Nova)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1690,8 +1690,9 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nova-snark"
-version = "0.22.0"
-source = "git+https://github.com/microsoft/Nova.git#a62bccf2063da5f8843352f5d1acb242252ac775"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e12911ac9672ad436acfc992f09e26a5960513bbe81d1572005cadd8c1be8f4"
 dependencies = [
  "bellperson",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,7 @@ dependencies = [
  "blstrs",
  "byteorder",
  "crossbeam-channel",
- "digest 0.10.7",
+ "digest",
  "ec-gpu",
  "ec-gpu-gen",
  "ff",
@@ -332,32 +332,11 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
-dependencies = [
- "block-padding",
- "byte-tools",
- "byteorder",
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array 0.14.7",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
+ "generic-array",
 ]
 
 [[package]]
@@ -412,12 +391,6 @@ name = "byte-slice-cast"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
-
-[[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytecount"
@@ -787,7 +760,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "typenum",
 ]
 
@@ -839,20 +812,11 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
-dependencies = [
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "crypto-common",
 ]
 
@@ -967,7 +931,7 @@ checksum = "16d9a9ea4c04632c16bc5c71a2fcc63d308481f7fc67eb1a1ce6315c44a426ae"
 dependencies = [
  "execute-command-macro",
  "execute-command-tokens",
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -1152,15 +1116,6 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
-name = "generic-array"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "generic-array"
@@ -1422,6 +1377,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,7 +1495,7 @@ dependencies = [
  "criterion",
  "dashmap",
  "ff",
- "generic-array 0.14.7",
+ "generic-array",
  "getrandom",
  "hex",
  "home",
@@ -1677,7 +1641,7 @@ dependencies = [
  "ec-gpu",
  "ec-gpu-gen",
  "ff",
- "generic-array 0.14.7",
+ "generic-array",
  "itertools 0.8.2",
  "log",
  "pasta_curves",
@@ -1727,20 +1691,19 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 [[package]]
 name = "nova-snark"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90acdc02f86ed9f5f902b6eaf921774a608b953fc320bf4bba29598e51f67833"
+source = "git+https://github.com/microsoft/Nova.git#a62bccf2063da5f8843352f5d1acb242252ac775"
 dependencies = [
  "bellperson",
  "bincode",
  "bitvec",
  "byteorder",
- "digest 0.8.1",
+ "digest",
  "ff",
  "flate2",
- "generic-array 0.14.7",
+ "generic-array",
  "getrandom",
  "halo2curves",
- "itertools 0.9.0",
+ "itertools 0.11.0",
  "neptune",
  "num-bigint 0.4.3",
  "num-integer",
@@ -1840,12 +1803,6 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
-name = "opaque-debug"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "opencl-sys"
@@ -2585,20 +2542,17 @@ checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.8.2"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd26bc0e7a2e3a7c959bc494caf58b72ee0c71d67704e9520f736ca7e4853ecf"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "block-buffer 0.7.3",
- "byte-tools",
- "digest 0.8.1",
+ "digest",
  "keccak",
- "opaque-debug",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ ff = "0.13"
 log = "0.4.19"
 metrics = "0.21.1"
 neptune = { version = "10.0.0" }
-nova = { git = "https://github.com/microsoft/Nova.git", package = "nova-snark", version = "0.22", default-features = false }
+nova = { version = "0.23", default-features = false, package = "nova-snark" }
 once_cell = "1.18.0"
 pairing = { version = "0.23" }
 pasta_curves = { version = "0.5.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ ff = "0.13"
 log = "0.4.19"
 metrics = "0.21.1"
 neptune = { version = "10.0.0" }
-nova = { package = "nova-snark", version = "0.22", default-features = false }
+nova = { git = "https://github.com/microsoft/Nova.git", package = "nova-snark", version = "0.22", default-features = false }
 once_cell = "1.18.0"
 pairing = { version = "0.23" }
 pasta_curves = { version = "0.5.1" }

--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -189,7 +189,7 @@ fn main() {
     println!("Setting up public parameters...");
 
     let pp_start = Instant::now();
-    let pp = public_params::<Sha256Coproc<Fr>>(REDUCTION_COUNT, lang_rc.clone()).unwrap();
+    let pp = public_params::<_, Sha256Coproc<Fr>>(REDUCTION_COUNT, lang_rc.clone()).unwrap();
     let pp_end = pp_start.elapsed();
 
     println!("Public parameters took {:?}", pp_end);

--- a/fcomm/src/bin/fcomm.rs
+++ b/fcomm/src/bin/fcomm.rs
@@ -1,4 +1,5 @@
 use log::info;
+use lurk::proof::nova::CurveCycleEquipped;
 use std::convert::TryFrom;
 use std::env;
 use std::fs::read_to_string;
@@ -492,7 +493,7 @@ fn opening_request<P: AsRef<Path>, F: LurkField + Serialize + DeserializeOwned>(
 }
 
 // Get proof from supplied path or else from stdin.
-fn proof<'a, P: AsRef<Path>, F: LurkField>(
+fn proof<'a, P: AsRef<Path>, F: CurveCycleEquipped>(
     proof_path: Option<P>,
 ) -> Result<Proof<'a, F>, error::Error>
 where

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -306,6 +306,8 @@ impl ReplCli {
             // LanguageField::BLS12_381 => repl!(limit, rc, blstrs::Scalar, backend),
             LanguageField::Vesta => todo!(),
             LanguageField::BLS12_381 => todo!(),
+            LanguageField::BN256 => todo!(),
+            LanguageField::Grumpkin => todo!(),
         }
     }
 }
@@ -349,6 +351,8 @@ impl LoadCli {
             // LanguageField::BLS12_381 => load!(limit, rc, blstrs::Scalar, backend),
             LanguageField::Vesta => todo!(),
             LanguageField::BLS12_381 => todo!(),
+            LanguageField::BN256 => todo!(),
+            LanguageField::Grumpkin => todo!(),
         }
     }
 }

--- a/src/field.rs
+++ b/src/field.rs
@@ -5,6 +5,7 @@
 //! as an extension of the ff::PrimeField trait, with conveniance methods
 //! relating this field to the expresions of the language.
 use ff::{PrimeField, PrimeFieldBits};
+use nova::provider::bn256_grumpkin::bn256;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use std::hash::Hash;
@@ -40,6 +41,10 @@ pub enum LanguageField {
     Vesta,
     /// The BLS12-381 scalar field,
     BLS12_381,
+    /// The BN256 scalar field,
+    BN256,
+    /// THe Grumpkin scalar field,
+    Grumpkin,
 }
 
 impl std::fmt::Display for LanguageField {
@@ -48,6 +53,8 @@ impl std::fmt::Display for LanguageField {
             Self::Pallas => write!(f, "Pallas"),
             Self::Vesta => write!(f, "Vesta"),
             Self::BLS12_381 => write!(f, "BLS12-381"),
+            Self::BN256 => write!(f, "BN256"),
+            Self::Grumpkin => write!(f, "Grumpkin"),
         }
     }
 }
@@ -246,6 +253,12 @@ impl LurkField for pasta_curves::pallas::Scalar {
 impl LurkField for pasta_curves::vesta::Scalar {
     const FIELD: LanguageField = LanguageField::Vesta;
 }
+
+impl LurkField for bn256::Scalar {
+    const FIELD: LanguageField = LanguageField::BN256;
+}
+
+// The impl LurkField for grumpkin::Scalar is technically possible, but voluntarily omitted to avoid confusion.
 
 // For working around the orphan trait impl rule
 /// Wrapper struct around a field element that implements additional traits

--- a/tests/lurk-tests.rs
+++ b/tests/lurk-tests.rs
@@ -1,8 +1,8 @@
 use lurk::{
     eval::lang::{Coproc, Lang},
-    proof::nova,
     repl::{repl, ReplState},
 };
+use pasta_curves::pallas::Scalar as S1;
 use std::path::Path;
 
 #[test]
@@ -37,10 +37,6 @@ fn lurk_tests() {
     for f in test_files {
         let joined = example_dir.join(f);
 
-        repl::<nova::S1, ReplState<nova::S1, Coproc<nova::S1>>, _, Coproc<nova::S1>>(
-            Some(joined),
-            Lang::new(),
-        )
-        .unwrap();
+        repl::<S1, ReplState<S1, Coproc<S1>>, _, Coproc<S1>>(Some(joined), Lang::new()).unwrap();
     }
 }


### PR DESCRIPTION
## What this Does

- makes all of our Nova-related structures generic in the type of the used primary scalar field, provided that field can be attached to a curve cycle with the suitable properties (see `CurveCyleEquipped` trait)
- sets up the curve cycle attachments for the `pallas::Scalar` and `bn256::Scalar` fields,
- allows us to start using the Grumpkin cycle.

## What This Does Not Do, *but helps with (as the present PR is a blocker for those tasks)*

- making public parameter caching generic, or supporting SnarkPack (#386, it still depends on Nova through `nova::PublicParams`)
- making `clutch` generic, or supporting SnarkPack (it still depends on Nova through `nova::NovaProver`)
- making `fcomm` generic, or supporting SnarkPack (#281, it still depends on Nova through `nova::NovaProver`)
- making the repl generic (#533, it still depends on Nova through `nova::Proof`)

## In Detail

- Implemented the `CurveCycleEquipped` trait, replacing previous curve-specific scalar types for improved generic programming over curve cycles.
- Updated various files, including `fcomm.rs`, `lurk_proof.rs`, `lib.rs` and `nova.rs` to accommodate the new `CurveCycleEquipped` type.
- Extended `LanguageField` enum with `BN256` and `Grumpkin` values and updated respective `fmt` display.
- Refactored the `public_params` function in `public_parameters/mod.rs and registry.rs` to use the new `CurveCycleEquipped` type.
- Modified proofs in `nova.rs` to work with the new `CurveCycleEquipped` type.
- Removed `nova` and `pasta_curves::pallas` dependencies from `lurk-tests.rs` and `registry.rs` respectively, demonstrating reduction in dependency.

Closes #519.