### PR TITLE
Fix feature configurations in Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,7 @@ dependencies = [
  "ec-gpu",
  "ec-gpu-gen",
  "ff",
+ "fs2",
  "group",
  "log",
  "memmap2",
@@ -1111,6 +1112,16 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "funty"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,10 +72,22 @@ rustyline = { version = "11.0", features = ["derive"], default-features = false 
 
 [features]
 default = []
-opencl = ["neptune/opencl"]
-cuda = ["neptune/cuda"]
+opencl = [
+	"neptune/opencl",
+	"bellperson/opencl",
+	"nova/opencl"
+]
+cuda = [
+	"neptune/cuda",
+	"bellperson/cuda",
+	"nova/cuda"
+]
 # compile without ISA extensions
-portable = ["blstrs/portable", "pasta-msm/portable"]
+portable = [
+	"blstrs/portable",
+	"pasta-msm/portable",
+	"nova/portable"
+]
 flamegraph = ["pprof/flamegraph", "pprof/criterion"]
 
 [dev-dependencies]


### PR DESCRIPTION
- Propagate 'portable', 'cuda' and 'opencl' features in 'bellperson' and 'nova'.