### PR TITLE
ci: Decrease nextest timeout and add retry

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,5 +6,7 @@ failure-output = "immediate-final"
 status-level = "skip"
 # Do not cancel the test run on the first failure.
 fail-fast = false
-# Mark tests as slow after 5mins, kill them after 50
-slow-timeout = { period = "300s", terminate-after = 10 }
+# Mark tests as slow after 5mins, kill them after 20mins
+slow-timeout = { period = "300s", terminate-after = 4 }
+# Retry failed tests once, marked flaky if test then passes
+retries = 1


### PR DESCRIPTION
Attempts to fix the sporadic timeout error observed in:
- https://github.com/lurk-lab/lurk-rs/actions/runs/5869723458/job/15915316564
- https://github.com/lurk-lab/lurk-rs/actions/runs/5828440849/job/15806166563

Purely speculative diagnosis: this timeout error could be a hardware resource issue on the self-hosted runners or (much less likely) a bug in Nextest.