### PR TITLE
fix hashing of symbols

### DIFF
--- a/src/eval/tests/mod.rs
+++ b/src/eval/tests/mod.rs
@@ -1597,7 +1597,7 @@ fn commitment_value() {
 fn commit_nil() {
     let s = &mut Store::<Fr>::default();
     let x = s
-        .read("0x239b15d97a9a69b3db1c9130601ec2a1f8ac2ed6033633e4fb5232d85c622250")
+        .read("0x1f7f3e554ed27c104d79bb69346996d61a735d5bbedc2da7da2935036d9c4fad")
         .unwrap();
 
     let expr = "(num (commit nil))";

--- a/src/store.rs
+++ b/src/store.rs
@@ -2245,6 +2245,31 @@ pub mod test {
     }
 
     #[test]
+    fn symbol_hashing() {
+        let s = &mut Store::<Fr>::default();
+        let foo_ptr = s.intern_string("foo");
+        let bar_ptr = s.intern_string("bar");
+        let foo_bar_ptr = s.intern_symbol(&Symbol::sym_from_vec(vec!["foo".into(), "bar".into()]));
+
+        let foo_z_ptr = s.hash_expr(&foo_ptr).unwrap();
+        let bar_z_ptr = s.hash_expr(&bar_ptr).unwrap();
+        let foo_bar_hash = s.hash_expr(&foo_bar_ptr).unwrap().1;
+
+        let foo_bar_hash_manual = s.poseidon_cache.hash4(&[
+            bar_z_ptr.0.to_field(),
+            bar_z_ptr.1,
+            ExprTag::Sym.to_field(),
+            s.poseidon_cache.hash4(&[
+                foo_z_ptr.0.to_field(),
+                foo_z_ptr.1,
+                ExprTag::Sym.to_field(),
+                Fr::ZERO,
+            ]),
+        ]);
+        assert_eq!(foo_bar_hash, foo_bar_hash_manual);
+    }
+
+    #[test]
     fn sym_and_key_hashes() {
         let s = &mut Store::<Fr>::default();
 

--- a/src/z_data/z_store.rs
+++ b/src/z_data/z_store.rs
@@ -168,7 +168,7 @@ impl<F: LurkField> ZStore<F> {
     ) -> (ZExprPtr<F>, ZExpr<F>) {
         let mut expr = ZExpr::RootSym;
         let mut ptr = expr.z_ptr(poseidon_cache);
-        for s in sym.path().iter().rev() {
+        for s in sym.path() {
             let (str_ptr, _) = self.put_string(s, poseidon_cache);
             expr = ZExpr::Sym(str_ptr, ptr);
             ptr = expr.z_ptr(poseidon_cache);

--- a/tests/lurk-cli-tests.rs
+++ b/tests/lurk-cli-tests.rs
@@ -91,7 +91,7 @@ fn test_prove_and_verify() {
 
     let mut file = File::create(lurk_file.clone()).unwrap();
     file.write_all(b"!(prove (+ 1 1))\n").unwrap();
-    file.write_all(b"!(verify \"Nova_Pallas_10_0d723f6dd68729d7d119a13386f81d04daf6e1715f9ad53fb1ea54646771108a\")\n").unwrap();
+    file.write_all(b"!(verify \"Nova_Pallas_10_3f2526abf20fc9006dd93c0d3ff49954ef070ef52d2e88426974de42cc27bdb2\")\n").unwrap();
 
     let mut cmd = lurk_cmd();
     cmd.arg("load");


### PR DESCRIPTION
This is yet another fix found during the implementation of #629.

Hashing a symbol should not do `.rev()` on the path. We should do it from left to right because that's how the `Store` interns symbols.

The reasoning is: symbols in the same package differ on hashing just by the tip of the path (the symbol name).

Note: LEM infra already gets this right as a consequence of how its `Store` does the interning, so no change is needed there.