### PR TITLE
Use reduction_count=2 in sha256 example.

### DIFF
--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -28,7 +28,7 @@ use sha2::{Digest, Sha256};
 use tracing_subscriber::{fmt, prelude::*, EnvFilter, Registry};
 use tracing_texray::TeXRayLayer;
 
-const REDUCTION_COUNT: usize = 10;
+const REDUCTION_COUNT: usize = 2;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct Sha256Coprocessor<F: LurkField> {


### PR DESCRIPTION
For some reason, the `sha256` example benchmark was set to use `reduction_count = 100`, changing this `reduction_count=2` speeds up the proving about 12x.

Although this is not a great benchmark, and is quite noisy, I still think we should prioritize gradually removing the impediments to expected performance. From that perspective, I note that we *should* be able to handle `reduction_count=1` with a single iteration, but something still seems to prevent that.

My greater concern is: what aspect of process led to the inflated `rc=100` being introduced (and left unnoticed) here?

Before (`rc = 100`):
```
➜  lurk-rs git:(master) cargo run --example sha256 1 f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b false
   Compiling lurk v0.2.0 (/Users/clwk/fil/lurk-rs)
    Finished dev [unoptimized + debuginfo] target(s) in 6.52s
     Running `target/debug/examples/sha256 1 f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b false`
Setting up public parameters (rc = 100)...

Using disk-cached public params for lang lurk-user-sha256-64-zero-bytes
Public parameters took 46.200555958s
Beginning proof step...
[src/proof/nova.rs:450] circuits.len() = 1
Proofs took 13.514285166s
Verifying proof...
Verify took 14.55727525s
Congratulations! You proved and verified a SHA256 hash calculation in 74.272116374s time!
```
  After (`rc=2`):

```
➜  lurk-rs git:(master) cargo run --example sha256 1 f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b false
    Blocking waiting for file lock on build directory
   Compiling lurk v0.2.0 (/Users/clwk/fil/lurk-rs)
    Finished dev [unoptimized + debuginfo] target(s) in 2.85s
     Running `target/debug/examples/sha256 1 f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b false`
Setting up public parameters (rc = 2)...
Using disk-cached public params for lang lurk-user-sha256-64-zero-bytes
Public parameters took 1.254868625s
Beginning proof step...
[src/proof/nova.rs:450] circuits.len() = 1
Proofs took 1.152806625s
Verifying proof...
Verify took 373.872625ms
Congratulations! You proved and verified a SHA256 hash calculation in 2.781547875s time!
```