### PR TITLE
Fix printing for keywords

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 setup-env: &setup-env
-  MSRV: 1.60.0
+  MSRV: 1.70.0
   RUSTFLAGS: "-Dwarnings"
   CARGO_INCREMENTAL: 0
   RUST_BACKTRACE: 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "Turing-Complete Zero Knowledge"
 edition = "2021"
 repository = "https://github.com/lurk-lab/lurk-rs"
-rust-version = "1.68.2"
+rust-version = "1.70.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Lurk
 
 [![CircleCI](https://circleci.com/gh/lurk-lab/lurk-rs.svg?style=shield)](https://circleci.com/gh/lurk-lab/lurk-rs)
-![minimum rustc 1.60][msrv-image]
+![minimum rustc 1.70][msrv-image]
 ![crates.io][crates-image]
 
-[msrv-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.70+-blue.svg
 [crates-image]: https://img.shields.io/crates/v/lurk.svg
 
 # Status (Alpha)

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -103,6 +103,11 @@ impl Symbol {
         Self::new_from_vec(path, true)
     }
 
+    #[inline]
+    pub fn set_as_keyword(&mut self) {
+        self.keyword = true;
+    }
+
     /// Creates a new Symbol with the path extended by the given vector of path segments.
     pub fn extend<A: AsRef<str>>(&self, child: &[A]) -> Self {
         let mut path = Vec::with_capacity(self.path.len() + child.len());

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -75,7 +75,8 @@ impl<F: LurkField> Write<F> for Expression<F> {
             }
             Key(car, cdr) => {
                 let head = store.fetch_string(car).expect("missing keyword head");
-                let tail = store.fetch_key(cdr).expect("missing keyword tail");
+                let mut tail = store.fetch_sym(cdr).expect("missing keyword tail");
+                tail.set_as_keyword();
                 write_symbol(w, tail.extend(&[head]), state)
             }
             EmptyStr => write!(w, "\"\""),
@@ -377,5 +378,13 @@ pub mod test {
         let num = store.num(5);
         let res = num.fmt_to_string(&store, initial_lurk_state());
         assert_eq!(&res, &"5");
+    }
+
+    #[test]
+    fn test_print_keyword() {
+        let mut store = Store::<Fr>::default();
+        let foo_key_ptr = store.intern_symbol(&Symbol::key_from_vec(vec!["foo".into()]));
+        let foo_key_str = foo_key_ptr.fmt_to_string(&store, initial_lurk_state());
+        assert_eq!(":foo", foo_key_str);
     }
 }


### PR DESCRIPTION
I don't know for how long, but printing keywords has been broken on `master`. Maybe this bug was introduced in the PR that added support for packages.

This PR fixes that issue.