### PR TITLE
Fix UX issue

### DIFF
--- a/src/public_parameters/error.rs
+++ b/src/public_parameters/error.rs
@@ -1,6 +1,7 @@
 use std::io;
 use thiserror::Error;
 
+#[non_exhaustive]
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("IO error: {0}")]


### PR DESCRIPTION
Replace `eprintln!` by `info!` in case of error when loading cached public params

Closes #654 