### PR TITLE
Unwrap setup result.

### DIFF
--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -199,7 +199,8 @@ where
         &circuit_secondary,
         Some(commitment_size_hint1),
         Some(commitment_size_hint2),
-    );
+    )
+    .unwrap();
     let (pk, vk) = CompressedSNARK::setup(&pp).unwrap();
     PublicParams { pp, pk, vk }
 }


### PR DESCRIPTION
The arecibo `DigestBuilder` PR (https://github.com/lurk-lab/arecibo/pull/40) changed `nova::PublicParams::setup()` to return a `Result`. This PR unbreaks `lurk-rs`, unwrapping here as we already do for `CompresedSNARK::setup()` on the next line.