### PR TITLE
IVC Coprocessor Benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,6 +175,10 @@ name = "synthesis"
 harness = false
 
 [[bench]]
+name = "sha256_ivc"
+harness = false
+
+[[bench]]
 name = "public_params"
 harness = false
 

--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -86,12 +86,16 @@ fn fibo_prove<M: measurement::Measurement>(
     c.bench_with_input(
         BenchmarkId::new(prove_params.name(), fib_n),
         &prove_params,
-        |b, _prove_params| {
+        |b, prove_params| {
             let mut store = Store::default();
 
             let env = empty_sym_env(&store);
-            let ptr = fib::<pasta_curves::Fq>(&mut store, state.clone(), black_box(fib_n as u64));
-            let prover = NovaProver::new(reduction_count, lang_pallas.clone());
+            let ptr = fib::<pasta_curves::Fq>(
+                &mut store,
+                state.clone(),
+                black_box(prove_params.fib_n as u64),
+            );
+            let prover = NovaProver::new(prove_params.reduction_count, lang_pallas.clone());
 
             let frames = &prover
                 .get_evaluation_frames(ptr, env, &mut store, limit, &lang_pallas)

--- a/benches/sha256_ivc.rs
+++ b/benches/sha256_ivc.rs
@@ -17,10 +17,7 @@ use pasta_curves::pallas::Scalar as Fr;
 use lurk::{
     circuit::gadgets::pointer::AllocatedPtr,
     coprocessor::{CoCircuit, Coprocessor},
-    eval::{
-        empty_sym_env,
-        lang::Lang,
-    },
+    eval::{empty_sym_env, lang::Lang},
     field::LurkField,
     proof::nova::NovaProver,
     proof::Prover,

--- a/benches/sha256_ivc.rs
+++ b/benches/sha256_ivc.rs
@@ -27,8 +27,8 @@ use sha2::{Digest, Sha256};
 
 const REDUCTION_COUNT: usize = 10;
 
-fn sha256_expr<F: LurkField>(store: &mut Store<F>) -> Ptr<F> {
-    let program = r#"
+fn sha256_expr<F: LurkField>(store: &mut Store<F>, x: Vec<F>) -> Ptr<F> {
+    let program = format!(r#"
 (letrec ((encode-1 (lambda (term) 
             (let ((type (car term))
                   (value (cdr term)))
@@ -43,10 +43,10 @@ fn sha256_expr<F: LurkField>(store: &mut Store<F>) -> Ptr<F> {
                     (cons 
                         (encode-1 (car input))
                         (encode (cdr input)))))))
-  (encode '((sha256 . 20) (lurk . 5) (id . 15))))
-"#;
+  (encode '((sha256 {x:?}) (lurk . 5) (id . 15))))
+"#);
 
-    store.read(program).unwrap()
+    store.read(&program).unwrap()
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -151,7 +151,7 @@ enum Sha256Coproc<F: LurkField> {
 }
 
 /// Run the example in this file with
-/// `cargo run --release --example sha256x`
+/// `cargo run --release --example sha256_ivc`
 fn main() {
     pretty_env_logger::init();
 

--- a/benches/sha256_ivc.rs
+++ b/benches/sha256_ivc.rs
@@ -252,8 +252,8 @@ fn sha256_ivc_prove<M: measurement::Measurement>(
 
 fn prove_benchmarks(c: &mut Criterion) {
     tracing::debug!("{:?}", &*lurk::config::CONFIG);
-    let reduction_counts = vec![100, 600, 700, 800, 900];
-    let batch_sizes = vec![1, 2, 5];
+    let reduction_counts = vec![10, 100];
+    let batch_sizes = vec![1, 2, 5, 10, 20];
     let mut group: BenchmarkGroup<'_, _> = c.benchmark_group("prove");
     group.sampling_mode(SamplingMode::Flat); // This can take a *while*
     group.sample_size(10);
@@ -331,8 +331,8 @@ fn sha256_ivc_prove_compressed<M: measurement::Measurement>(
 
 fn prove_compressed_benchmarks(c: &mut Criterion) {
     tracing::debug!("{:?}", &*lurk::config::CONFIG);
-    let reduction_counts = vec![100, 600, 700, 800, 900];
-    let batch_sizes = vec![1, 2, 5];
+    let reduction_counts = vec![10, 100];
+    let batch_sizes = vec![1, 2, 5, 10, 20];
     let mut group: BenchmarkGroup<'_, _> = c.benchmark_group("prove_compressed");
     group.sampling_mode(SamplingMode::Flat); // This can take a *while*
     group.sample_size(10);

--- a/benches/sha256_ivc.rs
+++ b/benches/sha256_ivc.rs
@@ -1,10 +1,10 @@
 //! This benchmark measures the IVC performance of coprocessors, by adding a `sha256`
 //! circuit alongside the lurk primary circuit. When supernova is integrated as a backend,
 //! then NIVC performance can also be tested. This benchmark serves as a baseline for that
-//! performance. 
-//! 
+//! performance.
+//!
 //! Note: The example [example/sha256_ivc.rs] is this same benchmark but as an example
-//! that's easier to play with and run. 
+//! that's easier to play with and run.
 
 use lurk::circuit::gadgets::data::GlobalAllocations;
 use lurk::state::user_sym;
@@ -208,7 +208,11 @@ fn sha256_ivc_prove<M: measurement::Measurement>(
     c: &mut BenchmarkGroup<'_, M>,
     state: Rc<RefCell<State>>,
 ) {
-    let ProveParams { arity, n: _, reduction_count } = prove_params;
+    let ProveParams {
+        arity,
+        n: _,
+        reduction_count,
+    } = prove_params;
 
     let limit = 10000;
 
@@ -287,7 +291,11 @@ fn sha256_ivc_prove_compressed<M: measurement::Measurement>(
     c: &mut BenchmarkGroup<'_, M>,
     state: Rc<RefCell<State>>,
 ) {
-    let ProveParams { arity, n: _, reduction_count } = prove_params;
+    let ProveParams {
+        arity,
+        n: _,
+        reduction_count,
+    } = prove_params;
 
     let limit = 10000;
 

--- a/benches/sha256_ivc.rs
+++ b/benches/sha256_ivc.rs
@@ -19,7 +19,7 @@ use lurk::{
     coprocessor::{CoCircuit, Coprocessor},
     eval::{
         empty_sym_env,
-        lang::{Coproc, Lang},
+        lang::Lang,
     },
     field::LurkField,
     proof::nova::NovaProver,
@@ -139,7 +139,7 @@ impl<F: LurkField> Coprocessor<F> for Sha256Coprocessor<F> {
         let mut input = vec![0u8; 64 * self.n];
 
         for (i, input_ptr) in args.iter().enumerate() {
-            let input_zptr = s.hash_expr(&input_ptr).unwrap();
+            let input_zptr = s.hash_expr(input_ptr).unwrap();
             let tag_zptr: F = input_zptr.tag().to_field();
             let hash_zptr = input_zptr.value();
             input[(64 * i)..(64 * i + 32)].copy_from_slice(&tag_zptr.to_bytes());
@@ -254,7 +254,7 @@ fn sha256_ivc_prove<M: measurement::Measurement>(
 }
 
 fn prove_benchmarks(c: &mut Criterion) {
-    let _ = dbg!(&*lurk::config::CONFIG);
+    tracing::debug!("{:?}", &*lurk::config::CONFIG);
     let reduction_counts = vec![100, 600, 700, 800, 900];
     let batch_sizes = vec![1, 2, 5];
     let mut group: BenchmarkGroup<'_, _> = c.benchmark_group("prove");
@@ -333,7 +333,7 @@ fn sha256_ivc_prove_compressed<M: measurement::Measurement>(
 }
 
 fn prove_compressed_benchmarks(c: &mut Criterion) {
-    let _ = dbg!(&*lurk::config::CONFIG);
+    tracing::debug!("{:?}", &*lurk::config::CONFIG);
     let reduction_counts = vec![100, 600, 700, 800, 900];
     let batch_sizes = vec![1, 2, 5];
     let mut group: BenchmarkGroup<'_, _> = c.benchmark_group("prove_compressed");

--- a/benches/sha256_ivc.rs
+++ b/benches/sha256_ivc.rs
@@ -188,7 +188,10 @@ impl ProveParams {
     fn name(&self) -> String {
         let date = env!("VERGEN_GIT_COMMIT_DATE");
         let sha = env!("VERGEN_GIT_SHA");
-        format!("{date}:{sha}:rc={}:sha256_ivc_{}", self.reduction_count, self.n)
+        format!(
+            "{date}:{sha}:rc={}:sha256_ivc_{}",
+            self.reduction_count, self.n
+        )
     }
 }
 

--- a/benches/sha256_ivc.rs
+++ b/benches/sha256_ivc.rs
@@ -1,39 +1,60 @@
-use std::marker::PhantomData;
-use std::sync::Arc;
-use std::time::Instant;
-
 use lurk::circuit::gadgets::data::GlobalAllocations;
-use lurk::circuit::gadgets::pointer::{AllocatedContPtr, AllocatedPtr};
-use lurk::coprocessor::{CoCircuit, Coprocessor};
-use lurk::eval::{empty_sym_env, lang::Lang};
-use lurk::field::LurkField;
-use lurk::proof::{nova::NovaProver, Prover};
-use lurk::ptr::Ptr;
-use lurk::public_parameters::with_public_params;
-use lurk::state::user_sym;
-use lurk::store::Store;
-use lurk::tag::{ExprTag, Tag};
-use lurk::Num;
+use lurk::{circuit::gadgets::pointer::AllocatedContPtr, tag::Tag};
+use std::{cell::RefCell, marker::PhantomData, rc::Rc, sync::Arc, time::Duration};
+
+use bellpepper::gadgets::{multipack::pack_bits, sha256::sha256};
+use bellpepper_core::{boolean::Boolean, ConstraintSystem, SynthesisError};
+use camino::Utf8Path;
+use criterion::{
+    black_box, criterion_group, criterion_main, measurement, BatchSize, BenchmarkGroup,
+    BenchmarkId, Criterion, SamplingMode,
+};
+
 use lurk_macros::Coproc;
+use pasta_curves::pallas;
 
-use bellpepper::gadgets::multipack::pack_bits;
-use bellpepper::gadgets::sha256::sha256;
-use bellpepper_core::boolean::Boolean;
-use bellpepper_core::{ConstraintSystem, SynthesisError};
-
-use pasta_curves::pallas::Scalar as Fr;
+use lurk::{
+    circuit::gadgets::pointer::AllocatedPtr,
+    coprocessor::{CoCircuit, Coprocessor},
+    eval::{
+        empty_sym_env,
+        lang::{Coproc, Lang},
+    },
+    field::LurkField,
+    proof::nova::NovaProver,
+    proof::Prover,
+    ptr::Ptr,
+    public_parameters::public_params,
+    state::State,
+    store::Store,
+    tag::ExprTag,
+    Num,
+};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
+use sha2::Sha256;
 
-const REDUCTION_COUNT: usize = 10;
+const PUBLIC_PARAMS_PATH: &str = "/var/tmp/lurk_benches/public_params";
 
-fn sha256_expr<F: LurkField>(store: &mut Store<F>, x: Vec<F>) -> Ptr<F> {
-    let program = format!(r#"
+fn sha256_ivc<F: LurkField>(
+    store: &mut Store<F>,
+    state: Rc<RefCell<State>>,
+    n: usize,
+    input: Vec<usize>,
+) -> Ptr<F> {
+    assert_eq!(n, input.len());
+    let input = input
+        .iter()
+        .map(|i| i.to_string())
+        .collect::<Vec<String>>()
+        .join(" ");
+    let input = format!("'({})", input);
+    let program = format!(
+        r#"
 (letrec ((encode-1 (lambda (term) 
             (let ((type (car term))
                   (value (cdr term)))
                 (if (eq 'sha256 type)
-                    (.lurk.user.sha256x-64-zero-bytes value)
+                    (eval (cons 'sha256_ivc_{n} value))
                     (if (eq 'lurk type)
                         (commit value)
                         (if (eq 'id type)
@@ -43,12 +64,12 @@ fn sha256_expr<F: LurkField>(store: &mut Store<F>, x: Vec<F>) -> Ptr<F> {
                     (cons 
                         (encode-1 (car input))
                         (encode (cdr input)))))))
-  (encode '((sha256 {x:?}) (lurk . 5) (id . 15))))
-"#);
+  (encode '((sha256 . {input}) (lurk . 5) (id . 15))))
+"#
+    );
 
-    store.read(&program).unwrap()
+    store.read_with_state(state, &program).unwrap()
 }
-
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct Sha256Coprocessor<F: LurkField> {
     n: usize,
@@ -57,7 +78,7 @@ pub(crate) struct Sha256Coprocessor<F: LurkField> {
 
 impl<F: LurkField> CoCircuit<F> for Sha256Coprocessor<F> {
     fn arity(&self) -> usize {
-        1
+        self.n
     }
 
     fn synthesize<CS: ConstraintSystem<F>>(
@@ -69,23 +90,29 @@ impl<F: LurkField> CoCircuit<F> for Sha256Coprocessor<F> {
         input_env: &AllocatedPtr<F>,
         input_cont: &AllocatedContPtr<F>,
     ) -> Result<(AllocatedPtr<F>, AllocatedPtr<F>, AllocatedContPtr<F>), SynthesisError> {
-        let preimage_ptr = &input_exprs[0];
-
         let zero = Boolean::constant(false);
 
-        let mut preimage_bits = preimage_ptr
-            .tag()
-            .to_bits_le_strict(&mut cs.namespace(|| "preimage_tag_bits"))?;
-        let preimage_hash_bits = preimage_ptr
-            .hash()
-            .to_bits_le_strict(&mut cs.namespace(|| "preimage_hash_bits"))?;
+        let mut bits = vec![];
 
-        preimage_bits.push(zero.clone()); // need 256 bits (or some multiple of 8).
-        preimage_bits.extend(preimage_hash_bits);
-        preimage_bits.push(zero); // need 256 bits (or some multiple of 8).
-        preimage_bits.reverse();
+        // println!("{:?}", input_exprs);
 
-        let mut digest_bits = sha256(cs.namespace(|| "digest_bits"), &preimage_bits)?;
+        for input_ptr in input_exprs {
+            let tag_bits = input_ptr
+                .tag()
+                .to_bits_le_strict(&mut cs.namespace(|| "preimage_tag_bits"))?;
+            let hash_bits = input_ptr
+                .hash()
+                .to_bits_le_strict(&mut cs.namespace(|| "preimage_hash_bits"))?;
+
+            bits.extend(tag_bits);
+            bits.push(zero.clone()); // need 256 bits (or some multiple of 8).
+            bits.extend(hash_bits);
+            bits.push(zero.clone()); // need 256 bits (or some multiple of 8).
+        }
+
+        bits.reverse();
+
+        let mut digest_bits = sha256(cs.namespace(|| "digest_bits"), &bits)?;
 
         digest_bits.reverse();
 
@@ -102,24 +129,26 @@ impl<F: LurkField> CoCircuit<F> for Sha256Coprocessor<F> {
 
 impl<F: LurkField> Coprocessor<F> for Sha256Coprocessor<F> {
     fn eval_arity(&self) -> usize {
-        1
+        self.n
     }
 
     fn simple_evaluate(&self, s: &mut Store<F>, args: &[Ptr<F>]) -> Ptr<F> {
         let mut hasher = Sha256::new();
 
-        let preimage_ptr = args[0];
-        let preimage_zptr = s.hash_expr(&preimage_ptr).unwrap();
-        let preimage_tag: F = preimage_zptr.tag().to_field();
-        let preimage_hash = preimage_zptr.value();
-        let mut input = [0u8; 64];
-        input[..32].copy_from_slice(&preimage_tag.to_bytes());
-        input[32..].copy_from_slice(&preimage_hash.to_bytes());
+        let mut input = vec![0u8; 64 * self.n];
+
+        for (i, input_ptr) in args.iter().enumerate() {
+            let input_zptr = s.hash_expr(&input_ptr).unwrap();
+            let tag_zptr: F = input_zptr.tag().to_field();
+            let hash_zptr = input_zptr.value();
+            input[(64 * i)..(64 * i + 32)].copy_from_slice(&tag_zptr.to_bytes());
+            input[(64 * i + 32)..(64 * (i + 1))].copy_from_slice(&hash_zptr.to_bytes());
+        }
+
         input.reverse();
 
         hasher.update(input);
         let mut bytes = hasher.finalize();
-
         bytes.reverse();
         let l = bytes.len();
         // Discard the two most significant bits.
@@ -150,58 +179,186 @@ enum Sha256Coproc<F: LurkField> {
     SC(Sha256Coprocessor<F>),
 }
 
-/// Run the example in this file with
-/// `cargo run --release --example sha256_ivc`
-fn main() {
-    pretty_env_logger::init();
-
-    let input_size = 64;
-
-    let store = &mut Store::<Fr>::new();
-    let cproc_sym = user_sym(&format!("sha256x-{input_size}-zero-bytes"));
-
-    let call = sha256_expr(store);
-
-    let lang = Lang::<Fr, Sha256Coproc<Fr>>::new_with_bindings(
-        store,
-        vec![(cproc_sym, Sha256Coprocessor::new(input_size).into())],
-    );
-    let lang_rc = Arc::new(lang.clone());
-
-    let nova_prover = NovaProver::<Fr, Sha256Coproc<Fr>>::new(REDUCTION_COUNT, lang);
-
-    println!("Setting up public parameters (rc = {REDUCTION_COUNT})...");
-
-    let pp_start = Instant::now();
-
-    // see the documentation on `with_public_params`
-    with_public_params(REDUCTION_COUNT, lang_rc.clone(), |pp| {
-        let pp_end = pp_start.elapsed();
-        println!("Public parameters took {:?}", pp_end);
-
-        println!("Beginning proof step...");
-        let proof_start = Instant::now();
-        let (proof, z0, zi, num_steps) = nova_prover
-            .evaluate_and_prove(pp, call, empty_sym_env(store), store, 10000, lang_rc)
-            .unwrap();
-        let proof_end = proof_start.elapsed();
-
-        println!("Proofs took {:?}", proof_end);
-
-        println!("Verifying proof...");
-
-        let verify_start = Instant::now();
-        let res = proof.verify(pp, num_steps, &z0, &zi).unwrap();
-        let verify_end = verify_start.elapsed();
-
-        println!("Verify took {:?}", verify_end);
-
-        if res {
-            println!(
-                "Congratulations! You proved and verified a SHA256 hash calculation in {:?} time!",
-                pp_end + proof_end + verify_end
-            );
-        }
-    })
-    .unwrap();
+struct ProveParams {
+    n: usize,
+    reduction_count: usize,
 }
+
+impl ProveParams {
+    fn name(&self) -> String {
+        let date = env!("VERGEN_GIT_COMMIT_DATE");
+        let sha = env!("VERGEN_GIT_SHA");
+        format!("{date}:{sha}:rc={}:sha256_ivc_{}", self.reduction_count, self.n)
+    }
+}
+
+fn sha256_ivc_prove<M: measurement::Measurement>(
+    prove_params: ProveParams,
+    c: &mut BenchmarkGroup<'_, M>,
+    state: Rc<RefCell<State>>,
+) {
+    let ProveParams { n, reduction_count } = prove_params;
+
+    let limit = 10000;
+    let lang_pallas = Lang::<pallas::Scalar, Coproc<pallas::Scalar>>::new();
+    let lang_rc = Arc::new(lang_pallas.clone());
+
+    // use cached public params
+    let pp = public_params(
+        reduction_count,
+        true,
+        lang_rc.clone(),
+        Utf8Path::new(PUBLIC_PARAMS_PATH),
+    )
+    .unwrap();
+
+    c.bench_with_input(
+        BenchmarkId::new(prove_params.name(), n),
+        &prove_params,
+        |b, prove_params| {
+            let mut store = Store::default();
+
+            let env = empty_sym_env(&store);
+            let ptr = sha256_ivc::<pasta_curves::Fq>(
+                &mut store,
+                state.clone(),
+                black_box(prove_params.n),
+                (0..n).collect(),
+            );
+            let prover = NovaProver::new(prove_params.reduction_count, lang_pallas.clone());
+
+            let frames = &prover
+                .get_evaluation_frames(ptr, env, &mut store, limit, &lang_pallas)
+                .unwrap();
+
+            b.iter_batched(
+                || (frames, lang_rc.clone()),
+                |(frames, lang_rc)| {
+                    let result = prover.prove(&pp, frames, &mut store, lang_rc);
+                    let _ = black_box(result);
+                },
+                BatchSize::LargeInput,
+            )
+        },
+    );
+}
+
+fn prove_benchmarks(c: &mut Criterion) {
+    let _ = dbg!(&*lurk::config::CONFIG);
+    let reduction_counts = vec![100, 600, 700, 800, 900];
+    let batch_sizes = vec![1, 2, 5];
+    let mut group: BenchmarkGroup<'_, _> = c.benchmark_group("prove");
+    group.sampling_mode(SamplingMode::Flat); // This can take a *while*
+    group.sample_size(10);
+    let state = State::init_lurk_state().rccell();
+
+    for n in batch_sizes.iter() {
+        for reduction_count in reduction_counts.iter() {
+            let prove_params = ProveParams {
+                n: *n,
+                reduction_count: *reduction_count,
+            };
+            sha256_ivc_prove(prove_params, &mut group, state.clone());
+        }
+    }
+}
+
+fn sha256_ivc_prove_compressed<M: measurement::Measurement>(
+    prove_params: ProveParams,
+    c: &mut BenchmarkGroup<'_, M>,
+    state: Rc<RefCell<State>>,
+) {
+    let ProveParams { n, reduction_count } = prove_params;
+
+    let limit = 10000;
+    let lang_pallas = Lang::<pallas::Scalar, Coproc<pallas::Scalar>>::new();
+    let lang_rc = Arc::new(lang_pallas.clone());
+
+    // use cached public params
+    let pp = public_params(
+        reduction_count,
+        true,
+        lang_rc.clone(),
+        Utf8Path::new(PUBLIC_PARAMS_PATH),
+    )
+    .unwrap();
+
+    c.bench_with_input(
+        BenchmarkId::new(prove_params.name(), n),
+        &prove_params,
+        |b, prove_params| {
+            let mut store = Store::default();
+
+            let env = empty_sym_env(&store);
+            let ptr = sha256_ivc::<pasta_curves::Fq>(
+                &mut store,
+                state.clone(),
+                black_box(prove_params.n),
+                (0..n).collect(),
+            );
+            let prover = NovaProver::new(prove_params.reduction_count, lang_pallas.clone());
+
+            let frames = &prover
+                .get_evaluation_frames(ptr, env, &mut store, limit, &lang_pallas)
+                .unwrap();
+
+            b.iter_batched(
+                || (frames, lang_rc.clone()),
+                |(frames, lang_rc)| {
+                    let (proof, _, _, _) = prover.prove(&pp, frames, &mut store, lang_rc).unwrap();
+                    let compressed_result = proof.compress(&pp).unwrap();
+
+                    let _ = black_box(compressed_result);
+                },
+                BatchSize::LargeInput,
+            )
+        },
+    );
+}
+
+fn prove_compressed_benchmarks(c: &mut Criterion) {
+    let _ = dbg!(&*lurk::config::CONFIG);
+    let reduction_counts = vec![100, 600, 700, 800, 900];
+    let batch_sizes = vec![1, 2, 5];
+    let mut group: BenchmarkGroup<'_, _> = c.benchmark_group("prove_compressed");
+    group.sampling_mode(SamplingMode::Flat); // This can take a *while*
+    group.sample_size(10);
+    let state = State::init_lurk_state().rccell();
+
+    for n in batch_sizes.iter() {
+        for reduction_count in reduction_counts.iter() {
+            let prove_params = ProveParams {
+                n: *n,
+                reduction_count: *reduction_count,
+            };
+            sha256_ivc_prove_compressed(prove_params, &mut group, state.clone());
+        }
+    }
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "flamegraph")] {
+        criterion_group! {
+            name = benches;
+            config = Criterion::default()
+            .measurement_time(Duration::from_secs(120))
+            .sample_size(10)
+            .with_profiler(pprof::criterion::PProfProfiler::new(100, pprof::criterion::Output::Flamegraph(None)));
+            targets =
+                prove_benchmarks,
+                prove_compressed_benchmarks
+         }
+    } else {
+        criterion_group! {
+            name = benches;
+            config = Criterion::default()
+            .measurement_time(Duration::from_secs(120))
+            .sample_size(10);
+            targets =
+                prove_benchmarks,
+                prove_compressed_benchmarks
+         }
+    }
+}
+
+criterion_main!(benches);

--- a/examples/sha256_ivc.rs
+++ b/examples/sha256_ivc.rs
@@ -169,7 +169,8 @@ enum Sha256Coproc<F: LurkField> {
 }
 
 /// Run the example in this file with
-/// `cargo run --release --example sha256_ivc`
+/// `cargo run --release --example sha256_ivc <n>`
+/// where `n` is the needed arity
 fn main() {
     pretty_env_logger::init();
     let args = std::env::args().collect::<Vec<_>>();

--- a/examples/sha256_ivc.rs
+++ b/examples/sha256_ivc.rs
@@ -1,0 +1,207 @@
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::time::Instant;
+
+use lurk::circuit::gadgets::data::GlobalAllocations;
+use lurk::circuit::gadgets::pointer::{AllocatedContPtr, AllocatedPtr};
+use lurk::coprocessor::{CoCircuit, Coprocessor};
+use lurk::eval::{empty_sym_env, lang::Lang};
+use lurk::field::LurkField;
+use lurk::proof::{nova::NovaProver, Prover};
+use lurk::ptr::Ptr;
+use lurk::public_parameters::with_public_params;
+use lurk::state::user_sym;
+use lurk::store::Store;
+use lurk::tag::{ExprTag, Tag};
+use lurk::Num;
+use lurk_macros::Coproc;
+
+use bellpepper::gadgets::multipack::pack_bits;
+use bellpepper::gadgets::sha256::sha256;
+use bellpepper_core::boolean::Boolean;
+use bellpepper_core::{ConstraintSystem, SynthesisError};
+
+use pasta_curves::pallas::Scalar as Fr;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+const REDUCTION_COUNT: usize = 10;
+
+fn sha256_expr<F: LurkField>(store: &mut Store<F>) -> Ptr<F> {
+    let program = r#"
+(letrec ((encode-1 (lambda (term) 
+            (let ((type (car term))
+                  (value (cdr term)))
+                (if (eq 'sha256 type)
+                    (.lurk.user.sha256x-64-zero-bytes value)
+                    (if (eq 'lurk type)
+                        (commit value)
+                        (if (eq 'id type)
+                            value))))))
+      (encode (lambda (input)
+                (if input
+                    (cons 
+                        (encode-1 (car input))
+                        (encode (cdr input)))))))
+  (encode '((sha256 . 20) (lurk . 5) (id . 15))))
+"#;
+
+    store.read(program).unwrap()
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct Sha256Coprocessor<F: LurkField> {
+    n: usize,
+    pub(crate) _p: PhantomData<F>,
+}
+
+impl<F: LurkField> CoCircuit<F> for Sha256Coprocessor<F> {
+    fn arity(&self) -> usize {
+        1
+    }
+
+    fn synthesize<CS: ConstraintSystem<F>>(
+        &self,
+        cs: &mut CS,
+        _g: &GlobalAllocations<F>,
+        _store: &Store<F>,
+        input_exprs: &[AllocatedPtr<F>],
+        input_env: &AllocatedPtr<F>,
+        input_cont: &AllocatedContPtr<F>,
+    ) -> Result<(AllocatedPtr<F>, AllocatedPtr<F>, AllocatedContPtr<F>), SynthesisError> {
+        let preimage_ptr = &input_exprs[0];
+
+        let zero = Boolean::constant(false);
+
+        let mut preimage_bits = preimage_ptr
+            .tag()
+            .to_bits_le_strict(&mut cs.namespace(|| "preimage_tag_bits"))?;
+        let preimage_hash_bits = preimage_ptr
+            .hash()
+            .to_bits_le_strict(&mut cs.namespace(|| "preimage_hash_bits"))?;
+
+        preimage_bits.push(zero.clone()); // need 256 bits (or some multiple of 8).
+        preimage_bits.extend(preimage_hash_bits);
+        preimage_bits.push(zero); // need 256 bits (or some multiple of 8).
+        preimage_bits.reverse();
+
+        let mut digest_bits = sha256(cs.namespace(|| "digest_bits"), &preimage_bits)?;
+
+        digest_bits.reverse();
+
+        // Fine to lose the last <1 bit of precision.
+        let digest_scalar = pack_bits(cs.namespace(|| "digest_scalar"), &digest_bits)?;
+        let output_expr = AllocatedPtr::alloc_tag(
+            &mut cs.namespace(|| "output_expr"),
+            ExprTag::Num.to_field(),
+            digest_scalar,
+        )?;
+        Ok((output_expr, input_env.clone(), input_cont.clone()))
+    }
+}
+
+impl<F: LurkField> Coprocessor<F> for Sha256Coprocessor<F> {
+    fn eval_arity(&self) -> usize {
+        1
+    }
+
+    fn simple_evaluate(&self, s: &mut Store<F>, args: &[Ptr<F>]) -> Ptr<F> {
+        let mut hasher = Sha256::new();
+
+        let preimage_ptr = args[0];
+        let preimage_zptr = s.hash_expr(&preimage_ptr).unwrap();
+        let preimage_tag: F = preimage_zptr.tag().to_field();
+        let preimage_hash = preimage_zptr.value();
+        let mut input = [0u8; 64];
+        input[..32].copy_from_slice(&preimage_tag.to_bytes());
+        input[32..].copy_from_slice(&preimage_hash.to_bytes());
+        input.reverse();
+
+        hasher.update(input);
+        let mut bytes = hasher.finalize();
+
+        bytes.reverse();
+        let l = bytes.len();
+        // Discard the two most significant bits.
+        bytes[l - 1] &= 0b00111111;
+
+        let scalar = F::from_bytes(&bytes).unwrap();
+        let result = Num::from_scalar(scalar);
+
+        s.intern_num(result)
+    }
+
+    fn has_circuit(&self) -> bool {
+        true
+    }
+}
+
+impl<F: LurkField> Sha256Coprocessor<F> {
+    pub(crate) fn new(n: usize) -> Self {
+        Self {
+            n,
+            _p: Default::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Coproc, Serialize, Deserialize)]
+enum Sha256Coproc<F: LurkField> {
+    SC(Sha256Coprocessor<F>),
+}
+
+/// Run the example in this file with
+/// `cargo run --release --example sha256_ivc`
+fn main() {
+    pretty_env_logger::init();
+
+    let input_size = 64;
+
+    let store = &mut Store::<Fr>::new();
+    let cproc_sym = user_sym(&format!("sha256x-{input_size}-zero-bytes"));
+
+    let call = sha256_expr(store);
+
+    let lang = Lang::<Fr, Sha256Coproc<Fr>>::new_with_bindings(
+        store,
+        vec![(cproc_sym, Sha256Coprocessor::new(input_size).into())],
+    );
+    let lang_rc = Arc::new(lang.clone());
+
+    let nova_prover = NovaProver::<Fr, Sha256Coproc<Fr>>::new(REDUCTION_COUNT, lang);
+
+    println!("Setting up public parameters (rc = {REDUCTION_COUNT})...");
+
+    let pp_start = Instant::now();
+
+    // see the documentation on `with_public_params`
+    with_public_params(REDUCTION_COUNT, lang_rc.clone(), |pp| {
+        let pp_end = pp_start.elapsed();
+        println!("Public parameters took {:?}", pp_end);
+
+        println!("Beginning proof step...");
+        let proof_start = Instant::now();
+        let (proof, z0, zi, num_steps) = nova_prover
+            .evaluate_and_prove(pp, call, empty_sym_env(store), store, 10000, lang_rc)
+            .unwrap();
+        let proof_end = proof_start.elapsed();
+
+        println!("Proofs took {:?}", proof_end);
+
+        println!("Verifying proof...");
+
+        let verify_start = Instant::now();
+        let res = proof.verify(pp, num_steps, &z0, &zi).unwrap();
+        let verify_end = verify_start.elapsed();
+
+        println!("Verify took {:?}", verify_end);
+
+        if res {
+            println!(
+                "Congratulations! You proved and verified a SHA256 hash calculation in {:?} time!",
+                pp_end + proof_end + verify_end
+            );
+        }
+    })
+    .unwrap();
+}

--- a/examples/sha256_ivc.rs
+++ b/examples/sha256_ivc.rs
@@ -30,9 +30,14 @@ const REDUCTION_COUNT: usize = 10;
 
 fn sha256_ivc<F: LurkField>(store: &mut Store<F>, n: usize, input: Vec<usize>) -> Ptr<F> {
     assert_eq!(n, input.len());
-    let input = input.iter().map(|i| i.to_string()).collect::<Vec<String>>().join(" ");
+    let input = input
+        .iter()
+        .map(|i| i.to_string())
+        .collect::<Vec<String>>()
+        .join(" ");
     let input = format!("'({})", input);
-    let program = format!(r#"
+    let program = format!(
+        r#"
 (letrec ((encode-1 (lambda (term) 
             (let ((type (car term))
                   (value (cdr term)))
@@ -48,7 +53,8 @@ fn sha256_ivc<F: LurkField>(store: &mut Store<F>, n: usize, input: Vec<usize>) -
                         (encode-1 (car input))
                         (encode (cdr input)))))))
   (encode '((sha256 . {input}) (lurk . 5) (id . 15))))
-"#);
+"#
+    );
 
     store.read(&program).unwrap()
 }

--- a/examples/sha256_ivc.rs
+++ b/examples/sha256_ivc.rs
@@ -2,7 +2,6 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Instant;
 
-use itertools::Itertools;
 use lurk::circuit::gadgets::data::GlobalAllocations;
 use lurk::circuit::gadgets::pointer::{AllocatedContPtr, AllocatedPtr};
 use lurk::coprocessor::{CoCircuit, Coprocessor};
@@ -186,7 +185,7 @@ fn main() {
     let store = &mut Store::<Fr>::new();
     let cproc_sym = user_sym(&format!("sha256_ivc_{n}"));
 
-    let call = sha256_ivc(store, n, (0..n).collect_vec());
+    let call = sha256_ivc(store, n, (0..n).collect());
 
     let lang = Lang::<Fr, Sha256Coproc<Fr>>::new_with_bindings(
         store,

--- a/examples/sha256x.rs
+++ b/examples/sha256x.rs
@@ -1,0 +1,204 @@
+use std::env;
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::time::Instant;
+
+use lurk::circuit::gadgets::constraints::alloc_equal;
+use lurk::circuit::gadgets::data::{allocate_constant, GlobalAllocations};
+use lurk::circuit::gadgets::pointer::{AllocatedContPtr, AllocatedPtr};
+use lurk::coprocessor::{CoCircuit, Coprocessor};
+use lurk::eval::{empty_sym_env, lang::Lang};
+use lurk::field::LurkField;
+use lurk::proof::{nova::NovaProver, Prover};
+use lurk::ptr::Ptr;
+use lurk::public_parameters::with_public_params;
+use lurk::state::user_sym;
+use lurk::store::Store;
+use lurk::tag::{ExprTag, Tag};
+use lurk_macros::Coproc;
+
+use bellpepper::gadgets::multipack::pack_bits;
+use bellpepper::gadgets::sha256::sha256;
+use bellpepper_core::boolean::{AllocatedBit, Boolean};
+use bellpepper_core::num::AllocatedNum;
+use bellpepper_core::{ConstraintSystem, SynthesisError};
+
+use pasta_curves::pallas::Scalar as Fr;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+const REDUCTION_COUNT: usize = 100;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct Sha256Coprocessor<F: LurkField> {
+    n: usize,
+    expected: [u128; 2],
+    pub(crate) _p: PhantomData<F>,
+}
+
+impl<F: LurkField> CoCircuit<F> for Sha256Coprocessor<F> {
+    fn arity(&self) -> usize {
+        1
+    }
+
+    fn synthesize<CS: ConstraintSystem<F>>(
+        &self,
+        cs: &mut CS,
+        _g: &GlobalAllocations<F>,
+        store: &Store<F>,
+        input_exprs: &[AllocatedPtr<F>],
+        input_env: &AllocatedPtr<F>,
+        input_cont: &AllocatedContPtr<F>,
+    ) -> Result<(AllocatedPtr<F>, AllocatedPtr<F>, AllocatedContPtr<F>), SynthesisError> {
+        // let false_bool = Boolean::from(AllocatedBit::alloc(
+        //     cs.namespace(|| "false bit"),
+        //     Some(false),
+        // )?);
+
+        // cs.enforce(
+        //     || "enforce zero preimage",
+        //     |lc| lc,
+        //     |lc| lc,
+        //     |_| false_bool.lc(CS::one(), F::ONE),
+        // );
+
+        let preimage_ptr = &input_exprs[0];
+        let mut preimage_bits = preimage_ptr
+            .tag()
+            .to_bits_le_strict(&mut cs.namespace(|| "preimage_tag_bits"))?;
+        let preimage_hash_bits = preimage_ptr
+            .hash()
+            .to_bits_le_strict(&mut cs.namespace(|| "preimage_hash_bits"))?;
+
+        preimage_bits.extend(preimage_hash_bits);
+        let mut digest_bits = sha256(cs.namespace(|| "digest_bits"), &preimage_bits)?;
+
+        digest_bits.reverse();
+
+        // Fine to lose the last <1 bit of precision.
+        let digest_scalar = pack_bits(cs.namespace(|| "digest_scalar"), &digest_bits)?;
+        let output_expr = AllocatedPtr::alloc_tag(
+            &mut cs.namespace(|| "output_expr"),
+            ExprTag::Num.to_field(),
+            digest_scalar,
+        )?;
+        Ok((output_expr, input_env.clone(), input_cont.clone()))
+    }
+}
+
+impl<F: LurkField> Coprocessor<F> for Sha256Coprocessor<F> {
+    fn eval_arity(&self) -> usize {
+        1
+    }
+
+    fn simple_evaluate(&self, s: &mut Store<F>, args: &[Ptr<F>]) -> Ptr<F> {
+        let mut hasher = Sha256::new();
+
+        let preimage_ptr = args[0];
+        let preimage_zptr = s.hash_expr(&preimage_ptr).unwrap();
+        let preimage_tag: F = preimage_zptr.tag().to_field();
+        let preimage_hash = preimage_zptr.value();
+        let mut input = [0u8; 64];
+        input[..32].copy_from_slice(&preimage_tag.to_bytes());
+        input[32..].copy_from_slice(&preimage_hash.to_bytes());
+
+        hasher.update(input);
+        let result = lurk::Num::from_bytes(hasher.finalize());
+
+        // let truncated = result & 0x7fffff;
+
+        s.intern_num(lurk::Num::from_scalar(result))
+    }
+
+    fn has_circuit(&self) -> bool {
+        true
+    }
+}
+
+impl<F: LurkField> Sha256Coprocessor<F> {
+    pub(crate) fn new(n: usize, expected: [u128; 2]) -> Self {
+        Self {
+            n,
+            expected,
+            _p: Default::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Coproc, Serialize, Deserialize)]
+enum Sha256Coproc<F: LurkField> {
+    SC(Sha256Coprocessor<F>),
+}
+
+/// Run the example in this file with
+/// `cargo run --release --example sha256 1 f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b false`
+fn main() {
+    pretty_env_logger::init();
+    let args: Vec<String> = env::args().collect();
+
+    let num_of_64_bytes = args[1].parse::<usize>().unwrap();
+    let expect = hex::decode(args[2].parse::<String>().unwrap()).unwrap();
+    let setup_only = args[3].parse::<bool>().unwrap();
+
+    let input_size = 64 * num_of_64_bytes;
+
+    let mut u: [u128; 2] = [0u128; 2];
+    for i in 0..2 {
+        u[i] = u128::from_be_bytes(expect[(i * 16)..(i + 1) * 16].try_into().unwrap())
+    }
+
+    u.reverse();
+
+    let store = &mut Store::<Fr>::new();
+    let cproc_sym = user_sym(&format!("sha256-{input_size}-zero-bytes"));
+    let cproc_sym_ptr = store.intern_symbol(&cproc_sym);
+
+    let lang = Lang::<Fr, Sha256Coproc<Fr>>::new_with_bindings(
+        store,
+        vec![(cproc_sym, Sha256Coprocessor::new(input_size, u).into())],
+    );
+    let lang_rc = Arc::new(lang.clone());
+
+    let cproc_call = store.list(&[cproc_sym_ptr]);
+
+    let nova_prover = NovaProver::<Fr, Sha256Coproc<Fr>>::new(REDUCTION_COUNT, lang);
+
+    println!("Setting up public parameters (rc = {REDUCTION_COUNT})...");
+
+    let pp_start = Instant::now();
+
+    // see the documentation on `with_public_params`
+    with_public_params(REDUCTION_COUNT, lang_rc.clone(), |pp| {
+        let pp_end = pp_start.elapsed();
+        println!("Public parameters took {:?}", pp_end);
+
+        if setup_only {
+            return;
+        }
+
+        println!("Beginning proof step...");
+        let proof_start = Instant::now();
+        let (proof, z0, zi, num_steps) = nova_prover
+            .evaluate_and_prove(pp, cproc_call, empty_sym_env(store), store, 10000, lang_rc)
+            .unwrap();
+        let proof_end = proof_start.elapsed();
+
+        println!("Proofs took {:?}", proof_end);
+
+        println!("Verifying proof...");
+
+        let verify_start = Instant::now();
+        let res = proof.verify(pp, num_steps, &z0, &zi).unwrap();
+        let verify_end = verify_start.elapsed();
+
+        println!("Verify took {:?}", verify_end);
+
+        if res {
+            println!(
+                "Congratulations! You proved and verified a SHA256 hash calculation in {:?} time!",
+                pp_end + proof_end + verify_end
+            );
+        }
+    })
+    .unwrap();
+}


### PR DESCRIPTION
Resolves #632 #485. 

We modify the original `sha256` benchmark to receive `n` arguments, and then incorporate it into a full lurk program to show a proof of concept for IVC with coprocessors. In the given benchmark and example, we can declare a `sha256_ivc_n` coprocessor parameterized by arity `n`.

Running `RUST_LOG=info cargo run --release --example sha256 2`, we execute
```
(letrec ((encode-1 (lambda (term) 
            (let ((type (car term))
                  (value (cdr term)))
                (if (eq 'sha256 type)
                    (eval (cons 'sha256_ivc_2 value))
                    (if (eq 'lurk type)
                        (commit value)
                        (if (eq 'id type)
                            value))))))
      (encode (lambda (input)
                (if input
                    (cons 
                        (encode-1 (car input))
                        (encode (cdr input)))))))
  (encode '((sha256 . '(0 1)) (lurk . 5) (id . 15))))
```
and get the following output as the final frame 🎉 :
```
INFO  lurk::eval > Frame: 152
        Expr: (0x209d20654870103ad435bc764376189b43ff49a6f3817ad7bec9aba9a360422a (comm 0x06332145e67677b767270ae6f73dd9c104cb50d70452f65e78081113ccff1b8e) 15)
        Env: nil
        Cont: Terminal
```