### PR TITLE
ci: make pr-test ignore pushes to the merge queue

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -3,7 +3,9 @@ name: Lurk CI tests
 on:
   merge_group:
   push:
-    branches-ignored: [master]
+    branches-ignore:
+      - "gh-readonly-queue/**"
+      - "master"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [master]


### PR DESCRIPTION
See doc: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore