### PR TITLE
chore: Remove `sppark` crate patch from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,6 +189,5 @@ name = "public_params"
 harness = false
 
 [patch.crates-io]
-sppark = { git = "https://github.com/supranational/sppark", rev="5fea26f43cc5d12a77776c70815e7c722fd1f8a7" }
 # This is needed to ensure halo2curves, which imports pasta-curves, uses the *same* traits in bn256_grumpkin
 pasta_curves = { git="https://github.com/lurk-lab/pasta_curves", branch="dev" }


### PR DESCRIPTION
- Removed the unnecessary `sppark` crate from the patch section in the project's Cargo.toml file
- Witnesses the release of sppark 0.1.5

Fixes #272