### PR TITLE
refactor: Refactor error handling (mostly in circuits)

### DIFF
--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -84,8 +84,7 @@ impl<F: LurkField> CoCircuit<F> for Sha256Coprocessor<F> {
                 let num = allocate_constant(
                     &mut cs.namespace(|| format!("allocate result {i}")),
                     F::from_u128(self.expected[i]),
-                )
-                .unwrap();
+                );
 
                 let eq = alloc_equal(
                     cs.namespace(|| format!("equate numbers {i}")),

--- a/lurk-macros/src/lib.rs
+++ b/lurk-macros/src/lib.rs
@@ -198,14 +198,14 @@ enum Lurk {
 }
 
 impl Lurk {
-    fn parse_raw(input: proc_macro2::TokenStream) -> Result<Self, syn::Error> {
+    fn parse_raw(input: proc_macro2::TokenStream) -> Self {
         // We just immediately turn the `TokenStream` into a string then delegate
         // to the Lurk parser. Although this is a little silly, it is simple.
         let string = input.to_string();
         let mut input_it = input.into_iter().peekable();
         while input_it.next().is_some() {}
 
-        Ok(Lurk::Src(string))
+        Lurk::Src(string)
     }
 
     fn emit(&self) -> TokenStream {
@@ -230,7 +230,7 @@ pub fn let_store(_tokens: TokenStream) -> TokenStream {
 
 #[proc_macro]
 pub fn lurk(tokens: TokenStream) -> TokenStream {
-    Lurk::parse_raw(tokens.into()).unwrap().emit()
+    Lurk::parse_raw(tokens.into()).emit()
 }
 
 /// This macro is used to generate round-trip serialization tests.

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -3291,10 +3291,10 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         })
         .expect("alloc was passed an unfallible closure, yet failed!");
 
-        let open_secret = AllocatedNum::alloc(&mut cs.namespace(|| "open_secret"), || {
-            Ok(open_secret_scalar)
-        })
-        .expect("alloc was passed an unfallible closure, yet failed!");
+        let open_secret =
+            AllocatedNum::alloc_infallible(&mut cs.namespace(|| "open_secret"), || {
+                open_secret_scalar
+            });
 
         let arg1 = AllocatedPtr::by_index(1, &continuation_components);
 
@@ -5005,18 +5005,14 @@ fn enforce_u64_div_mod<F: LurkField, CS: ConstraintSystem<F>>(
         (0, 0) // Dummy
     };
 
-    let alloc_r_num = AllocatedNum::alloc(&mut cs.namespace(|| "r num"), || Ok(F::from_u64(r)))
-        .expect("alloc was passed an unfallible closure, yet failed!");
-    let alloc_q_num = AllocatedNum::alloc(&mut cs.namespace(|| "q num"), || Ok(F::from_u64(q)))
-        .expect("alloc was passed an unfallible closure, yet failed!");
-    let alloc_arg1_num = AllocatedNum::alloc(&mut cs.namespace(|| "arg1 num"), || {
-        Ok(F::from_u64(arg1_u64))
-    })
-    .expect("alloc was passed an unfallible closure, yet failed!");
-    let alloc_arg2_num = AllocatedNum::alloc(&mut cs.namespace(|| "arg2 num"), || {
-        Ok(F::from_u64(arg2_u64))
-    })
-    .expect("alloc was passed an unfallible closure, yet failed!");
+    let alloc_r_num =
+        AllocatedNum::alloc_infallible(&mut cs.namespace(|| "r num"), || F::from_u64(r));
+    let alloc_q_num =
+        AllocatedNum::alloc_infallible(&mut cs.namespace(|| "q num"), || F::from_u64(q));
+    let alloc_arg1_num =
+        AllocatedNum::alloc_infallible(&mut cs.namespace(|| "arg1 num"), || F::from_u64(arg1_u64));
+    let alloc_arg2_num =
+        AllocatedNum::alloc_infallible(&mut cs.namespace(|| "arg2 num"), || F::from_u64(arg2_u64));
 
     // a = b * q + r
     let product_u64mod = mul(
@@ -5094,8 +5090,7 @@ fn allocate_unconstrained_bignum<F: LurkField, CS: ConstraintSystem<F>>(
     let mut bytes_padded = [0u8; 32];
     bytes_padded[0..bytes_le.len()].copy_from_slice(&bytes_le);
     let ff = F::from_bytes(&bytes_padded).unwrap();
-    AllocatedNum::alloc(&mut cs.namespace(|| "num"), || Ok(ff))
-        .expect("alloc was passed an unfallible closure, yet failed!")
+    AllocatedNum::alloc_infallible(&mut cs.namespace(|| "num"), || ff)
 }
 
 fn car_cdr_named<F: LurkField, CS: ConstraintSystem<F>>(
@@ -5929,12 +5924,11 @@ mod tests {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
         let alloc_most_positive =
-            AllocatedNum::alloc(&mut cs.namespace(|| "most positive"), || {
-                Ok(Fr::most_positive())
-            })
-            .expect("alloc was passed an unfallible closure, yet failed!");
-        let alloc_num = AllocatedNum::alloc(&mut cs.namespace(|| "num"), || Ok(Fr::from_u64(42)))
-            .expect("alloc was passed an unfallible closure, yet failed!");
+            AllocatedNum::alloc_infallible(&mut cs.namespace(|| "most positive"), || {
+                Fr::most_positive()
+            });
+        let alloc_num =
+            AllocatedNum::alloc_infallible(&mut cs.namespace(|| "num"), || Fr::from_u64(42));
         let cond = Boolean::Constant(true);
 
         let res = enforce_less_than_bound(

--- a/src/circuit/gadgets/constraints.rs
+++ b/src/circuit/gadgets/constraints.rs
@@ -1160,10 +1160,8 @@ mod tests {
         fn prop_add_constraint((x, y) in any::<(FWrap<Fr>, FWrap<Fr>)>()) {
             let mut cs = TestConstraintSystem::<Fr>::new();
 
-            let a = AllocatedNum::alloc(cs.namespace(|| "a"), || Ok(x.0))
-                .expect("alloc failed");
-            let b = AllocatedNum::alloc(cs.namespace(|| "b"), || Ok(y.0))
-                .expect("alloc failed");
+            let a = AllocatedNum::alloc_infallible(cs.namespace(|| "a"), || x.0);
+            let b = AllocatedNum::alloc_infallible(cs.namespace(|| "b"), || y.0);
 
             let res = add(cs.namespace(|| "a+b"), &a, &b).expect("add failed");
 
@@ -1180,10 +1178,8 @@ mod tests {
 
                let mut cs = TestConstraintSystem::<Fr>::new();
 
-            let a = AllocatedNum::alloc(cs.namespace(|| "a"), || Ok(x.0))
-                .expect("alloc failed");
-            let b = AllocatedNum::alloc(cs.namespace(|| "b"), || Ok(y.0))
-                .expect("alloc failed");
+            let a = AllocatedNum::alloc_infallible(cs.namespace(|| "a"), || x.0);
+            let b = AllocatedNum::alloc_infallible(cs.namespace(|| "b"), || y.0);
 
             let res = sub(cs.namespace(|| "a-b"), &a, &b).expect("subtraction failed");
 

--- a/src/circuit/gadgets/constraints.rs
+++ b/src/circuit/gadgets/constraints.rs
@@ -96,11 +96,10 @@ pub(crate) fn add<F: PrimeField, CS: ConstraintSystem<F>>(
 /// Creates a linear combination representing the popcount (sum of one bits) of `v`.
 pub(crate) fn popcount_lc<F: PrimeField, CS: ConstraintSystem<F>>(
     v: &[Boolean],
-) -> Result<LinearCombination<F>, SynthesisError> {
-    v.iter()
-        .try_fold(LinearCombination::<F>::zero(), |acc, bit| {
-            add_to_lc::<F, CS>(bit, acc, F::ONE)
-        })
+) -> LinearCombination<F> {
+    v.iter().fold(LinearCombination::<F>::zero(), |acc, bit| {
+        add_to_lc::<F, CS>(bit, acc, F::ONE)
+    })
 }
 
 /// Adds a constraint to CS, enforcing that the addition of the allocated numbers in vector `v`
@@ -109,8 +108,8 @@ pub(crate) fn popcount_equal<F: PrimeField, CS: ConstraintSystem<F>>(
     cs: &mut CS,
     v: &[Boolean],
     sum: Variable,
-) -> Result<(), SynthesisError> {
-    let popcount = popcount_lc::<F, CS>(v)?;
+) {
+    let popcount = popcount_lc::<F, CS>(v);
 
     // popcount * 1 = sum
     cs.enforce(
@@ -119,8 +118,6 @@ pub(crate) fn popcount_equal<F: PrimeField, CS: ConstraintSystem<F>>(
         |lc| lc + CS::one(),
         |lc| lc + sum,
     );
-
-    Ok(())
 }
 
 /// Adds a constraint to CS, enforcing that the addition of the allocated numbers in vector `v`
@@ -132,7 +129,7 @@ pub(crate) fn popcount_equal<F: PrimeField, CS: ConstraintSystem<F>>(
 pub(crate) fn enforce_popcount_one<F: PrimeField, CS: ConstraintSystem<F>>(
     cs: &mut CS,
     v: &[Boolean],
-) -> Result<(), SynthesisError> {
+) {
     popcount_equal(cs, v, CS::one())
 }
 
@@ -140,14 +137,12 @@ pub(crate) fn add_to_lc<F: PrimeField, CS: ConstraintSystem<F>>(
     b: &Boolean,
     lc: LinearCombination<F>,
     scalar: F,
-) -> Result<LinearCombination<F>, SynthesisError> {
-    let v_lc = match b {
+) -> LinearCombination<F> {
+    match b {
         Boolean::Constant(c) => lc + (if *c { scalar } else { F::ZERO }, CS::one()),
         Boolean::Is(ref v) => lc + (scalar, v.get_variable()),
         Boolean::Not(ref v) => lc + (scalar, CS::one()) - (scalar, v.get_variable()),
-    };
-
-    Ok(v_lc)
+    }
 }
 
 /// If premise is true, enforce `a` fits into 64 bits. It shows a non-deterministic
@@ -177,7 +172,7 @@ pub(crate) fn implies_u64<F: LurkField, CS: ConstraintSystem<F>>(
         premise,
         &bits,
         a,
-    )?;
+    );
 
     Ok(())
 }
@@ -188,11 +183,11 @@ pub(crate) fn implies_pack<F: LurkField, CS: ConstraintSystem<F>>(
     premise: &Boolean,
     v: &[Boolean],
     num: &AllocatedNum<F>,
-) -> Result<(), SynthesisError> {
+) {
     let mut coeff = F::ONE;
     let mut pack = LinearCombination::<F>::zero();
     for b in v {
-        pack = add_to_lc::<F, CS>(b, pack, coeff)?;
+        pack = add_to_lc::<F, CS>(b, pack, coeff);
         coeff = coeff.double();
     }
     let diff = |_| pack - num.get_variable();
@@ -200,8 +195,6 @@ pub(crate) fn implies_pack<F: LurkField, CS: ConstraintSystem<F>>(
     let zero = |lc| lc;
 
     cs.enforce(|| "pack", diff, premise_lc, zero);
-
-    Ok(())
 }
 
 /// Enforce v is the bit decomposition of num, therefore we have that 0 <= num < 2ˆ(sizeof(v)).
@@ -209,7 +202,7 @@ pub(crate) fn enforce_pack<F: LurkField, CS: ConstraintSystem<F>>(
     cs: CS,
     v: &[Boolean],
     num: &AllocatedNum<F>,
-) -> Result<(), SynthesisError> {
+) {
     implies_pack(cs, &Boolean::Constant(true), v, num)
 }
 
@@ -726,7 +719,7 @@ pub(crate) fn enforce_implication_lc<
     mut cs: CS,
     premise: &Boolean,
     implication_lc: L,
-) -> Result<(), SynthesisError> {
+) {
     let premise_b = premise.lc(CS::one(), F::ONE);
     let premise_c = premise_b.clone();
 
@@ -737,8 +730,6 @@ pub(crate) fn enforce_implication_lc<
         |_| premise_b,
         |_| premise_c,
     );
-
-    Ok(())
 }
 
 /// Takes a boolean premise and a function that produces a `LinearCombination` (with same specification as `enforce`).
@@ -751,12 +742,10 @@ pub(crate) fn enforce_implication_lc_zero<
     mut cs: CS,
     premise: &Boolean,
     implication_lc: L,
-) -> Result<(), SynthesisError> {
+) {
     let premise_a = premise.lc(CS::one(), F::ONE);
     // premise * implication = zero
     cs.enforce(|| "implication", |_| premise_a, implication_lc, |lc| lc);
-
-    Ok(())
 }
 
 /// Adds a constraint to CS, enforcing that the number of true bits in `Boolean` vector `v`
@@ -767,10 +756,10 @@ pub(crate) fn enforce_selector_with_premise<F: PrimeField, CS: ConstraintSystem<
     cs: &mut CS,
     premise: &Boolean,
     v: &[Boolean],
-) -> Result<(), SynthesisError> {
-    let popcount = popcount_lc::<F, CS>(v)?;
+) {
+    let popcount = popcount_lc::<F, CS>(v);
 
-    enforce_implication_lc(cs, premise, |_| popcount)
+    enforce_implication_lc(cs, premise, |_| popcount);
 }
 
 /// Enforce `premise` implies `implication`.
@@ -778,10 +767,10 @@ pub(crate) fn enforce_implication<CS: ConstraintSystem<F>, F: PrimeField>(
     cs: CS,
     premise: &Boolean,
     implication: &Boolean,
-) -> Result<(), SynthesisError> {
+) {
     enforce_implication_lc(cs, premise, |_|
                            // One if implication is true, zero otherwise.
-                           implication.lc(CS::one(), F::ONE))
+                           implication.lc(CS::one(), F::ONE));
 }
 
 /// Enforce equality of two allocated numbers given an implication premise
@@ -790,7 +779,7 @@ pub(crate) fn implies_equal<CS: ConstraintSystem<F>, F: PrimeField>(
     premise: &Boolean,
     a: &AllocatedNum<F>,
     b: &AllocatedNum<F>,
-) -> Result<(), SynthesisError> {
+) {
     enforce_implication_lc_zero(cs, premise, |lc| {
         // Zero iff `a` == `b`.
         lc + a.get_variable() - b.get_variable()
@@ -803,7 +792,7 @@ pub(crate) fn implies_equal_const<CS: ConstraintSystem<F>, F: PrimeField>(
     premise: &Boolean,
     a: &AllocatedNum<F>,
     b: F,
-) -> Result<(), SynthesisError> {
+) {
     enforce_implication_lc_zero(cs, premise, |lc| lc + a.get_variable() - (b, CS::one()))
 }
 
@@ -892,7 +881,7 @@ pub(crate) fn implies_equal_zero<CS: ConstraintSystem<F>, F: PrimeField>(
     cs: &mut CS,
     premise: &Boolean,
     a: &AllocatedNum<F>,
-) -> Result<(), SynthesisError> {
+) {
     enforce_implication_lc_zero(cs, premise, |lc| lc + a.get_variable())
 }
 
@@ -1004,7 +993,7 @@ mod tests {
                 let mut cs = TestConstraintSystem::<Fr>::new();
                 let num = AllocatedNum::alloc(cs.namespace(|| "num"), || Ok(Fr::from(n))).unwrap();
                 let pb = Boolean::constant(premise);
-                let _ = implies_equal_zero(&mut cs.namespace(|| "implies equal zero"), &pb, &num);
+                implies_equal_zero(&mut cs.namespace(|| "implies equal zero"), &pb, &num);
                 cs.is_satisfied()
             };
 
@@ -1021,7 +1010,7 @@ mod tests {
                 let a_num = AllocatedNum::alloc(cs.namespace(|| "a_num"), || Ok(a)).unwrap();
                 let b_num = AllocatedNum::alloc(cs.namespace(|| "b_num"), || Ok(b)).unwrap();
                 let pb = Boolean::constant(premise);
-                let _ = implies_equal(&mut cs.namespace(|| "implies equal"), &pb, &a_num, &b_num);
+                implies_equal(&mut cs.namespace(|| "implies equal"), &pb, &a_num, &b_num);
                 cs.is_satisfied()
             };
 
@@ -1075,7 +1064,7 @@ mod tests {
                 let mut cs = TestConstraintSystem::<Fr>::new();
                 let num = AllocatedNum::alloc(cs.namespace(|| "num"), || Ok(n)).unwrap();
                 let pb = Boolean::constant(premise);
-                let _ = implies_equal_const(&mut cs.namespace(|| "implies equal zero"), &pb, &num, t);
+                implies_equal_const(&mut cs.namespace(|| "implies equal zero"), &pb, &num, t);
                 cs.is_satisfied()
             };
 
@@ -1100,7 +1089,7 @@ mod tests {
                     v[e] = Boolean::constant(true);
                 };
                 let alloc_sum = AllocatedNum::alloc(cs.namespace(|| "sum"), || Ok(Fr::from(sum)));
-                let _ = popcount_equal(&mut cs.namespace(|| "popcount equal"), &v, alloc_sum.unwrap().get_variable());
+                popcount_equal(&mut cs.namespace(|| "popcount equal"), &v, alloc_sum.unwrap().get_variable());
                 assert_eq!(cs.is_satisfied(), result);
             };
 
@@ -1151,7 +1140,7 @@ mod tests {
                     }
                     let mut cs = TestConstraintSystem::<Fr>::new();
                     let p = Boolean::Constant(premise);
-                    let _ = enforce_selector_with_premise(&mut cs.namespace(|| "enforce selector with premise"), &p, &v);
+                    enforce_selector_with_premise(&mut cs.namespace(|| "enforce selector with premise"), &p, &v);
                     assert_eq!(cs.is_satisfied(), result);
                 };
 
@@ -1278,7 +1267,7 @@ mod tests {
                 cs.namespace(|| "enforce_implication_lc"),
                 &premise,
                 |_| lc,
-            ).expect("enforce_implication_lc failed");
+            );
 
 
             prop_assert!((!premise_val || lc_val) == cs.is_satisfied())
@@ -1308,8 +1297,7 @@ mod tests {
             cs.namespace(|| "enforce_implication_lc_big"),
             &premise_true,
             |_| test_lc_big.clone(),
-        )
-        .expect("enforce_implication_lc failed");
+        );
 
         assert!(!cs.is_satisfied());
 
@@ -1328,8 +1316,7 @@ mod tests {
             cs.namespace(|| "enforce_implication_lc_big_with_false"),
             &premise_false,
             |_| test_lc_big,
-        )
-        .expect("enforce_implication_lc failed");
+        );
 
         assert!(cs.is_satisfied());
 
@@ -1355,8 +1342,7 @@ mod tests {
             cs.namespace(|| "enforce_implication_lc_arb_num"),
             &premise_true,
             |_| test_lc_arb_num,
-        )
-        .expect("enforce_implication_lc failed");
+        );
 
         assert!(cs.is_satisfied());
     }
@@ -1385,8 +1371,7 @@ mod tests {
             cs.namespace(|| "enforce_implication_lc_big"),
             &premise_true,
             |_| test_lc_big.clone(),
-        )
-        .expect("enforce_implication_lc failed");
+        );
 
         assert!(!cs.is_satisfied());
 
@@ -1409,8 +1394,7 @@ mod tests {
             cs.namespace(|| "enforce_implication_lc_one"),
             &premise_true,
             |_| test_lc_one.clone(),
-        )
-        .expect("enforce_implication_lc failed");
+        );
 
         assert!(!cs.is_satisfied());
 
@@ -1430,8 +1414,7 @@ mod tests {
             cs.namespace(|| "enforce_implication_lc_big_with_false"),
             &premise_false,
             |_| test_lc_big,
-        )
-        .expect("enforce_implication_lc failed");
+        );
 
         assert!(cs.is_satisfied());
 
@@ -1455,8 +1438,7 @@ mod tests {
             cs.namespace(|| "enforce_implication_lc_arb_num"),
             &premise_true,
             |_| test_lc_arb_num,
-        )
-        .expect("enforce_implication_lc failed");
+        );
 
         assert!(cs.is_satisfied());
     }

--- a/src/circuit/gadgets/data.rs
+++ b/src/circuit/gadgets/data.rs
@@ -171,10 +171,9 @@ impl<F: LurkField> GlobalAllocations<F> {
             Op2::Quotient.allocate_constant(&mut cs.namespace(|| "op2_quotient_tag"));
         let op2_modulo_tag = Op2::Modulo.allocate_constant(&mut cs.namespace(|| "op2_modulo_tag"));
         let op2_numequal_tag =
-            AllocatedNum::alloc(&mut cs.namespace(|| "op2_numequal_tag"), || {
-                Ok(Op2::NumEqual.to_field())
-            })
-            .expect("alloc was passed an unfallible closure, yet failed!");
+            AllocatedNum::alloc_infallible(&mut cs.namespace(|| "op2_numequal_tag"), || {
+                Op2::NumEqual.to_field()
+            });
         let op2_less_tag = Op2::Less.allocate_constant(&mut cs.namespace(|| "op2_less_tag"));
         let op2_less_equal_tag =
             Op2::LessEqual.allocate_constant(&mut cs.namespace(|| "op2_less_equal_tag"));
@@ -182,10 +181,10 @@ impl<F: LurkField> GlobalAllocations<F> {
             Op2::Greater.allocate_constant(&mut cs.namespace(|| "op2_greater_tag"));
         let op2_greater_equal_tag =
             Op2::GreaterEqual.allocate_constant(&mut cs.namespace(|| "op2_greater_equal_tag"));
-        let op2_equal_tag = AllocatedNum::alloc(&mut cs.namespace(|| "op2_equal_tag"), || {
-            Ok(Op2::Equal.to_field())
-        })
-        .expect("alloc was passed an unfallible closure, yet failed!");
+        let op2_equal_tag =
+            AllocatedNum::alloc_infallible(&mut cs.namespace(|| "op2_equal_tag"), || {
+                Op2::Equal.to_field()
+            });
 
         let c = store.expect_constants();
 
@@ -385,8 +384,7 @@ pub fn allocate_constant<F: LurkField, CS: ConstraintSystem<F>>(
     cs: &mut CS,
     val: F,
 ) -> AllocatedNum<F> {
-    let allocated = AllocatedNum::<F>::alloc(cs.namespace(|| "allocate"), || Ok(val))
-        .expect("alloc was passed an unfallible closure, yet failed!");
+    let allocated = AllocatedNum::<F>::alloc_infallible(cs.namespace(|| "allocate"), || val);
 
     // allocated * 1 = val
     cs.enforce(

--- a/src/circuit/gadgets/data.rs
+++ b/src/circuit/gadgets/data.rs
@@ -116,81 +116,76 @@ impl<F: LurkField> GlobalAllocations<F> {
             &store.strnil(),
         )?;
 
-        let thunk_tag = ExprTag::Thunk.allocate_constant(&mut cs.namespace(|| "thunk_tag"))?;
-        let cons_tag = ExprTag::Cons.allocate_constant(&mut cs.namespace(|| "cons_tag"))?;
-        let char_tag = ExprTag::Char.allocate_constant(&mut cs.namespace(|| "char_tag"))?;
-        let str_tag = ExprTag::Str.allocate_constant(&mut cs.namespace(|| "str_tag"))?;
-        let num_tag = ExprTag::Num.allocate_constant(&mut cs.namespace(|| "num_tag"))?;
-        let u64_tag = ExprTag::U64.allocate_constant(&mut cs.namespace(|| "u64_tag"))?;
-        let comm_tag = ExprTag::Comm.allocate_constant(&mut cs.namespace(|| "comm_tag"))?;
-        let fun_tag = ExprTag::Fun.allocate_constant(&mut cs.namespace(|| "fun_tag"))?;
+        let thunk_tag = ExprTag::Thunk.allocate_constant(&mut cs.namespace(|| "thunk_tag"));
+        let cons_tag = ExprTag::Cons.allocate_constant(&mut cs.namespace(|| "cons_tag"));
+        let char_tag = ExprTag::Char.allocate_constant(&mut cs.namespace(|| "char_tag"));
+        let str_tag = ExprTag::Str.allocate_constant(&mut cs.namespace(|| "str_tag"));
+        let num_tag = ExprTag::Num.allocate_constant(&mut cs.namespace(|| "num_tag"));
+        let u64_tag = ExprTag::U64.allocate_constant(&mut cs.namespace(|| "u64_tag"));
+        let comm_tag = ExprTag::Comm.allocate_constant(&mut cs.namespace(|| "comm_tag"));
+        let fun_tag = ExprTag::Fun.allocate_constant(&mut cs.namespace(|| "fun_tag"));
 
         let outermost_cont_tag =
-            ContTag::Outermost.allocate_constant(&mut cs.namespace(|| "outermost_cont_tag"))?;
+            ContTag::Outermost.allocate_constant(&mut cs.namespace(|| "outermost_cont_tag"));
         let lookup_cont_tag =
-            ContTag::Lookup.allocate_constant(&mut cs.namespace(|| "lookup_cont_tag"))?;
-        let let_cont_tag = ContTag::Let.allocate_constant(&mut cs.namespace(|| "let_cont_tag"))?;
+            ContTag::Lookup.allocate_constant(&mut cs.namespace(|| "lookup_cont_tag"));
+        let let_cont_tag = ContTag::Let.allocate_constant(&mut cs.namespace(|| "let_cont_tag"));
         let letrec_cont_tag =
-            ContTag::LetRec.allocate_constant(&mut cs.namespace(|| "letrec_cont_tag"))?;
-        let tail_cont_tag =
-            ContTag::Tail.allocate_constant(&mut cs.namespace(|| "tail_cont_tag"))?;
+            ContTag::LetRec.allocate_constant(&mut cs.namespace(|| "letrec_cont_tag"));
+        let tail_cont_tag = ContTag::Tail.allocate_constant(&mut cs.namespace(|| "tail_cont_tag"));
         let call0_cont_tag =
-            ContTag::Call0.allocate_constant(&mut cs.namespace(|| "call0_cont_tag"))?;
-        let call_cont_tag =
-            ContTag::Call.allocate_constant(&mut cs.namespace(|| "call_cont_tag"))?;
+            ContTag::Call0.allocate_constant(&mut cs.namespace(|| "call0_cont_tag"));
+        let call_cont_tag = ContTag::Call.allocate_constant(&mut cs.namespace(|| "call_cont_tag"));
         let call2_cont_tag =
-            ContTag::Call2.allocate_constant(&mut cs.namespace(|| "call2_cont_tag"))?;
-        let unop_cont_tag =
-            ContTag::Unop.allocate_constant(&mut cs.namespace(|| "unop_cont_tag"))?;
-        let emit_cont_tag =
-            ContTag::Emit.allocate_constant(&mut cs.namespace(|| "emit_cont_tag"))?;
+            ContTag::Call2.allocate_constant(&mut cs.namespace(|| "call2_cont_tag"));
+        let unop_cont_tag = ContTag::Unop.allocate_constant(&mut cs.namespace(|| "unop_cont_tag"));
+        let emit_cont_tag = ContTag::Emit.allocate_constant(&mut cs.namespace(|| "emit_cont_tag"));
         let binop_cont_tag =
-            ContTag::Binop.allocate_constant(&mut cs.namespace(|| "binop_cont_tag"))?;
+            ContTag::Binop.allocate_constant(&mut cs.namespace(|| "binop_cont_tag"));
         let binop2_cont_tag =
-            ContTag::Binop2.allocate_constant(&mut cs.namespace(|| "binop2_cont_tag"))?;
-        let if_cont_tag = ContTag::If.allocate_constant(&mut cs.namespace(|| "if_cont_tag"))?;
+            ContTag::Binop2.allocate_constant(&mut cs.namespace(|| "binop2_cont_tag"));
+        let if_cont_tag = ContTag::If.allocate_constant(&mut cs.namespace(|| "if_cont_tag"));
 
-        let op1_car_tag = Op1::Car.allocate_constant(&mut cs.namespace(|| "op1_car_tag"))?;
-        let op1_cdr_tag = Op1::Cdr.allocate_constant(&mut cs.namespace(|| "op1_cdr_tag"))?;
-        let op1_commit_tag =
-            Op1::Commit.allocate_constant(&mut cs.namespace(|| "op1_commit_tag"))?;
-        let op1_num_tag = Op1::Num.allocate_constant(&mut cs.namespace(|| "op1_num_tag"))?;
-        let op1_char_tag = Op1::Char.allocate_constant(&mut cs.namespace(|| "op1_char_tag"))?;
-        let op1_u64_tag = Op1::U64.allocate_constant(&mut cs.namespace(|| "op1_u64_tag"))?;
-        let op1_comm_tag = Op1::Comm.allocate_constant(&mut cs.namespace(|| "op1_comm_tag"))?;
-        let op1_open_tag = Op1::Open.allocate_constant(&mut cs.namespace(|| "op1_open_tag"))?;
-        let op1_secret_tag =
-            Op1::Secret.allocate_constant(&mut cs.namespace(|| "op1_secret_tag"))?;
-        let op1_atom_tag = Op1::Atom.allocate_constant(&mut cs.namespace(|| "op1_atom_tag"))?;
-        let op1_emit_tag = Op1::Emit.allocate_constant(&mut cs.namespace(|| "op1_emit_tag"))?;
-        let op2_cons_tag = Op2::Cons.allocate_constant(&mut cs.namespace(|| "op2_cons_tag"))?;
+        let op1_car_tag = Op1::Car.allocate_constant(&mut cs.namespace(|| "op1_car_tag"));
+        let op1_cdr_tag = Op1::Cdr.allocate_constant(&mut cs.namespace(|| "op1_cdr_tag"));
+        let op1_commit_tag = Op1::Commit.allocate_constant(&mut cs.namespace(|| "op1_commit_tag"));
+        let op1_num_tag = Op1::Num.allocate_constant(&mut cs.namespace(|| "op1_num_tag"));
+        let op1_char_tag = Op1::Char.allocate_constant(&mut cs.namespace(|| "op1_char_tag"));
+        let op1_u64_tag = Op1::U64.allocate_constant(&mut cs.namespace(|| "op1_u64_tag"));
+        let op1_comm_tag = Op1::Comm.allocate_constant(&mut cs.namespace(|| "op1_comm_tag"));
+        let op1_open_tag = Op1::Open.allocate_constant(&mut cs.namespace(|| "op1_open_tag"));
+        let op1_secret_tag = Op1::Secret.allocate_constant(&mut cs.namespace(|| "op1_secret_tag"));
+        let op1_atom_tag = Op1::Atom.allocate_constant(&mut cs.namespace(|| "op1_atom_tag"));
+        let op1_emit_tag = Op1::Emit.allocate_constant(&mut cs.namespace(|| "op1_emit_tag"));
+        let op2_cons_tag = Op2::Cons.allocate_constant(&mut cs.namespace(|| "op2_cons_tag"));
         let op2_strcons_tag =
-            Op2::StrCons.allocate_constant(&mut cs.namespace(|| "op2_strcons_tag"))?;
-        let op2_hide_tag = Op2::Hide.allocate_constant(&mut cs.namespace(|| "op2_hide_tag"))?;
-        let op2_begin_tag = Op2::Begin.allocate_constant(&mut cs.namespace(|| "op2_begin_tag"))?;
-        let op2_sum_tag = Op2::Sum.allocate_constant(&mut cs.namespace(|| "op2_sum_tag"))?;
-        let op2_diff_tag = Op2::Diff.allocate_constant(&mut cs.namespace(|| "op2_diff_tag"))?;
+            Op2::StrCons.allocate_constant(&mut cs.namespace(|| "op2_strcons_tag"));
+        let op2_hide_tag = Op2::Hide.allocate_constant(&mut cs.namespace(|| "op2_hide_tag"));
+        let op2_begin_tag = Op2::Begin.allocate_constant(&mut cs.namespace(|| "op2_begin_tag"));
+        let op2_sum_tag = Op2::Sum.allocate_constant(&mut cs.namespace(|| "op2_sum_tag"));
+        let op2_diff_tag = Op2::Diff.allocate_constant(&mut cs.namespace(|| "op2_diff_tag"));
 
         let op2_product_tag =
-            Op2::Product.allocate_constant(&mut cs.namespace(|| "op2_product_tag"))?;
+            Op2::Product.allocate_constant(&mut cs.namespace(|| "op2_product_tag"));
         let op2_quotient_tag =
-            Op2::Quotient.allocate_constant(&mut cs.namespace(|| "op2_quotient_tag"))?;
-        let op2_modulo_tag =
-            Op2::Modulo.allocate_constant(&mut cs.namespace(|| "op2_modulo_tag"))?;
+            Op2::Quotient.allocate_constant(&mut cs.namespace(|| "op2_quotient_tag"));
+        let op2_modulo_tag = Op2::Modulo.allocate_constant(&mut cs.namespace(|| "op2_modulo_tag"));
         let op2_numequal_tag =
             AllocatedNum::alloc(&mut cs.namespace(|| "op2_numequal_tag"), || {
                 Ok(Op2::NumEqual.to_field())
-            })?;
-        let op2_less_tag = Op2::Less.allocate_constant(&mut cs.namespace(|| "op2_less_tag"))?;
+            })
+            .expect("alloc was passed an unfallible closure, yet failed!");
+        let op2_less_tag = Op2::Less.allocate_constant(&mut cs.namespace(|| "op2_less_tag"));
         let op2_less_equal_tag =
-            Op2::LessEqual.allocate_constant(&mut cs.namespace(|| "op2_less_equal_tag"))?;
+            Op2::LessEqual.allocate_constant(&mut cs.namespace(|| "op2_less_equal_tag"));
         let op2_greater_tag =
-            Op2::Greater.allocate_constant(&mut cs.namespace(|| "op2_greater_tag"))?;
+            Op2::Greater.allocate_constant(&mut cs.namespace(|| "op2_greater_tag"));
         let op2_greater_equal_tag =
-            Op2::GreaterEqual.allocate_constant(&mut cs.namespace(|| "op2_greater_equal_tag"))?;
+            Op2::GreaterEqual.allocate_constant(&mut cs.namespace(|| "op2_greater_equal_tag"));
         let op2_equal_tag = AllocatedNum::alloc(&mut cs.namespace(|| "op2_equal_tag"), || {
             Ok(Op2::Equal.to_field())
-        })?;
+        })
+        .expect("alloc was passed an unfallible closure, yet failed!");
 
         let c = store.expect_constants();
 
@@ -206,15 +201,15 @@ impl<F: LurkField> GlobalAllocations<F> {
         defsym!(dummy_arg_ptr, "_", dummy);
         defsym!(lambda_sym, "lambda", lambda);
 
-        let true_num = allocate_constant(&mut cs.namespace(|| "true"), F::ONE)?;
-        let false_num = allocate_constant(&mut cs.namespace(|| "false"), F::ZERO)?;
-        let default_num = allocate_constant(&mut cs.namespace(|| "default"), F::ZERO)?;
+        let true_num = allocate_constant(&mut cs.namespace(|| "true"), F::ONE);
+        let false_num = allocate_constant(&mut cs.namespace(|| "false"), F::ZERO);
+        let default_num = allocate_constant(&mut cs.namespace(|| "default"), F::ZERO);
 
         let power2_32_ff = F::pow_vartime(&F::from_u64(2), [32]);
-        let power2_32_num = allocate_constant(&mut cs.namespace(|| "pow(2,32)"), power2_32_ff)?;
+        let power2_32_num = allocate_constant(&mut cs.namespace(|| "pow(2,32)"), power2_32_ff);
 
         let power2_64_ff = F::pow_vartime(&F::from_u64(2), [64]);
-        let power2_64_num = allocate_constant(&mut cs.namespace(|| "pow(2,64)"), power2_64_ff)?;
+        let power2_64_num = allocate_constant(&mut cs.namespace(|| "pow(2,64)"), power2_64_ff);
 
         Ok(Self {
             terminal_ptr,
@@ -389,8 +384,9 @@ impl<F: LurkField> Ptr<F> {
 pub fn allocate_constant<F: LurkField, CS: ConstraintSystem<F>>(
     cs: &mut CS,
     val: F,
-) -> Result<AllocatedNum<F>, SynthesisError> {
-    let allocated = AllocatedNum::<F>::alloc(cs.namespace(|| "allocate"), || Ok(val))?;
+) -> AllocatedNum<F> {
+    let allocated = AllocatedNum::<F>::alloc(cs.namespace(|| "allocate"), || Ok(val))
+        .expect("alloc was passed an unfallible closure, yet failed!");
 
     // allocated * 1 = val
     cs.enforce(
@@ -400,14 +396,14 @@ pub fn allocate_constant<F: LurkField, CS: ConstraintSystem<F>>(
         |_| Boolean::Constant(true).lc(CS::one(), val),
     );
 
-    Ok(allocated)
+    allocated
 }
 
 impl ExprTag {
     pub fn allocate_constant<F: LurkField, CS: ConstraintSystem<F>>(
         &self,
         cs: &mut CS,
-    ) -> Result<AllocatedNum<F>, SynthesisError> {
+    ) -> AllocatedNum<F> {
         allocate_constant(
             &mut cs.namespace(|| format!("{self:?} tag")),
             self.to_field(),
@@ -419,7 +415,7 @@ impl ContTag {
     pub fn allocate_constant<F: LurkField, CS: ConstraintSystem<F>>(
         &self,
         cs: &mut CS,
-    ) -> Result<AllocatedNum<F>, SynthesisError> {
+    ) -> AllocatedNum<F> {
         allocate_constant(
             &mut cs.namespace(|| format!("{self:?} base continuation tag")),
             self.to_field(),
@@ -431,7 +427,7 @@ impl Op1 {
     pub fn allocate_constant<F: LurkField, CS: ConstraintSystem<F>>(
         &self,
         cs: &mut CS,
-    ) -> Result<AllocatedNum<F>, SynthesisError> {
+    ) -> AllocatedNum<F> {
         allocate_constant(
             &mut cs.namespace(|| format!("{self:?} tag")),
             self.to_field(),
@@ -443,7 +439,7 @@ impl Op2 {
     pub fn allocate_constant<F: LurkField, CS: ConstraintSystem<F>>(
         &self,
         cs: &mut CS,
-    ) -> Result<AllocatedNum<F>, SynthesisError> {
+    ) -> AllocatedNum<F> {
         allocate_constant(
             &mut cs.namespace(|| format!("{self:?} tag")),
             self.to_field(),

--- a/src/circuit/gadgets/macros.rs
+++ b/src/circuit/gadgets/macros.rs
@@ -119,7 +119,7 @@ macro_rules! implies_equal {
             }),
             $condition,
             &equal,
-        )?;
+        );
     }};
 }
 
@@ -154,7 +154,7 @@ macro_rules! implies {
             }),
             $condition,
             $implication,
-        )?;
+        );
     }};
 }
 

--- a/src/circuit/gadgets/pointer.rs
+++ b/src/circuit/gadgets/pointer.rs
@@ -82,7 +82,7 @@ impl<F: LurkField> AllocatedPtr<F> {
         tag: F,
         alloc_hash: AllocatedNum<F>,
     ) -> Result<Self, SynthesisError> {
-        let alloc_tag = allocate_constant(&mut cs.namespace(|| "tag"), tag)?;
+        let alloc_tag = allocate_constant(&mut cs.namespace(|| "tag"), tag);
 
         Ok(AllocatedPtr {
             tag: alloc_tag,
@@ -94,8 +94,8 @@ impl<F: LurkField> AllocatedPtr<F> {
         cs: &mut CS,
         value: ZExprPtr<F>,
     ) -> Result<Self, SynthesisError> {
-        let alloc_tag = allocate_constant(&mut cs.namespace(|| "tag"), value.tag_field())?;
-        let alloc_hash = allocate_constant(&mut cs.namespace(|| "hash"), *value.value())?;
+        let alloc_tag = allocate_constant(&mut cs.namespace(|| "tag"), value.tag_field());
+        let alloc_hash = allocate_constant(&mut cs.namespace(|| "hash"), *value.value());
 
         Ok(AllocatedPtr {
             tag: alloc_tag,
@@ -191,20 +191,19 @@ impl<F: LurkField> AllocatedPtr<F> {
         cs: &mut CS,
         premise: &Boolean,
         other: &AllocatedPtr<F>,
-    ) -> Result<(), SynthesisError> {
+    ) {
         implies_equal(
             &mut cs.namespace(|| "implies tag equal"),
             premise,
             self.tag(),
             other.tag(),
-        )?;
+        );
         implies_equal(
             &mut cs.namespace(|| "implies hash equal"),
             premise,
             self.hash(),
             other.hash(),
-        )?;
-        Ok(())
+        );
     }
 
     pub fn is_nil<CS: ConstraintSystem<F>>(
@@ -597,8 +596,8 @@ impl<F: LurkField> AllocatedContPtr<F> {
         cs: &mut CS,
         value: ZContPtr<F>,
     ) -> Result<Self, SynthesisError> {
-        let alloc_tag = allocate_constant(&mut cs.namespace(|| "tag"), value.tag_field())?;
-        let alloc_hash = allocate_constant(&mut cs.namespace(|| "hash"), *value.value())?;
+        let alloc_tag = allocate_constant(&mut cs.namespace(|| "tag"), value.tag_field());
+        let alloc_hash = allocate_constant(&mut cs.namespace(|| "hash"), *value.value());
 
         Ok(AllocatedContPtr {
             tag: alloc_tag,
@@ -785,7 +784,7 @@ impl<F: LurkField> AllocatedContPtr<F> {
             &mut cs.namespace(|| format!("not_dummy implies real cont {:?}", &name)),
             not_dummy,
             &acc.expect("acc was never initialized"),
-        )?;
+        );
 
         let cont = AllocatedContPtr {
             tag: cont_tag.clone(),

--- a/src/z_data/serde/ser.rs
+++ b/src/z_data/serde/ser.rs
@@ -42,8 +42,8 @@ impl<'a> StructSerializer<'a> {
         Ok(())
     }
 
-    fn end_inner(self) -> Result<Vec<ZData>, SerdeError> {
-        Ok(self.cell)
+    fn end_inner(self) -> Vec<ZData> {
+        self.cell
     }
 }
 
@@ -394,7 +394,7 @@ impl<'a> ser::SerializeStruct for StructSerializer<'a> {
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        Ok(ZData::Cell(self.end_inner()?))
+        Ok(ZData::Cell(self.end_inner()))
     }
 }
 
@@ -413,7 +413,7 @@ impl<'a> ser::SerializeStructVariant for StructSerializer<'a> {
         let mut cell = vec![u8::try_from(self.variant_index)
             .unwrap()
             .serialize(self.ser)?];
-        cell.extend(self.end_inner()?);
+        cell.extend(self.end_inner());
         Ok(ZData::Cell(cell))
     }
 }


### PR DESCRIPTION
## Summary

Some error handling is entirely motivated by calling an infallible function that nonetheless returns `Result<>`: `AllocatedNum::alloc`, when called with an infallible closure. 

This PR materializes this as a draft with an `.expect()`, something that incidentally was already done in functions such as `allocate_unconstrained_bignum` -- and is now normalized throughout the code base. 

We should merge the [sister bellpepper PR](https://github.com/lurk-lab/bellpepper/pull/22) to perform this more ergonomically by offering an explicitly infallible variant of `alloc`.

While I was there, I fixed a couple functions that required a `Result` for exactly no reason (I needed to use `clippy::unnecessary_wraps`, and they were lowering the signal-to-noise ratio of that tool).

## TODO

- [x] refactor based on the latest bellpepper.

## Details

- Removed uneeded `Result` wrapping from various functions and methods across several files, making them infallible and changing the error handling approach.
- Materialize that certain closures, such as the ones passed in `AllocatedNum::alloc`, are infallible,
- Improved code readability by eliminating unnecessary question marks and unwrapping of Results in various function calls and test cases.
- Modified various methods to return their results directly instead of wrapping them in a `Result` type, simplifying error handling.
- Adapted the corresponding function call sites and test cases according to the changes in return types.