### PR TITLE
Allows proving for incomplete computations

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,52 +114,42 @@ Lurk REPL welcomes you.
 	Expr: (let ((square (lambda (x) (* x x)))) (square 8))
 	Env: nil
 	Cont: Outermost
-
  INFO  lurk::eval > Frame: 1
 	Expr: (lambda (x) (* x x))
 	Env: nil
 	Cont: Let{ var: square, body: (square 8), saved_env: nil, continuation: Outermost }
-
  INFO  lurk::eval > Frame: 2
 	Expr: (square 8)
 	Env: ((square . <FUNCTION (x) (* x x)>))
 	Cont: Tail{ saved_env: nil, continuation: Outermost }
-
  INFO  lurk::eval > Frame: 3
 	Expr: square
 	Env: ((square . <FUNCTION (x) (* x x)>))
 	Cont: Call{ unevaled_arg: 8, saved_env: ((square . <FUNCTION (x) (* x x)>)), continuation: Tail{ saved_env: nil, continuation: Outermost } }
-
  INFO  lurk::eval > Frame: 4
 	Expr: 8
 	Env: ((square . <FUNCTION (x) (* x x)>))
 	Cont: Call2{ function: <FUNCTION (x) (* x x)>, saved_env: ((square . <FUNCTION (x) (* x x)>)), continuation: Tail{ saved_env: nil, continuation: Outermost } }
-
  INFO  lurk::eval > Frame: 5
 	Expr: (* x x)
 	Env: ((x . 8))
 	Cont: Tail{ saved_env: nil, continuation: Outermost }
-
  INFO  lurk::eval > Frame: 6
 	Expr: x
 	Env: ((x . 8))
 	Cont: Binop{ operator: product#, unevaled_args: (x), saved_env: ((x . 8)), continuation: Tail{ saved_env: nil, continuation: Outermost } }
-
  INFO  lurk::eval > Frame: 7
 	Expr: x
 	Env: ((x . 8))
 	Cont: Binop2{ operator: product#, evaled_arg: 8, continuation: Tail{ saved_env: nil, continuation: Outermost } }
-
  INFO  lurk::eval > Frame: 8
 	Expr: Thunk{ value: 64 => cont: Outermost}
 	Env: nil
 	Cont: Dummy
-
  INFO  lurk::eval > Frame: 9
 	Expr: 64
 	Env: nil
 	Cont: Terminal
-
 [9 iterations] => 64
 > 
 ```

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -60,13 +60,13 @@ struct LoadArgs {
     #[clap(long, value_parser)]
     config: Option<PathBuf>,
 
-    /// Maximum number of iterations allowed (defaults to 100_000_000)
-    #[clap(long, value_parser)]
-    limit: Option<usize>,
-
     /// Reduction count used for proofs (defaults to 10)
     #[clap(long, value_parser)]
     rc: Option<usize>,
+
+    /// Iterations allowed (defaults to 100_000_000; rounded up to the next multiple of rc)
+    #[clap(long, value_parser)]
+    limit: Option<usize>,
 
     /// Prover backend (defaults to "Nova")
     #[clap(long, value_parser)]
@@ -92,10 +92,10 @@ struct LoadCli {
     config: Option<PathBuf>,
 
     #[clap(long, value_parser)]
-    limit: Option<usize>,
+    rc: Option<usize>,
 
     #[clap(long, value_parser)]
-    rc: Option<usize>,
+    limit: Option<usize>,
 
     #[clap(long, value_parser)]
     backend: Option<String>,
@@ -111,8 +111,8 @@ impl LoadArgs {
             zstore: self.zstore,
             prove: self.prove,
             config: self.config,
-            limit: self.limit,
             rc: self.rc,
+            limit: self.limit,
             backend: self.backend,
             field: self.field,
         }
@@ -133,13 +133,13 @@ struct ReplArgs {
     #[clap(long, value_parser)]
     config: Option<PathBuf>,
 
-    /// Maximum number of iterations allowed (defaults to 100_000_000)
-    #[clap(long, value_parser)]
-    limit: Option<usize>,
-
     /// Reduction count used for proofs (defaults to 10)
     #[clap(long, value_parser)]
     rc: Option<usize>,
+
+    /// Iterations allowed (defaults to 100_000_000; rounded up to the next multiple of rc)
+    #[clap(long, value_parser)]
+    limit: Option<usize>,
 
     /// Prover backend (defaults to "Nova")
     #[clap(long, value_parser)]
@@ -162,10 +162,10 @@ struct ReplCli {
     config: Option<PathBuf>,
 
     #[clap(long, value_parser)]
-    limit: Option<usize>,
+    rc: Option<usize>,
 
     #[clap(long, value_parser)]
-    rc: Option<usize>,
+    limit: Option<usize>,
 
     #[clap(long, value_parser)]
     backend: Option<String>,
@@ -180,8 +180,8 @@ impl ReplArgs {
             load: self.load,
             zstore: self.zstore,
             config: self.config,
-            limit: self.limit,
             rc: self.rc,
+            limit: self.limit,
             backend: self.backend,
             field: self.field,
         }
@@ -262,18 +262,18 @@ fn get_store<F: LurkField + for<'a> serde::de::Deserialize<'a>>(
 }
 
 macro_rules! new_repl {
-    ( $cli: expr, $limit: expr, $rc: expr, $field: path, $backend: expr ) => {{
+    ( $cli: expr, $rc: expr, $limit: expr, $field: path, $backend: expr ) => {{
         let mut store = get_store(&$cli.zstore).with_context(|| "reading store from file")?;
         let env = store.nil();
-        Repl::<$field>::new(store, env, $limit, $rc, $backend)
+        Repl::<$field>::new(store, env, $rc, $limit, $backend)
     }};
 }
 
 impl ReplCli {
     pub fn run(&self) -> Result<()> {
         macro_rules! repl {
-            ( $limit: expr, $rc: expr, $field: path, $backend: expr ) => {{
-                let mut repl = new_repl!(self, $limit, $rc, $field, $backend);
+            ( $rc: expr, $limit: expr, $field: path, $backend: expr ) => {{
+                let mut repl = new_repl!(self, $rc, $limit, $field, $backend);
                 if let Some(lurk_file) = &self.load {
                     repl.load_file(lurk_file)?;
                 }
@@ -281,8 +281,8 @@ impl ReplCli {
             }};
         }
         let config = get_config(&self.config)?;
-        let limit = get_parsed_usize("limit", &self.limit, &config, DEFAULT_LIMIT)?;
         let rc = get_parsed_usize("rc", &self.rc, &config, DEFAULT_RC)?;
+        let limit = get_parsed_usize("limit", &self.limit, &config, DEFAULT_LIMIT)?;
         let backend = get_parsed(
             "backend",
             &self.backend,
@@ -297,13 +297,12 @@ impl ReplCli {
             parse_field,
             backend.default_field(),
         )?;
-        validate_non_zero("limit", limit)?;
         validate_non_zero("rc", rc)?;
         backend.validate_field(&field)?;
         match field {
-            LanguageField::Pallas => repl!(limit, rc, pallas::Scalar, backend),
-            // LanguageField::Vesta => repl!(limit, rc, vesta::Scalar, backend),
-            // LanguageField::BLS12_381 => repl!(limit, rc, blstrs::Scalar, backend),
+            LanguageField::Pallas => repl!(rc, limit, pallas::Scalar, backend),
+            // LanguageField::Vesta => repl!(rc, limit, vesta::Scalar, backend),
+            // LanguageField::BLS12_381 => repl!(rc, limit, blstrs::Scalar, backend),
             LanguageField::Vesta => todo!(),
             LanguageField::BLS12_381 => todo!(),
             LanguageField::BN256 => todo!(),
@@ -315,8 +314,8 @@ impl ReplCli {
 impl LoadCli {
     pub fn run(&self) -> Result<()> {
         macro_rules! load {
-            ( $limit: expr, $rc: expr, $field: path, $backend: expr ) => {{
-                let mut repl = new_repl!(self, $limit, $rc, $field, $backend);
+            ( $rc: expr, $limit: expr, $field: path, $backend: expr ) => {{
+                let mut repl = new_repl!(self, $rc, $limit, $field, $backend);
                 repl.load_file(&self.lurk_file)?;
                 if self.prove {
                     #[cfg(not(target_arch = "wasm32"))]
@@ -326,8 +325,8 @@ impl LoadCli {
             }};
         }
         let config = get_config(&self.config)?;
-        let limit = get_parsed_usize("limit", &self.limit, &config, DEFAULT_LIMIT)?;
         let rc = get_parsed_usize("rc", &self.rc, &config, DEFAULT_RC)?;
+        let limit = get_parsed_usize("limit", &self.limit, &config, DEFAULT_LIMIT)?;
         let backend = get_parsed(
             "backend",
             &self.backend,
@@ -342,13 +341,12 @@ impl LoadCli {
             parse_field,
             backend.default_field(),
         )?;
-        validate_non_zero("limit", limit)?;
         validate_non_zero("rc", rc)?;
         backend.validate_field(&field)?;
         match field {
-            LanguageField::Pallas => load!(limit, rc, pallas::Scalar, backend),
-            // LanguageField::Vesta => load!(limit, rc, vesta::Scalar, backend),
-            // LanguageField::BLS12_381 => load!(limit, rc, blstrs::Scalar, backend),
+            LanguageField::Pallas => load!(rc, limit, pallas::Scalar, backend),
+            // LanguageField::Vesta => load!(rc, limit, vesta::Scalar, backend),
+            // LanguageField::BLS12_381 => load!(rc, limit, blstrs::Scalar, backend),
             LanguageField::Vesta => todo!(),
             LanguageField::BLS12_381 => todo!(),
             LanguageField::BN256 => todo!(),

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -423,7 +423,7 @@ where
         let mut iterations = 0;
         let mut emitted_vec = vec![];
         for _ in 0..self.limit {
-            if matches!(io.cont.tag, ContTag::Terminal | ContTag::Error) {
+            if Evaluable::<F, Witness<F>, C>::is_complete(&io) {
                 break;
             }
             (io, _) = io.reduce(self.store, self.lang)?;

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -61,6 +61,19 @@ pub struct Frame<T: Copy, W: Copy, C> {
     pub _p: PhantomData<C>,
 }
 
+impl<T: Copy, W: Copy, C> Frame<T, W, C> {
+    #[inline]
+    fn new(input: T, output: T, i: usize, witness: W) -> Self {
+        Self {
+            input,
+            output,
+            i,
+            witness,
+            _p: Default::default(),
+        }
+    }
+}
+
 #[cfg_attr(not(target_arch = "wasm32"), derive(Arbitrary))]
 #[cfg_attr(not(target_arch = "wasm32"), serde_test)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -192,7 +205,7 @@ impl<F: LurkField, C: Coprocessor<F>> Evaluable<F, Witness<F>, C> for IO<F> {
 
     fn log(&self, store: &Store<F>, i: usize) {
         info!(
-            "Frame: {}\n\tExpr: {}\n\tEnv: {}\n\tCont: {}{}\n",
+            "Frame: {}\n\tExpr: {}\n\tEnv: {}\n\tCont: {}{}",
             i,
             self.expr.fmt_to_string(store),
             self.env.fmt_to_string(store),
@@ -317,35 +330,6 @@ impl<'a, F: LurkField, C: Coprocessor<F>> FrameIt<'a, Witness<F>, F, C> {
             lang,
         })
     }
-
-    /// Like `.iter().take(n).last()`, but skips intermediary stages, to optimize
-    /// for evaluation.
-    fn next_n(
-        mut self,
-        n: usize,
-    ) -> Result<
-        (
-            Frame<IO<F>, Witness<F>, C>,
-            Frame<IO<F>, Witness<F>, C>,
-            Vec<Ptr<F>>,
-        ),
-        ReductionError,
-    > {
-        let mut previous_frame = self.frame.clone();
-        let mut emitted: Vec<Ptr<F>> = Vec::new();
-        for _ in 0..n {
-            if self.frame.is_complete() {
-                break;
-            }
-            let new_frame = self.frame.next(self.store, self.lang)?;
-
-            if let Some(expr) = new_frame.output.maybe_emitted_expression(self.store) {
-                emitted.push(expr);
-            }
-            previous_frame = std::mem::replace(&mut self.frame, new_frame);
-        }
-        Ok((self.frame, previous_frame, emitted))
-    }
 }
 
 // Wrapper struct to preserve errors that would otherwise be lost during iteration
@@ -416,6 +400,7 @@ impl<'a, F: LurkField, C: Coprocessor<F>> Evaluator<'a, F, C>
 where
     IO<F>: Copy,
 {
+    #[inline]
     pub fn new(
         expr: Ptr<F>,
         env: Ptr<F>,
@@ -428,30 +413,30 @@ where
             env,
             store,
             limit,
-            terminal_frame: None,
             lang,
         }
     }
 
     pub fn eval(&mut self) -> Result<(IO<F>, usize, Vec<Ptr<F>>), ReductionError> {
-        let initial_input = self.initial();
-        let frame_iterator = FrameIt::new(initial_input, self.store, self.lang)?;
-
-        // Initial input performs one reduction, so we need limit - 1 more.
-        let (ultimate_frame, _penultimate_frame, emitted) =
-            frame_iterator.next_n(self.limit - 1)?;
-        let output = ultimate_frame.output;
-
-        let was_terminal = ultimate_frame.is_complete();
-        let i = ultimate_frame.i;
-        if was_terminal {
-            self.terminal_frame = Some(ultimate_frame);
+        let mut io = self.initial();
+        Evaluable::<F, Witness<F>, C>::log(&io, self.store, 0);
+        let mut iterations = 0;
+        let mut emitted_vec = vec![];
+        for _ in 0..self.limit {
+            if matches!(io.cont.tag, ContTag::Terminal | ContTag::Error) {
+                break;
+            }
+            (io, _) = io.reduce(self.store, self.lang)?;
+            if let Some(emitted) = io.maybe_emitted_expression(self.store) {
+                emitted_vec.push(emitted);
+            }
+            iterations += 1;
+            Evaluable::<F, Witness<F>, C>::log(&io, self.store, iterations);
         }
-        let iterations = if was_terminal { i } else { i + 1 };
-        // NOTE: We compute a terminal frame but don't include it in the iteration count.
-        Ok((output, iterations, emitted))
+        Ok((io, iterations, emitted_vec))
     }
 
+    #[inline]
     pub fn initial(&mut self) -> IO<F> {
         IO {
             expr: self.expr,
@@ -466,12 +451,28 @@ where
         Ok(FrameIt::new(initial_input, self.store, self.lang)?.take(self.limit))
     }
 
-    // Wraps frames in Result type in order to fail gracefully
+    /// Wraps frames in Result type in order to fail gracefully.
+    ///
+    /// Note: the output will have an identity frame at the end if there's still
+    /// room, that is, if `self.limit` hasn't been reached. This is useful for
+    /// proving when padding the last frame is necessary.
     pub fn get_frames(&mut self) -> Result<Vec<Frame<IO<F>, Witness<F>, C>>, ReductionError> {
-        let frame = FrameIt::new(self.initial(), self.store, self.lang)?;
-        let result_frame = ResultFrame(Ok(frame)).take(self.limit);
-        let ret: Result<Vec<_>, _> = result_frame.collect();
-        ret
+        let mut input = self.initial();
+        Evaluable::<F, Witness<F>, C>::log(&input, self.store, 0);
+        let mut frames = vec![];
+        for i in 0..self.limit {
+            let (output, witness) = input.reduce(self.store, self.lang)?;
+            let frame = Frame::new(input, output, i, witness);
+            let is_complete = frame.is_complete();
+            frames.push(frame);
+            if is_complete {
+                break;
+            }
+            // logging after `break` to ignore the identity frame
+            Evaluable::<F, Witness<F>, C>::log(&output, self.store, i + 1);
+            input = output;
+        }
+        Ok(frames)
     }
 
     pub fn generate_frames<Fp: Fn(usize) -> bool>(
@@ -529,6 +530,5 @@ pub struct Evaluator<'a, F: LurkField, C: Coprocessor<F>> {
     env: Ptr<F>,
     store: &'a mut Store<F>,
     limit: usize,
-    terminal_frame: Option<Frame<IO<F>, Witness<F>, C>>,
     lang: &'a Lang<F, C>,
 }


### PR DESCRIPTION
This PR also brings in other improvements:

* Use more basic building blocks for `Evaluator::eval` in order to avoid unnecessary clones. This speeds up evaluation:

```
eval_benchmark/eval_go_base_bls12/_10_16
                        time:   [540.20 µs 541.31 µs 542.61 µs]
                        change: [-13.016% -12.822% -12.564%] (p = 0.00 < 0.05)
                        Performance has improved.
eval_benchmark/eval_go_base_pallas/_10_16
                        time:   [539.73 µs 540.17 µs 540.57 µs]
                        change: [-14.290% -13.874% -13.618%] (p = 0.00 < 0.05)
                        Performance has improved.
eval_benchmark/eval_go_base_bls12/_10_160
                        time:   [5.1792 ms 5.1861 ms 5.1932 ms]
                        change: [-13.298% -13.154% -13.015%] (p = 0.00 < 0.05)
                        Performance has improved.
eval_benchmark/eval_go_base_pallas/_10_160
                        time:   [5.1816 ms 5.1878 ms 5.1949 ms]
                        change: [-13.680% -13.468% -13.298%] (p = 0.00 < 0.05)
                        Performance has improved.
```

* Fix off-by-1 errors when logging because the last frame wasn't being logged when the computation just reached the iteration limit
* Removes a `\n` in the logs to make them more compact vertically

Closes #526 