### PR TITLE
refactor: Refactor Ptr struct to generic with type Tag

### DIFF
--- a/src/tag.rs
+++ b/src/tag.rs
@@ -7,7 +7,7 @@ use std::{convert::TryFrom, fmt};
 use crate::field::LurkField;
 use crate::ptr::TypePredicates;
 
-pub trait Tag: Into<u16> + TryFrom<u16> + Copy + Sized + Eq + fmt::Debug {
+pub trait Tag: Into<u16> + TryFrom<u16> + Copy + Sized + std::hash::Hash + Eq + fmt::Debug {
     fn from_field<F: LurkField>(f: &F) -> Option<Self>;
     fn to_field<F: LurkField>(&self) -> F;
 


### PR DESCRIPTION
## Summary

In order to unify the current and LEM ways of defining the primary circuit and operating on it (so as to further #629), we need to abstract away a type that allows the developer to specify the associated types this circuit construction relies on. We started on this path with #644 and #647.

At a high level, each of the two implementations we have in mind for those traits define a single pointer type, rather than two. It would be ergonomic to have one.

The present PR defines `Ptr` and `ContPtr` as two distinct instantiations of a single pointer type, which is something we've wanted to do for a while already. We just needed an excuse.

## Details 

- Refactored `Ptr` struct into a generic `GPtr` struct, introducing type parameter `T` and associating it with `Tag` interface.
- Created `Ptr` and `ContPtr` types derived from `GPtr`.
- Common methods are defined on `GPtr`,
- Transferred pertinent predicate methods such as `is_nil`, `is_cons`, `is_atom`, `is_list`, `as_cons`, `as_list` to `GPtr<F, ExprTag>`.
- Transferred `ContPtr` struct and corresponding methods to `GPtr<F, ContTag>`.
- No modifications made to `ExprTag` / `ContTag` and associated enum elements in `tag.rs`.
- Added `std::hash::Hash` trait to `Tag` interface in `tag.rs`.