### PR TITLE
LEM match optimization

### DIFF
--- a/src/circuit/gadgets/constraints.rs
+++ b/src/circuit/gadgets/constraints.rs
@@ -692,6 +692,7 @@ pub(crate) fn and_v<CS: ConstraintSystem<F>, F: PrimeField>(
 
 /// This is a replication of Bellperson's original `and`, but receives a mutable
 /// reference for the constraint system instead of a copy
+#[allow(dead_code)]
 pub(crate) fn and<CS: ConstraintSystem<F>, F: PrimeField>(
     cs: &mut CS,
     a: &Boolean,

--- a/src/circuit/gadgets/constraints.rs
+++ b/src/circuit/gadgets/constraints.rs
@@ -796,6 +796,16 @@ pub(crate) fn implies_equal<CS: ConstraintSystem<F>, F: PrimeField>(
     })
 }
 
+/// Enforce equality of an allocated number and a constant given an implication premise
+pub(crate) fn implies_equal_const<CS: ConstraintSystem<F>, F: PrimeField>(
+    cs: &mut CS,
+    premise: &Boolean,
+    a: &AllocatedNum<F>,
+    b: F,
+) -> Result<(), SynthesisError> {
+    enforce_implication_lc_zero(cs, premise, |lc| lc + a.get_variable() - (b, CS::one()))
+}
+
 /// Enforce equality of two allocated numbers given an implication premise
 #[allow(dead_code)]
 pub(crate) fn implies_equal_zero<CS: ConstraintSystem<F>, F: PrimeField>(

--- a/src/circuit/gadgets/constraints.rs
+++ b/src/circuit/gadgets/constraints.rs
@@ -846,6 +846,45 @@ pub(crate) fn implies_unequal<CS: ConstraintSystem<F>, F: PrimeField>(
     Ok(())
 }
 
+/// Enforce inequality of two allocated numbers given an implication premise
+pub(crate) fn implies_unequal_const<CS: ConstraintSystem<F>, F: PrimeField>(
+    cs: &mut CS,
+    premise: &Boolean,
+    a: &AllocatedNum<F>,
+    b: F,
+) -> Result<(), SynthesisError> {
+    // We know that `a != b` iff `a-b` has an inverse, i.e. that there exists
+    // `c` such that `c * (a-b) = 1`. Thus, we can add the constraint that there
+    // must exist `c` such that `c * (a-b) = premise`, enforcing the difference
+    // only when `premise = 1`; otherwise the constraint is trivially satisfied
+    // for `c = 0`
+    let q = cs.alloc(
+        || "q",
+        || {
+            let premise = premise
+                .get_value()
+                .ok_or(SynthesisError::AssignmentMissing)?;
+            if premise {
+                let a = a.get_value().ok_or(SynthesisError::AssignmentMissing)?;
+                let inv = (a - b).invert();
+                if inv.is_some().into() {
+                    Ok(inv.unwrap())
+                } else {
+                    Ok(F::ZERO)
+                }
+            } else {
+                Ok(F::ZERO)
+            }
+        },
+    )?;
+    let maybe_inverse = |lc| lc + q;
+    let implication_lc = |lc| lc + a.get_variable() - (b, CS::one());
+    let premise = |_| premise.lc(CS::one(), F::ONE);
+
+    cs.enforce(|| "implication", maybe_inverse, implication_lc, premise);
+    Ok(())
+}
+
 /// Enforce equality of two allocated numbers given an implication premise
 #[allow(dead_code)]
 pub(crate) fn implies_equal_zero<CS: ConstraintSystem<F>, F: PrimeField>(

--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -971,8 +971,8 @@ mod tests {
     use blstrs::Scalar as Fr;
 
     const NUM_INPUTS: usize = 1;
-    const NUM_AUX: usize = 9743;
-    const NUM_CONSTRAINTS: usize = 12036;
+    const NUM_AUX: usize = 10023;
+    const NUM_CONSTRAINTS: usize = 12316;
     const NUM_SLOTS: SlotsCounter = SlotsCounter {
         hash2: 16,
         hash3: 4,

--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -971,8 +971,8 @@ mod tests {
     use blstrs::Scalar as Fr;
 
     const NUM_INPUTS: usize = 1;
-    const NUM_AUX: usize = 10023;
-    const NUM_CONSTRAINTS: usize = 12316;
+    const NUM_AUX: usize = 9885;
+    const NUM_CONSTRAINTS: usize = 12178;
     const NUM_SLOTS: SlotsCounter = SlotsCounter {
         hash2: 16,
         hash3: 4,

--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -971,8 +971,8 @@ mod tests {
     use blstrs::Scalar as Fr;
 
     const NUM_INPUTS: usize = 1;
-    const NUM_AUX: usize = 9807;
-    const NUM_CONSTRAINTS: usize = 12068;
+    const NUM_AUX: usize = 9711;
+    const NUM_CONSTRAINTS: usize = 12004;
     const NUM_SLOTS: SlotsCounter = SlotsCounter {
         hash2: 16,
         hash3: 4,

--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -971,8 +971,8 @@ mod tests {
     use blstrs::Scalar as Fr;
 
     const NUM_INPUTS: usize = 1;
-    const NUM_AUX: usize = 10442;
-    const NUM_CONSTRAINTS: usize = 12703;
+    const NUM_AUX: usize = 9807;
+    const NUM_CONSTRAINTS: usize = 12068;
     const NUM_SLOTS: SlotsCounter = SlotsCounter {
         hash2: 16,
         hash3: 4,

--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -971,8 +971,8 @@ mod tests {
     use blstrs::Scalar as Fr;
 
     const NUM_INPUTS: usize = 1;
-    const NUM_AUX: usize = 9711;
-    const NUM_CONSTRAINTS: usize = 12004;
+    const NUM_AUX: usize = 9743;
+    const NUM_CONSTRAINTS: usize = 12036;
     const NUM_SLOTS: SlotsCounter = SlotsCounter {
         hash2: 16,
         hash3: 4,


### PR DESCRIPTION
This PR optimizes the match expressions in LEM. Here's a table comparing the costs of the current match vs the optimized one:
```org
|                    | CURRENT | OPTIMIZED |
|--------------------+---------+-----------|
| NO DEFAULT         | 3x + 1  | 2x + 1    |
| DEFAULT            | 3x + 2  | 3x + 2    |
| NO DEFAULT, NESTED | 4x + 1  | 2x + 1    |
| DEFAULT, NESTED    | 4x + 3  | 3x + 2    |
```
where `x` is the number of cases; nested matches are the most common matches.

Suppose we have a match like
```rust
match xs.tag {
    Expr::Nil => {
        foo
    }
    Expr::Cons => {
        bar
    }
    Expr::Str => {
        baz
    }
}
```
Then, this is how we translate to circuits: for each case, we allocate a boolean `b`, then add an `implies_equal` (which costs 1) from `b` to `x.tag == tag` (`x` the variable that is matched, and `tag` the respective tag of the branch). This means that we can choose the values of each `b`, *as long as the variable's tag is equal to the tag of the branch*. To account for `not_dummy`, instead of doing `and` statements to each `b`, we simply add all the booleans to a list, including `not_dummy.not()`, and require that the popcount be 1. This means that either `not_dummy` must be false, or only one of the branches must be selected. This means that, as long as the match does not have a default case, it costs `2*x + 1` (one constraint per case for the boolean, one constraint per case for the implies_equal and 1 constraint for the popcount).

Now, a match with a default case, like
```rust
match xs.tag {
    Expr::Nil => {
        foo
    }
    Expr::Cons => {
        bar
    };
    baz
}
```
has an issue, in that the default case can always be chosen. So we must require that, if the default was chosen, then all of the other cases were impossible. I.e., if `b_def` is the boolean for the default case, then we must add `implies_unequal` from `b_def` to `x.tag != tag` for each possible tag. I.e., the default case costs 1 more, for the boolean, and `x` more for the `implies_unequal`s, or `3x + 2` total