### PR TITLE
ci: Checkout submodule in `linux_ignored` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
       RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - uses: actions-rs/toolchain@v1
       - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci_ignored.yml
+++ b/.github/workflows/ci_ignored.yml
@@ -15,6 +15,8 @@ jobs:
       RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - uses: actions-rs/toolchain@v1
       - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lurk-lib"]
 	path = lurk-lib
-	url = git@github.com:lurk-lab/lurk-lib.git
+	url = https://github.com/lurk-lab/lurk-lib.git


### PR DESCRIPTION
Fixes submodule error in https://github.com/lurk-lab/lurk-rs/actions/runs/5856346363/job/15875862609

Also changes the `lurk-lib` git module URL to HTTPS, which is not required by the [checkout action](https://github.com/actions/checkout#usage) but simplifies such checkouts in contexts without an SSH key.