### PR TITLE
chore: Upgrade clap in fcomm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,14 +488,9 @@ version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
- "atty",
  "bitflags 1.3.2",
- "clap_derive 3.2.25",
  "clap_lex 0.2.4",
  "indexmap",
- "once_cell",
- "strsim",
- "termcolor",
  "textwrap 0.16.0",
 ]
 
@@ -506,17 +501,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b0827b011f6f8ab38590295339817b0d26f344aa4932c3ced71b45b0c54b4a9"
 dependencies = [
  "clap_builder",
- "clap_derive 4.3.12",
+ "clap_derive",
  "once_cell",
 ]
 
 [[package]]
 name = "clap-verbosity-flag"
-version = "1.0.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0636f9c040082f8e161555a305f8cec1a1c2828b3d981c812b8c39f4ac00c42c"
+checksum = "1eef05769009513df2eb1c3b4613e7fad873a14c600ff025b08f250f59fee7de"
 dependencies = [
- "clap 3.2.25",
+ "clap 4.3.17",
  "log",
 ]
 
@@ -530,19 +525,6 @@ dependencies = [
  "anstyle",
  "clap_lex 0.5.0",
  "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
-dependencies = [
- "heck 0.4.1",
- "proc-macro-error",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -990,7 +972,7 @@ dependencies = [
  "bincode",
  "blstrs",
  "camino",
- "clap 3.2.25",
+ "clap 4.3.17",
  "clap-verbosity-flag",
  "ff",
  "hex",

--- a/fcomm/Cargo.toml
+++ b/fcomm/Cargo.toml
@@ -17,8 +17,8 @@ base64 = { workspace = true }
 bellperson = { workspace = true }
 bincode = { workspace = true }
 blstrs = { workspace = true }
-clap = { version = "3.2", features = ["derive"] }
-clap-verbosity-flag = "1.0"
+clap = { workspace = true, features = ["derive"] }
+clap-verbosity-flag = "2.0"
 ff = { workspace = true }
 hex = { version = "0.4.3", features = ["serde"] }
 log = { workspace = true }

--- a/fcomm/src/bin/fcomm.rs
+++ b/fcomm/src/bin/fcomm.rs
@@ -21,7 +21,7 @@ use lurk::ptr::{Ptr, TypePredicates};
 use lurk::public_parameters::error;
 use lurk::store::Store;
 
-use clap::{AppSettings, Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use clap_verbosity_flag::{Verbosity, WarnLevel};
 
 use fcomm::{
@@ -34,7 +34,6 @@ use lurk::public_parameters::{public_params, FileStore};
 /// Functional commitments
 #[derive(Parser, Debug)]
 #[clap(version, about, long_about = None)]
-#[clap(global_setting(AppSettings::DeriveDisplayOrder))]
 struct Cli {
     /// Evaluate inputs before passing to function (outside the proof) when opening. Otherwise inputs are unevaluated.
     #[clap(long, value_parser)]

--- a/fcomm/tests/proof_tests.rs
+++ b/fcomm/tests/proof_tests.rs
@@ -24,9 +24,9 @@ fn test_bad_command() {
     let mut cmd = fcomm_cmd();
 
     cmd.arg("uiop");
-    cmd.assert().failure().stderr(predicate::str::contains(
-        "error: Found argument 'uiop' which wasn't expected, or isn't valid in this context",
-    ));
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("unrecognized subcommand \'uiop\'"));
 }
 
 #[test]


### PR DESCRIPTION
- Removed `AppSettings` and `AppSettings::DeriveDisplayOrder` from `fcomm.rs`, cleaning up unused imports.
  See https://github.com/clap-rs/clap/blob/a3d93f485f0178f13fabedc55664071778d3f1d9/CHANGELOG.md?plain=1#L731
- Upgraded 'clap' package in `Cargo.toml` to align with the workspace version.
- Updated 'clap-verbosity-flag' package from '1.0' to '2.0',