### PR TITLE
ci: Cache the cargo-msrv install

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -103,6 +103,7 @@ jobs:
       with:
         toolchain: stable
         override: true
+    - uses: Swatinem/rust-cache@v2
     - name: Install cargo-msrv
       run: cargo install cargo-msrv
     - name: Check Rust MSRV

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - uses: Swatinem/rust-cache@v2
       - name: Install cargo-msrv
         run: cargo install cargo-msrv
       - name: Check Rust MSRV


### PR DESCRIPTION
This speeds up the MSRV check action by a few minutes.

Before: https://github.com/samuelburnham/lurk-rs/actions/runs/5624783183/job/15242302546
After: https://github.com/samuelburnham/lurk-rs/actions/runs/5624854347/job/15242509112