### PR TITLE
refactor: Replace `dbg!` macro with `log::debug` across modules

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -6,6 +6,7 @@
 xclippy = [
     "clippy", "--workspace", "--all-targets", "--",
     "-Wclippy::all",
+    "-Wclippy::dbg_macro",
     "-Wclippy::match_same_arms",
     "-Wclippy::cast_lossless",
     "-Wclippy::disallowed_methods",

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -4940,7 +4940,11 @@ fn car_cdr_named<F: LurkField, CS: ConstraintSystem<F>>(
     )?;
 
     if cons_not_dummy.get_value().unwrap_or(false) && !real_cons.get_value().unwrap_or(true) {
-        dbg!(maybe_cons.hash().get_value(), &allocated_digest.get_value());
+        log::debug!(
+            "{:?} {:?}",
+            maybe_cons.hash().get_value(),
+            &allocated_digest.get_value()
+        );
         panic!(
             "tried to take car_cdr of a non-dummy cons ({:?}) but supplied wrong value",
             name

--- a/src/circuit/gadgets/hashes.rs
+++ b/src/circuit/gadgets/hashes.rs
@@ -312,7 +312,7 @@ impl<'a, F: LurkField> AllocatedContWitness<'a, F> {
         if !expect_dummy {
             match allocated_name {
                 Err(_) => {
-                    dbg!(&self.witness);
+                    log::debug!("{:?}", &self.witness);
                     panic!("requested {:?} but found a dummy allocation", name)
                 }
                 Ok(alloc_name) => {

--- a/src/circuit/gadgets/pointer.rs
+++ b/src/circuit/gadgets/pointer.rs
@@ -346,7 +346,7 @@ impl<F: LurkField> AllocatedPtr<F> {
         implies!(cs, not_dummy, &cons_is_real);
 
         if not_dummy.get_value().unwrap_or(false) && !cons_is_real.get_value().unwrap_or(true) {
-            dbg!(name);
+            log::debug!("{:?}", name);
             panic!("uh oh!");
         }
 

--- a/src/eval/reduction.rs
+++ b/src/eval/reduction.rs
@@ -566,7 +566,7 @@ fn reduce_with_witness_inner<F: LurkField, C: Coprocessor<F>>(
 
                         // `fun_form` must be a function or potentially evaluate to one.
                         if !fun_form.is_potentially(ExprTag::Fun) {
-                            dbg!("not potentially fun");
+                            log::debug!("{}", "not potentially fun");
                             Control::Error(expr, env)
                         } else if args.is_nil() {
                             Control::Return(

--- a/src/eval/tests/mod.rs
+++ b/src/eval/tests/mod.rs
@@ -2515,29 +2515,29 @@ fn op_syntax_error<T: Op + Copy>() {
 
         {
             let expr = format!("({name} . 1)");
-            dbg!(&expr);
+            log::debug!("{:?}", &expr);
             test_aux::<Coproc<Fr>>(s, &expr, None, None, Some(error), None, 1, None);
         }
 
         if !op.supports_arity(0) {
             let expr = format!("({name})");
-            dbg!(&expr);
+            log::debug!("{:?}", &expr);
             test_aux::<Coproc<Fr>>(s, &expr, None, None, Some(error), None, 1, None);
         }
         if !op.supports_arity(1) {
             let expr = format!("({name} 123)");
-            dbg!(&expr);
+            log::debug!("{:?}", &expr);
             test_aux::<Coproc<Fr>>(s, &expr, None, None, Some(error), None, 1, None);
         }
         if !op.supports_arity(2) {
             let expr = format!("({name} 123 456)");
-            dbg!(&expr);
+            log::debug!("{:?}", &expr);
             test_aux::<Coproc<Fr>>(s, &expr, None, None, Some(error), None, 1, None);
         }
 
         if !op.supports_arity(3) {
             let expr = format!("({name} 123 456 789)");
-            dbg!(&expr);
+            log::debug!("{:?}", &expr);
             let iterations = if op.supports_arity(2) { 2 } else { 1 };
             test_aux::<Coproc<Fr>>(s, &expr, None, None, Some(error), None, iterations, None);
         }

--- a/src/hash_witness.rs
+++ b/src/hash_witness.rs
@@ -257,7 +257,7 @@ impl<F: LurkField> HashWitness<ConsName, Cons<F>, MAX_CONSES_PER_REDUCTION, F> {
                     if !store.ptr_eq(&hash.cons, &nil).unwrap() {
                         use crate::writer::Write;
                         let cons = hash.cons.fmt_to_string(store, state);
-                        dbg!(hash.cons, cons, name, existing_name);
+                        log::debug!("{:?} {:?} {:?} {:?}", hash.cons, cons, name, existing_name);
                         panic!("duplicate");
                     }
                 }

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -40,18 +40,18 @@ pub fn verify_sequential_css<F: LurkField + Copy, C: Coprocessor<F>>(
     for (i, (multiframe, cs)) in css.iter().enumerate() {
         if let Some(prev) = previous_frame {
             if !prev.precedes(multiframe) {
-                dbg!(i, "not preceeding frame");
+                log::debug!("{} {}", i, "not preceeding frame");
                 return Ok(false);
             }
         }
         if !cs.is_satisfied() {
-            dbg!(i, "cs not satisfied");
+            log::debug!("{} {}", i, "cs not satisfied");
             return Ok(false);
         }
 
         let public_inputs = multiframe.public_inputs();
         if !cs.verify(&public_inputs) {
-            dbg!(i, "cs not verified");
+            log::debug!("{} {}", i, "cs not verified");
             return Ok(false);
         }
         previous_frame = Some(multiframe);

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -539,7 +539,7 @@ pub mod tests {
 
             let res = proof.verify(&pp, num_steps, &z0, &zi);
             if res.is_err() {
-                dbg!(&res);
+                log::debug!("{:?}", &res);
             }
             assert!(res.unwrap());
 
@@ -578,7 +578,7 @@ pub mod tests {
             if unsat.is_some() {
                 // For some reason, this isn't getting printed from within the implementation as expected.
                 // Since we always want to know this information, if the condition occurs, just print it here.
-                dbg!(unsat);
+                log::debug!("{:?}", unsat);
             }
             assert!(cs.is_satisfied());
             assert!(cs.verify(&multiframe.public_inputs()));
@@ -1169,23 +1169,23 @@ pub mod tests {
 
             if !op.supports_arity(0) {
                 let expr = format!("({name})");
-                dbg!(&expr);
+                log::debug!("{:?}", &expr);
                 test_aux::<Coproc<Fr>>(s, &expr, None, None, Some(error), None, 1, None);
             }
             if !op.supports_arity(1) {
                 let expr = format!("({name} 123)");
-                dbg!(&expr);
+                log::debug!("{:?}", &expr);
                 test_aux::<Coproc<Fr>>(s, &expr, None, None, Some(error), None, 1, None);
             }
             if !op.supports_arity(2) {
                 let expr = format!("({name} 123 456)");
-                dbg!(&expr);
+                log::debug!("{:?}", &expr);
                 test_aux::<Coproc<Fr>>(s, &expr, None, None, Some(error), None, 1, None);
             }
 
             if !op.supports_arity(3) {
                 let expr = format!("({name} 123 456 789)");
-                dbg!(&expr);
+                log::debug!("{:?}", &expr);
                 let iterations = if op.supports_arity(2) { 2 } else { 1 };
                 test_aux::<Coproc<Fr>>(s, &expr, None, None, Some(error), None, iterations, None);
             }

--- a/src/store.rs
+++ b/src/store.rs
@@ -2273,7 +2273,7 @@ pub mod test {
         let sym1 = store.car(&expr).unwrap();
         let sss = store.fetch_sym(&sym);
         let hash = store.hash_expr(&sym);
-        dbg!(&sym1, &sss, &hash);
+        log::debug!("{:?} {:?} {:?}", &sym1, &sss, &hash);
 
         assert_eq!(sym, sym1);
     }


### PR DESCRIPTION
- Replaced usage of `dbg!` debugging macros with `log::debug` across various files,
- Included `dbg_macro` to the list of project-wide clippy lints for code quality assurance.

Helps #614 