### PR TITLE
MultiFrameTrait

### DIFF
--- a/examples/circom.rs
+++ b/examples/circom.rs
@@ -38,9 +38,10 @@ use lurk::circuit::gadgets::pointer::AllocatedPtr;
 #[cfg(not(target_arch = "wasm32"))]
 use lurk::coprocessor::circom::non_wasm::CircomCoprocessor;
 
+use lurk::circuit::circuit_frame::MultiFrame;
 use lurk::eval::{empty_sym_env, lang::Lang};
 use lurk::field::LurkField;
-use lurk::proof::{nova::NovaProver, Prover};
+use lurk::proof::{nova::NovaProver, MultiFrameTrait, Prover};
 use lurk::ptr::Ptr;
 use lurk::public_parameters::{public_params, public_params_default_dir};
 use lurk::store::Store;
@@ -115,7 +116,10 @@ fn main() {
     let expr = format!("({coproc_expr})");
     let ptr = store.read(&expr).unwrap();
 
-    let nova_prover = NovaProver::<Fr, Sha256Coproc<Fr>>::new(REDUCTION_COUNT, lang.clone());
+    let nova_prover = NovaProver::<Fr, Sha256Coproc<Fr>, MultiFrame<'_, Fr, Sha256Coproc<Fr>>>::new(
+        REDUCTION_COUNT,
+        lang.clone(),
+    );
     let lang_rc = Arc::new(lang);
 
     println!("Setting up public parameters...");

--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Instant;
 
+use lurk::circuit::circuit_frame::MultiFrame;
 use lurk::circuit::gadgets::constraints::alloc_equal;
 use lurk::circuit::gadgets::data::{allocate_constant, GlobalAllocations};
 use lurk::circuit::gadgets::pointer::{AllocatedContPtr, AllocatedPtr};
@@ -181,7 +182,10 @@ fn main() {
 
     let cproc_call = store.list(&[cproc_sym_ptr]);
 
-    let nova_prover = NovaProver::<Fr, Sha256Coproc<Fr>>::new(REDUCTION_COUNT, lang);
+    let nova_prover = NovaProver::<Fr, Sha256Coproc<Fr>, MultiFrame<'_, Fr, Sha256Coproc<Fr>>>::new(
+        REDUCTION_COUNT,
+        lang,
+    );
 
     println!("Setting up public parameters (rc = {REDUCTION_COUNT})...");
 

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -67,7 +67,7 @@ pub struct MultiFrame<'a, F: LurkField, C: Coprocessor<F>> {
     pub count: usize,
 }
 
-impl<'a, F: LurkField, C: Coprocessor<F>> MultiFrameTrait<F, C> for MultiFrame<'a, F, C> {
+impl<'a, F: LurkField, C: Coprocessor<F>> MultiFrameTrait<'a, F, C> for MultiFrame<'a, F, C> {
     type Store = Store<F>;
     type Ptr = Ptr<F>;
     type Frame = Frame<IO<F>, Witness<F>, C>;
@@ -108,38 +108,10 @@ impl<'a, F: LurkField, C: Coprocessor<F>> MultiFrameTrait<F, C> for MultiFrame<'
             count,
         }
     }
-}
 
-impl<'a, F: LurkField, C: Coprocessor<F>> CircuitFrame<'a, F, C> {
-    pub fn blank() -> Self {
-        Self {
-            store: None,
-            input: None,
-            output: None,
-            witness: None,
-            _p: Default::default(),
-        }
-    }
-
-    pub fn from_frame(frame: &Frame<IO<F>, Witness<F>, C>, store: &'a Store<F>) -> Self {
-        CircuitFrame {
-            store: Some(store),
-            input: Some(frame.input),
-            output: Some(frame.output),
-            witness: Some(frame.witness),
-            _p: Default::default(),
-        }
-    }
-}
-
-impl<'a, F: LurkField, C: Coprocessor<F>> MultiFrame<'a, F, C> {
-    pub fn get_store(&self) -> &Store<F> {
-        self.store.expect("store missing")
-    }
-
-    pub fn from_frames(
+    fn from_frames(
         count: usize,
-        frames: &[Frame<IO<F>, Witness<F>, C>],
+        frames: &[Self::Frame],
         store: &'a Store<F>,
         lang: Arc<Lang<F, C>>,
     ) -> Vec<Self> {
@@ -185,7 +157,7 @@ impl<'a, F: LurkField, C: Coprocessor<F>> MultiFrame<'a, F, C> {
     }
 
     /// Make a dummy `MultiFrame`, duplicating `self`'s final `CircuitFrame`.
-    pub(crate) fn make_dummy(
+    fn make_dummy(
         count: usize,
         circuit_frame: Option<CircuitFrame<'a, F, C>>,
         store: &'a Store<F>,
@@ -209,6 +181,34 @@ impl<'a, F: LurkField, C: Coprocessor<F>> MultiFrame<'a, F, C> {
             cached_witness: None,
             count,
         }
+    }
+}
+
+impl<'a, F: LurkField, C: Coprocessor<F>> CircuitFrame<'a, F, C> {
+    pub fn blank() -> Self {
+        Self {
+            store: None,
+            input: None,
+            output: None,
+            witness: None,
+            _p: Default::default(),
+        }
+    }
+
+    pub fn from_frame(frame: &Frame<IO<F>, Witness<F>, C>, store: &'a Store<F>) -> Self {
+        CircuitFrame {
+            store: Some(store),
+            input: Some(frame.input),
+            output: Some(frame.output),
+            witness: Some(frame.witness),
+            _p: Default::default(),
+        }
+    }
+}
+
+impl<'a, F: LurkField, C: Coprocessor<F>> MultiFrame<'a, F, C> {
+    pub fn get_store(&self) -> &Store<F> {
+        self.store.expect("store missing")
     }
 
     pub fn synthesize_frames_sequential<CS: ConstraintSystem<F>>(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,7 +6,7 @@ mod field_data;
 mod lurk_proof;
 pub mod paths;
 mod repl;
-pub mod repl_lem;
+// pub mod repl_lem;
 
 use anyhow::{bail, Context, Result};
 use camino::Utf8PathBuf;
@@ -27,7 +27,7 @@ use crate::{
 use crate::cli::{
     paths::set_lurk_dirs,
     repl::{validate_non_zero, Repl},
-    repl_lem::ReplLEM,
+    //    repl_lem::ReplLEM,
 };
 
 use self::backend::Backend;
@@ -380,11 +380,12 @@ impl ReplCli {
         macro_rules! repl {
             ( $rc:expr, $limit:expr, $field:path, $backend:expr ) => {{
                 if self.lem {
-                    let mut repl = ReplLEM::<$field>::new(None, $rc, $limit, $backend);
-                    if let Some(lurk_file) = &self.load {
-                        repl.load_file(lurk_file)?;
-                    }
-                    repl.start()
+                    unimplemented!("LEM");
+                    // let mut repl = ReplLEM::<$field>::new(None, $rc, $limit, $backend);
+                    // if let Some(lurk_file) = &self.load {
+                    //     repl.load_file(lurk_file)?;
+                    // }
+                    // repl.start()
                 } else {
                     let mut repl = new_repl!(self, $rc, $limit, $field, $backend);
                     if let Some(lurk_file) = &self.load {
@@ -436,12 +437,13 @@ impl LoadCli {
         macro_rules! load {
             ( $rc:expr, $limit:expr, $field:path, $backend:expr ) => {{
                 if self.lem {
-                    let mut repl = ReplLEM::<$field>::new(None, $rc, $limit, $backend);
-                    repl.load_file(&self.lurk_file)?;
-                    if self.prove {
-                        repl.prove_last_frames()?;
-                    }
-                    Ok(())
+                    unimplemented!("LEM");
+                    // let mut repl = ReplLEM::<$field>::new(None, $rc, $limit, $backend);
+                    // repl.load_file(&self.lurk_file)?;
+                    // if self.prove {
+                    //     repl.prove_last_frames()?;
+                    // }
+                    // Ok(())
                 } else {
                     let mut repl = new_repl!(self, $rc, $limit, $field, $backend);
                     repl.load_file(&self.lurk_file)?;

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -24,6 +24,7 @@ use super::{
 };
 
 use crate::{
+    circuit::MultiFrame,
     cli::paths::{proof_path, public_params_dir},
     eval::{
         lang::{Coproc, Lang},
@@ -200,7 +201,11 @@ impl Repl<F> {
                         let pp =
                             public_params(self.rc, true, self.lang.clone(), &public_params_dir())?;
 
-                        let prover = NovaProver::new(self.rc, (*self.lang).clone());
+                        let prover =
+                            NovaProver::<'_, F, Coproc<F>, MultiFrame<'_, F, Coproc<F>>>::new(
+                                self.rc,
+                                (*self.lang).clone(),
+                            );
 
                         info!("Proving");
                         let (proof, public_inputs, public_outputs, num_steps) =

--- a/src/cli/repl_lem.rs
+++ b/src/cli/repl_lem.rs
@@ -25,7 +25,7 @@ use crate::{
     package::{Package, SymbolRef},
     parser,
     proof::{
-        nova_lem::{public_params, NovaProver},
+        nova::{public_params, NovaProver},
         Prover,
     },
     state::State,

--- a/src/lem/circuit.rs
+++ b/src/lem/circuit.rs
@@ -83,40 +83,40 @@ impl<'a, F: LurkField, C: Coprocessor<F>> MultiFrameTrait<'a, F, C> for MultiFra
     type GlobalAllocation = GlobalAllocator<F>;
     type AllocatedIO = Vec<AllocatedPtr<F>>;
 
-    fn precedes(&self, maybe_next: &Self) -> bool {
+    fn precedes(&self, _maybe_next: &Self) -> bool {
         todo!()
     }
 
     fn synthesize_frames<CS: ConstraintSystem<F>>(
         &self,
-        cs: &mut CS,
-        store: &Self::Store,
-        input: Self::AllocatedIO,
-        frames: &[Self::CircuitFrame],
-        g: &Self::GlobalAllocation,
+        _cs: &mut CS,
+        _store: &Self::Store,
+        _input: Self::AllocatedIO,
+        _frames: &[Self::CircuitFrame],
+        _g: &Self::GlobalAllocation,
     ) -> Self::AllocatedIO {
         todo!()
     }
 
-    fn blank(count: usize, lang: Arc<Lang<F, C>>) -> Self {
+    fn blank(_count: usize, _lang: Arc<Lang<F, C>>) -> Self {
         todo!()
     }
 
     fn from_frames(
-        count: usize,
-        frames: &[Self::Frame],
-        store: &'a Self::Store,
-        lang: Arc<Lang<F, C>>,
+        _count: usize,
+        _frames: &[Self::Frame],
+        _store: &'a Self::Store,
+        _lang: Arc<Lang<F, C>>,
     ) -> Vec<Self> {
         todo!()
     }
 
     /// Make a dummy instance, duplicating `self`'s final `CircuitFrame`.
     fn make_dummy(
-        count: usize,
-        circuit_frame: Option<Self::CircuitFrame>,
-        store: &'a Self::Store,
-        lang: Arc<Lang<F, C>>,
+        _count: usize,
+        _circuit_frame: Option<Self::CircuitFrame>,
+        _store: &'a Self::Store,
+        _lang: Arc<Lang<F, C>>,
     ) -> Self {
         todo!()
     }

--- a/src/lem/circuit.rs
+++ b/src/lem/circuit.rs
@@ -26,13 +26,15 @@
 use anyhow::{Context, Result};
 use bellpepper::util_cs::witness_cs::WitnessCS;
 use bellpepper_core::{
-    ConstraintSystem, SynthesisError,
+    Circuit, ConstraintSystem, SynthesisError,
     {
         boolean::{AllocatedBit, Boolean},
         num::AllocatedNum,
     },
 };
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::marker::PhantomData;
+use std::sync::Arc;
 
 use crate::circuit::gadgets::{
     constraints::{
@@ -45,7 +47,10 @@ use crate::circuit::gadgets::{
 };
 
 use crate::{
+    coprocessor::Coprocessor,
+    eval::lang::Lang,
     field::{FWrap, LurkField},
+    proof::{MultiFrameTrait, Provable},
     tag::ExprTag::*,
 };
 
@@ -59,18 +64,89 @@ use super::{
 };
 
 #[derive(Clone)]
-pub struct MultiFrame<'a, F: LurkField> {
-    pub func: &'a Func,
+pub struct MultiFrame<'a, F: LurkField, C: Coprocessor<F>> {
+    pub func: Arc<Func>,
     pub store: Option<&'a Store<F>>,
     pub input: Option<Vec<Ptr<F>>>,
     pub output: Option<Vec<Ptr<F>>>,
     pub frames: Option<Vec<Frame<F>>>,
     pub cached_witness: Option<WitnessCS<F>>,
     pub reduction_count: usize,
+    _p: PhantomData<C>,
 }
 
-impl<'a, F: LurkField> MultiFrame<'a, F> {
-    pub fn blank(func: &'a Func, reduction_count: usize) -> Self {
+impl<'a, F: LurkField, C: Coprocessor<F>> MultiFrameTrait<'a, F, C> for MultiFrame<'a, F, C> {
+    type Store = Store<F>;
+    type Ptr = Ptr<F>;
+    type Frame = Frame<F>;
+    type CircuitFrame = ();
+    type GlobalAllocation = GlobalAllocator<F>;
+    type AllocatedIO = Vec<AllocatedPtr<F>>;
+
+    fn precedes(&self, maybe_next: &Self) -> bool {
+        todo!()
+    }
+
+    fn synthesize_frames<CS: ConstraintSystem<F>>(
+        &self,
+        cs: &mut CS,
+        store: &Self::Store,
+        input: Self::AllocatedIO,
+        frames: &[Self::CircuitFrame],
+        g: &Self::GlobalAllocation,
+    ) -> Self::AllocatedIO {
+        todo!()
+    }
+
+    fn blank(count: usize, lang: Arc<Lang<F, C>>) -> Self {
+        todo!()
+    }
+
+    fn from_frames(
+        count: usize,
+        frames: &[Self::Frame],
+        store: &'a Self::Store,
+        lang: Arc<Lang<F, C>>,
+    ) -> Vec<Self> {
+        todo!()
+    }
+
+    /// Make a dummy instance, duplicating `self`'s final `CircuitFrame`.
+    fn make_dummy(
+        count: usize,
+        circuit_frame: Option<Self::CircuitFrame>,
+        store: &'a Self::Store,
+        lang: Arc<Lang<F, C>>,
+    ) -> Self {
+        todo!()
+    }
+}
+
+impl<'a, F: LurkField, C: Coprocessor<F>> Circuit<F> for MultiFrame<'a, F, C> {
+    fn synthesize<CS>(self, _: &mut CS) -> Result<(), SynthesisError>
+    where
+        CS: ConstraintSystem<F>,
+    {
+        todo!()
+    }
+}
+
+impl<'a, F: LurkField, C: Coprocessor<F>> Provable<F> for MultiFrame<'a, F, C> {
+    fn public_inputs(&self) -> Vec<F> {
+        todo!()
+    }
+
+    fn public_input_size() -> usize {
+        todo!()
+    }
+
+    fn reduction_count(&self) -> usize {
+        self.reduction_count
+    }
+}
+
+impl<'a, F: LurkField, C: Coprocessor<F>> MultiFrame<'a, F, C> {
+    pub fn blank(func: Arc<Func>, reduction_count: usize) -> Self {
         Self {
             func,
             store: None,
@@ -79,11 +155,12 @@ impl<'a, F: LurkField> MultiFrame<'a, F> {
             frames: None,
             cached_witness: None,
             reduction_count,
+            _p: Default::default(),
         }
     }
 
     pub fn from_frames(
-        func: &'a Func,
+        func: Arc<Func>,
         reduction_count: usize,
         frames: &[Frame<F>],
         store: &'a Store<F>,
@@ -108,13 +185,14 @@ impl<'a, F: LurkField> MultiFrame<'a, F> {
             debug_assert!(!inner_frames.is_empty());
 
             let mf = MultiFrame {
-                func,
+                func: func.clone(),
                 store: Some(store),
                 input: Some(input),
                 output: Some(output),
                 frames: Some(inner_frames),
                 cached_witness: None,
                 reduction_count,
+                _p: Default::default(),
             };
 
             multi_frames.push(mf);

--- a/src/lem/mod.rs
+++ b/src/lem/mod.rs
@@ -70,6 +70,8 @@ pub mod store;
 mod var_map;
 pub mod zstore;
 
+use crate::coprocessor::Coprocessor;
+use crate::eval::lang::Lang;
 use crate::field::LurkField;
 use crate::symbol::Symbol;
 use crate::tag::{ContTag, ExprTag, Tag as TagTrait};
@@ -91,6 +93,12 @@ pub struct Func {
     pub output_size: usize,
     pub body: Block,
     pub slot: SlotsCounter,
+}
+
+impl<F: LurkField, C: Coprocessor<F>> From<&Lang<F, C>> for Func {
+    fn from(lang: &Lang<F, C>) -> Self {
+        eval::eval_step().clone()
+    }
 }
 
 /// LEM variables

--- a/src/lem/mod.rs
+++ b/src/lem/mod.rs
@@ -96,7 +96,7 @@ pub struct Func {
 }
 
 impl<F: LurkField, C: Coprocessor<F>> From<&Lang<F, C>> for Func {
-    fn from(lang: &Lang<F, C>) -> Self {
+    fn from(_lang: &Lang<F, C>) -> Self {
         eval::eval_step().clone()
     }
 }

--- a/src/proof/groth16.rs
+++ b/src/proof/groth16.rs
@@ -97,7 +97,9 @@ where
     pub reduction_count: usize,
 }
 
-impl<C: Coprocessor<Scalar>, M: MultiFrameTrait<Scalar, C>> Groth16Prover<Bls12, C, Scalar, M> {
+impl<'a, C: Coprocessor<Scalar>, M: MultiFrameTrait<'a, Scalar, C>>
+    Groth16Prover<'a, Bls12, C, Scalar, M>
+{
     /// Creates Groth16 parameters using the given reduction count.
     pub fn create_groth_params(
         reduction_count: usize,
@@ -244,14 +246,15 @@ impl<C: Coprocessor<Scalar>, M: MultiFrameTrait<Scalar, C>> Groth16Prover<Bls12,
 /// A prover struct for the Groth16 proving system.
 /// Implements the crate::Prover trait.
 pub struct Groth16Prover<
+    'a,
     E: Engine + MultiMillerLoop,
     C: Coprocessor<F>,
     F: LurkField,
-    M: MultiFrameTrait<F, C>,
+    M: MultiFrameTrait<'a, F, C>,
 > {
     reduction_count: usize,
     lang: Lang<F, C>,
-    _p: PhantomData<(E, C, F, M)>,
+    _p: PhantomData<(E, &'a M)>,
 }
 
 /// Public parameters for the Groth16 proving system.
@@ -260,8 +263,8 @@ pub struct PublicParams<E: Engine + MultiMillerLoop>(pub groth16::Parameters<E>)
 
 impl PublicParameters for PublicParams<Bls12> {}
 
-impl<'a, 'b, C: Coprocessor<Scalar>, M: MultiFrameTrait<Scalar, C>> Prover<'a, 'b, Scalar, C, M>
-    for Groth16Prover<Bls12, C, Scalar, M>
+impl<'a, 'b, C: Coprocessor<Scalar>, M: MultiFrameTrait<'a, Scalar, C>> Prover<'a, 'b, Scalar, C, M>
+    for Groth16Prover<'a, Bls12, C, Scalar, M>
 {
     type PublicParams = PublicParams<Bls12>;
 

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -45,7 +45,7 @@ pub trait MultiFrameTrait<'a, F: LurkField, C: Coprocessor<F>>:
     fn synthesize_frames<CS: ConstraintSystem<F>>(
         &self,
         cs: &mut CS,
-        store: &Store<F>,
+        store: &Self::Store,
         input_expr: AllocatedPtr<F>,
         input_env: AllocatedPtr<F>,
         input_cont: AllocatedContPtr<F>,
@@ -60,7 +60,7 @@ pub trait MultiFrameTrait<'a, F: LurkField, C: Coprocessor<F>>:
     fn from_frames(
         count: usize,
         frames: &[Self::Frame],
-        store: &'a Store<F>,
+        store: &'a Self::Store,
         lang: Arc<Lang<F, C>>,
     ) -> Vec<Self>;
 
@@ -68,7 +68,7 @@ pub trait MultiFrameTrait<'a, F: LurkField, C: Coprocessor<F>>:
     fn make_dummy(
         count: usize,
         circuit_frame: Option<Self::CircuitFrame>,
-        store: &'a Store<F>,
+        store: &'a Self::Store,
         lang: Arc<Lang<F, C>>,
     ) -> Self;
 }

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -10,7 +10,7 @@ pub mod groth16;
 /// An adapter to a Nova proving system implementation.
 pub mod nova;
 /// An adapter to a Nova proving system implementation in LEM.
-//pub mod nova_lem;
+pub mod nova_lem;
 use crate::circuit::gadgets::pointer::{AllocatedContPtr, AllocatedPtr};
 
 use crate::coprocessor::Coprocessor;
@@ -22,6 +22,7 @@ use crate::store::Store;
 use bellpepper_core::{test_cs::TestConstraintSystem, Circuit, ConstraintSystem, SynthesisError};
 
 use std::sync::Arc;
+
 
 /// Trait to support multiple `MultiFrame` implementations.
 pub trait MultiFrameTrait<'a, F: LurkField, C: Coprocessor<F>>:
@@ -70,6 +71,7 @@ pub trait MultiFrameTrait<'a, F: LurkField, C: Coprocessor<F>>:
         store: &'a Self::Store,
         lang: Arc<Lang<F, C>>,
     ) -> Self;
+
 }
 
 /// Represents a sequential Constraint System for a given proof.

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -27,17 +27,18 @@ use std::sync::Arc;
 pub trait MultiFrameTrait<'a, F: LurkField, C: Coprocessor<F>>:
     Provable<F> + Circuit<F> + Clone
 {
-    /// The `Store` associated with this implementation.
+    /// The associated `Store` type
     type Store;
-    /// The `Ptr` type associated with this implementation.
+    /// The associated `Ptr` type
     type Ptr;
-    /// The `Frame` type associated with this implementation.
+    /// The associated `Frame` type
     type Frame;
-    /// The `CircuitFrame` type associated with this implementation.
+    /// The associated `CircuitFrame` type
     type CircuitFrame;
-    /// The type which manages global allocations for this implementation.
+    /// The associated type which manages global allocations
     type GlobalAllocation;
-
+    /// The associated type of allocated input and output to the circuit
+    type AllocatedIO;
     /// Returns true if the supplied instance directly precedes this one in a sequential computation trace.
     fn precedes(&self, maybe_next: &Self) -> bool;
 
@@ -46,12 +47,10 @@ pub trait MultiFrameTrait<'a, F: LurkField, C: Coprocessor<F>>:
         &self,
         cs: &mut CS,
         store: &Self::Store,
-        input_expr: AllocatedPtr<F>,
-        input_env: AllocatedPtr<F>,
-        input_cont: AllocatedContPtr<F>,
+        input: Self::AllocatedIO,
         frames: &[Self::CircuitFrame],
         g: &Self::GlobalAllocation,
-    ) -> (AllocatedPtr<F>, AllocatedPtr<F>, AllocatedContPtr<F>);
+    ) -> Self::AllocatedIO;
 
     /// Synthesize a blank circuit.
     fn blank(count: usize, lang: Arc<Lang<F, C>>) -> Self;

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -11,13 +11,13 @@ pub mod groth16;
 pub mod nova;
 /// An adapter to a Nova proving system implementation in LEM.
 pub mod nova_lem;
-use crate::circuit::gadgets::pointer::{AllocatedContPtr, AllocatedPtr};
+
 
 use crate::coprocessor::Coprocessor;
 use crate::eval::lang::Lang;
 use crate::field::LurkField;
 
-use crate::store::Store;
+
 
 use bellpepper_core::{test_cs::TestConstraintSystem, Circuit, ConstraintSystem, SynthesisError};
 

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -390,7 +390,7 @@ impl<'a, F: LurkField, C: Coprocessor<F>> StepCircuit<F> for MultiFrame<'a, F, C
                 let s = self.store.expect("store missing");
                 let g = GlobalAllocations::new(&mut cs.namespace(|| "global_allocations"), s)?;
 
-                self.synthesize_frames(cs, s, input_expr, input_env, input_cont, frames, &g)
+                self.synthesize_frames(cs, s, (input_expr, input_env, input_cont), frames, &g)
             }
             None => {
                 assert!(self.store.is_none());
@@ -400,7 +400,7 @@ impl<'a, F: LurkField, C: Coprocessor<F>> StepCircuit<F> for MultiFrame<'a, F, C
 
                 let g = GlobalAllocations::new(&mut cs.namespace(|| "global_allocations"), &s)?;
 
-                self.synthesize_frames(cs, &s, input_expr, input_env, input_cont, &frames, &g)
+                self.synthesize_frames(cs, &s, (input_expr, input_env, input_cont), &frames, &g)
             }
         };
 

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -215,11 +215,11 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> C1<'a, F, C> {
 
 /// A struct for the Nova prover that operates on field elements of type `F`.
 #[derive(Debug)]
-pub struct NovaProver<F: CurveCycleEquipped, C: Coprocessor<F>, M: MultiFrameTrait<F, C>> {
+pub struct NovaProver<'a, F: CurveCycleEquipped, C: Coprocessor<F>, M: MultiFrameTrait<'a, F, C>> {
     // `reduction_count` specifies the number of small-step reductions are performed in each recursive step.
     reduction_count: usize,
     lang: Lang<F, C>,
-    _p: PhantomData<M>,
+    _p: PhantomData<&'a M>,
 }
 
 impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> PublicParameters for PublicParams<'a, F, C>
@@ -229,8 +229,8 @@ where
 {
 }
 
-impl<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a, M: MultiFrameTrait<F, C>>
-    Prover<'a, '_, F, C, M> for NovaProver<F, C, M>
+impl<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a, M: MultiFrameTrait<'a, F, C>>
+    Prover<'a, '_, F, C, M> for NovaProver<'a, F, C, M>
 where
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
@@ -252,7 +252,7 @@ where
     }
 }
 
-impl<F: CurveCycleEquipped, C: Coprocessor<F>> NovaProver<F, C, MultiFrame<'_, F, C>>
+impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> NovaProver<'a, F, C, MultiFrame<'a, F, C>>
 where
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
@@ -276,7 +276,7 @@ where
     }
 
     /// Proves the computation given the public parameters, frames, and store.
-    pub fn prove<'a>(
+    pub fn prove(
         &'a self,
         pp: &'a PublicParams<'_, F, C>,
         frames: &[Frame<IO<F>, Witness<F>, C>],
@@ -295,7 +295,7 @@ where
     }
 
     /// Evaluates and proves the computation given the public parameters, expression, environment, and store.
-    pub fn evaluate_and_prove<'a>(
+    pub fn evaluate_and_prove(
         &'a self,
         pp: &'a PublicParams<'_, F, C>,
         expr: Ptr<F>,

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -123,24 +123,24 @@ pub type C1<'a, F, C> = MultiFrame<'a, F, C>;
 pub type C2<F> = TrivialTestCircuit<<G2<F> as Group>::Scalar>;
 
 /// Type alias for Nova Public Parameters with the curve cycle types defined above.
-pub type NovaPublicParams<'a, F, C> = nova::PublicParams<G1<F>, G2<F>, C1<'a, F, C>, C2<F>>;
+pub type NovaPublicParams<F, C1> = nova::PublicParams<G1<F>, G2<F>, C1, C2<F>>;
 
 /// A struct that contains public parameters for the Nova proving system.
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct PublicParams<'a, F, C: Coprocessor<F>>
+pub struct PublicParams<F, C1: StepCircuit<F>>
 where
     F: CurveCycleEquipped,
     // technical bounds that would disappear once associated_type_bounds stabilizes
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
-    pp: NovaPublicParams<'a, F, C>,
-    pk: ProverKey<G1<F>, G2<F>, C1<'a, F, C>, C2<F>, SS1<F>, SS2<F>>,
-    vk: VerifierKey<G1<F>, G2<F>, C1<'a, F, C>, C2<F>, SS1<F>, SS2<F>>,
+    pub(crate) pp: NovaPublicParams<F, C1>,
+    pub(crate) pk: ProverKey<G1<F>, G2<F>, C1, C2<F>, SS1<F>, SS2<F>>,
+    pub(crate) vk: VerifierKey<G1<F>, G2<F>, C1, C2<F>, SS1<F>, SS2<F>>,
 }
 
-impl<'c, F: CurveCycleEquipped, C: Coprocessor<F>> Abomonation for PublicParams<'c, F, C>
+impl<F: CurveCycleEquipped, C1: StepCircuit<F>> Abomonation for PublicParams<F, C1>
 where
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
@@ -181,15 +181,16 @@ where
 }
 
 /// Generates the public parameters for the Nova proving system.
-pub fn public_params<'a, F: CurveCycleEquipped, C: Coprocessor<F>>(
+pub fn public_params<'a, F: CurveCycleEquipped, C: Coprocessor<F>, M: StepCircuit<F> + MultiFrameTrait<'a, F, C>>(
     num_iters_per_step: usize,
     lang: Arc<Lang<F, C>>,
-) -> PublicParams<'a, F, C>
+) -> PublicParams<F, M>
 where
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
-    let (circuit_primary, circuit_secondary) = C1::circuits(num_iters_per_step, lang);
+
+    let (circuit_primary, circuit_secondary) = circuits(num_iters_per_step, lang);
 
     let commitment_size_hint1 = <SS1<F> as RelaxedR1CSSNARKTrait<G1<F>>>::commitment_key_floor();
     let commitment_size_hint2 = <SS2<F> as RelaxedR1CSSNARKTrait<G2<F>>>::commitment_key_floor();
@@ -204,13 +205,11 @@ where
     PublicParams { pp, pk, vk }
 }
 
-impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> C1<'a, F, C> {
-    fn circuits(count: usize, lang: Arc<Lang<F, C>>) -> (C1<'a, F, C>, C2<F>) {
-        (
-            MultiFrame::blank(count, lang),
-            TrivialTestCircuit::default(),
-        )
-    }
+fn circuits<'a, F: CurveCycleEquipped, C: Coprocessor<F>, M: MultiFrameTrait<'a, F, C>>(count: usize, lang: Arc<Lang<F, C>>) -> (M, C2<F>) {
+     (
+        M::blank(count, lang),
+        TrivialTestCircuit::default(),
+    )
 }
 
 /// A struct for the Nova prover that operates on field elements of type `F`.
@@ -222,20 +221,24 @@ pub struct NovaProver<'a, F: CurveCycleEquipped, C: Coprocessor<F>, M: MultiFram
     _p: PhantomData<&'a M>,
 }
 
-impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> PublicParameters for PublicParams<'a, F, C>
+impl<'a, F: CurveCycleEquipped, C1: StepCircuit<F>> PublicParameters for PublicParams<F, C1>
 where
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
 }
 
-impl<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a, M: MultiFrameTrait<'a, F, C>>
-    Prover<'a, '_, F, C, M> for NovaProver<'a, F, C, M>
+impl<
+        'a,
+        F: CurveCycleEquipped,
+        C: Coprocessor<F> + 'a,
+        M: StepCircuit<F> + MultiFrameTrait<'a, F, C>,
+    > Prover<'a, '_, F, C, M> for NovaProver<'a, F, C, M>
 where
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
-    type PublicParams = PublicParams<'a, F, C>;
+    type PublicParams = PublicParams<F, M>;
     fn new(reduction_count: usize, lang: Lang<F, C>) -> Self {
         NovaProver::<F, C, M> {
             reduction_count,
@@ -278,7 +281,7 @@ where
     /// Proves the computation given the public parameters, frames, and store.
     pub fn prove(
         &'a self,
-        pp: &'a PublicParams<'_, F, C>,
+        pp: &'a PublicParams<F, MultiFrame<'a, F, C>>,
         frames: &[Frame<IO<F>, Witness<F>, C>],
         store: &'a mut Store<F>,
         lang: Arc<Lang<F, C>>,
@@ -297,7 +300,7 @@ where
     /// Evaluates and proves the computation given the public parameters, expression, environment, and store.
     pub fn evaluate_and_prove(
         &'a self,
-        pp: &'a PublicParams<'_, F, C>,
+        pp: &'a PublicParams<F, MultiFrame<'a, F, C>>,
         expr: Ptr<F>,
         env: Ptr<F>,
         store: &'a mut Store<F>,
@@ -422,7 +425,7 @@ where
 {
     /// Proves the computation recursively, generating a recursive SNARK proof.
     pub fn prove_recursively(
-        pp: &'a PublicParams<'_, F, C>,
+        pp: &'a PublicParams<F, MultiFrame<'a, F, C>>,
         store: &'a Store<F>,
         circuits: &[C1<'a, F, C>],
         num_iters_per_step: usize,
@@ -442,7 +445,7 @@ where
         let (_circuit_primary, circuit_secondary): (
             MultiFrame<'_, F, C>,
             TrivialTestCircuit<<G2<F> as Group>::Scalar>,
-        ) = C1::<'a>::circuits(num_iters_per_step, lang);
+        ) = crate::proof::nova::circuits(num_iters_per_step, lang);
 
         dbg!(circuits.len());
 
@@ -556,7 +559,10 @@ where
     }
 
     /// Compresses the proof using a (Spartan) Snark (finishing step)
-    pub fn compress(self, pp: &'a PublicParams<'_, F, C>) -> Result<Self, ProofError> {
+    pub fn compress(
+        self,
+        pp: &'a PublicParams<F, MultiFrame<'a, F, C>>,
+    ) -> Result<Self, ProofError> {
         match &self {
             Self::Recursive(recursive_snark) => Ok(Self::Compressed(Box::new(CompressedSNARK::<
                 _,
@@ -577,7 +583,7 @@ where
     /// Verifies the proof given the public parameters, the number of steps, and the input and output values.
     pub fn verify(
         &self,
-        pp: &PublicParams<'_, F, C>,
+        pp: &PublicParams<F, MultiFrame<'a, F, C>>,
         num_steps: usize,
         z0: &[F],
         zi: &[F],

--- a/src/proof/nova_lem.rs
+++ b/src/proof/nova_lem.rs
@@ -24,7 +24,7 @@ use crate::config::CONFIG;
 use crate::error::ProofError;
 use crate::eval::{lang::DummyCoprocessor, lang::Lang};
 use crate::field::LurkField;
-use crate::proof::{Prover, PublicParameters};
+use crate::proof::{MultiFrameTrait, Prover, PublicParameters};
 
 use crate::lem::{circuit::MultiFrame, interpreter::Frame, store::Store, Func};
 
@@ -141,7 +141,8 @@ where
 {
 }
 
-impl<'a, F: CurveCycleEquipped> Prover<'a, '_, F, DummyCoprocessor<F>> for NovaProver<F>
+impl<'a, F: CurveCycleEquipped, M: MultiFrameTrait<F, DummyCoprocessor<F>>>
+    Prover<'a, '_, F, DummyCoprocessor<F>, M> for NovaProver<F>
 where
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,

--- a/src/proof/nova_lem.rs
+++ b/src/proof/nova_lem.rs
@@ -96,7 +96,7 @@ impl<'a, F: LurkField, C: Coprocessor<F>> StepCircuit<F> for MultiFrame<'a, F, C
             None => {
                 assert!(self.store.is_none());
                 let s = self.func.init_store();
-                let blank_frame = Frame::blank(&*self.func);
+                let blank_frame = Frame::blank(&self.func);
                 let frames = vec![blank_frame; self.reduction_count];
                 self.synthesize_frames(cs, &s, &input, &frames, true)?
             }

--- a/src/public_parameters/disk_cache.rs
+++ b/src/public_parameters/disk_cache.rs
@@ -7,7 +7,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use nova::traits::Group;
 
 use crate::coprocessor::Coprocessor;
-use crate::proof::nova::{CurveCycleEquipped, PublicParams, G1, G2};
+use crate::proof::nova::{CurveCycleEquipped, PublicParams, C1, G1, G2};
 use crate::public_parameters::error::Error;
 
 pub(crate) struct PublicParamDiskCache<F, C>
@@ -38,7 +38,7 @@ where
         self.dir.join(Utf8PathBuf::from(key))
     }
 
-    pub(crate) fn get(&self, key: &str) -> Result<PublicParams<'static, F, C>, Error> {
+    pub(crate) fn get(&self, key: &str) -> Result<PublicParams<F, C1<'static, F, C>>, Error> {
         let file = File::open(self.key_path(key))?;
         let reader = BufReader::new(file);
         bincode::deserialize_from(reader).map_err(|e| {
@@ -54,7 +54,11 @@ where
         Ok(bytes)
     }
 
-    pub(crate) fn set(&self, key: &str, data: &PublicParams<'static, F, C>) -> Result<(), Error> {
+    pub(crate) fn set(
+        &self,
+        key: &str,
+        data: &PublicParams<F, C1<'static, F, C>>,
+    ) -> Result<(), Error> {
         let file = File::create(self.key_path(key)).expect("failed to create file");
         let writer = BufWriter::new(&file);
         bincode::serialize_into(writer, &data).map_err(|e| {

--- a/src/public_parameters/mod.rs
+++ b/src/public_parameters/mod.rs
@@ -14,6 +14,7 @@ mod disk_cache;
 pub mod error;
 mod mem_cache;
 
+use crate::proof::nova::C1;
 use crate::public_parameters::error::Error;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -33,7 +34,7 @@ pub fn public_params<F: CurveCycleEquipped, C: Coprocessor<F> + 'static>(
     abomonated: bool,
     lang: Arc<Lang<F, C>>,
     disk_cache_path: &Utf8Path,
-) -> Result<Arc<PublicParams<'static, F, C>>, Error>
+) -> Result<Arc<PublicParams<F, C1<'static, F, C>>>, Error>
 where
     F::CK1: Sync + Send,
     F::CK2: Sync + Send,
@@ -62,7 +63,7 @@ pub fn with_public_params<C, F: CurveCycleEquipped, Fn, T>(
 ) -> Result<T, Error>
 where
     C: Coprocessor<F> + 'static,
-    Fn: FnOnce(&PublicParams<'static, F, C>) -> T,
+    Fn: FnOnce(&PublicParams<F, C1<'static, F, C>>) -> T,
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {

--- a/tests/lurk-lib-tests.rs
+++ b/tests/lurk-lib-tests.rs
@@ -1,6 +1,6 @@
 use camino::Utf8PathBuf;
 use lurk::{
-    cli::{backend::Backend, repl_lem::ReplLEM},
+    cli::backend::Backend,
     eval::lang::{Coproc, Lang},
     repl::{repl, ReplState},
 };
@@ -60,11 +60,11 @@ fn lurk_cli_tests_lem() {
         );
     }
 
-    let mut repl = ReplLEM::new(None, 10, 100000000, Backend::Nova);
+    //     let mut repl = ReplLEM::new(None, 10, 100000000, Backend::Nova);
 
-    for f in TEST_FILES {
-        let joined = Utf8PathBuf::from_path_buf(example_dir.join(f)).unwrap();
+    // for f in TEST_FILES {
+    //     let joined = Utf8PathBuf::from_path_buf(example_dir.join(f)).unwrap();
 
-        let _ = repl.load_file(&joined);
-    }
+    //     let _ = repl.load_file(&joined);
+    // }
 }


### PR DESCRIPTION
This PR attempts to partially address #639 my creating `MultiFrameTrait` and implementing it for `MultiFrame`.

In order to accomplish this without also implementing the LEM equivalent, it comments out inclusion of the duplicated LEM code as necessary.

A logical next step would be an attempt to implement `MultiFrameTrait` for LEM in such a way that the duplication can be reduced or eliminated.
