### PR TITLE
refactor: Enhance error handling and messaging across modules

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -22,6 +22,7 @@ xclippy = [
     "-Wclippy::map_unwrap_or",
     "-Wclippy::needless_borrow",
     "-Wclippy::checked_conversions",
+    "-Wclippy::trait_duplication_in_bounds",
     "-Wrust_2018_idioms",
     "-Wtrivial_numeric_casts",
     "-Wunused_lifetimes",

--- a/.cargo/config
+++ b/.cargo/config
@@ -11,6 +11,7 @@ xclippy = [
     "-Wclippy::dbg_macro",
     "-Wclippy::disallowed_methods",
     "-Wclippy::derive_partial_eq_without_eq",
+    "-Wclippy::enum_glob_use",
     "-Wclippy::filter_map_next",
     "-Wclippy::flat_map_option",
     "-Wclippy::inefficient_to_string",
@@ -22,5 +23,6 @@ xclippy = [
     "-Wclippy::needless_borrow",
     "-Wclippy::checked_conversions",
     "-Wrust_2018_idioms",
+    "-Wtrivial_numeric_casts",
     "-Wunused_lifetimes",
 ]

--- a/benches/end2end.rs
+++ b/benches/end2end.rs
@@ -309,7 +309,7 @@ fn prove_benchmark(c: &mut Criterion) {
 
         b.iter(|| {
             let result = prover
-                .prove(&pp, &frames, &mut store, lang_pallas_rc.clone())
+                .prove(&pp, &frames, &store, lang_pallas_rc.clone())
                 .unwrap();
             black_box(result);
         })
@@ -362,7 +362,7 @@ fn prove_compressed_benchmark(c: &mut Criterion) {
 
         b.iter(|| {
             let (proof, _, _, _) = prover
-                .prove(&pp, &frames, &mut store, lang_pallas_rc.clone())
+                .prove(&pp, &frames, &store, lang_pallas_rc.clone())
                 .unwrap();
 
             let compressed_result = proof.compress(&pp).unwrap();
@@ -412,7 +412,7 @@ fn verify_benchmark(c: &mut Criterion) {
                 )
                 .unwrap();
             let (proof, z0, zi, num_steps) = prover
-                .prove(&pp, &frames, &mut store, lang_pallas_rc.clone())
+                .prove(&pp, &frames, &store, lang_pallas_rc.clone())
                 .unwrap();
 
             b.iter_batched(
@@ -470,7 +470,7 @@ fn verify_compressed_benchmark(c: &mut Criterion) {
                 )
                 .unwrap();
             let (proof, z0, zi, num_steps) = prover
-                .prove(&pp, &frames, &mut store, lang_pallas_rc.clone())
+                .prove(&pp, &frames, &store, lang_pallas_rc.clone())
                 .unwrap();
 
             let compressed_proof = proof.compress(&pp).unwrap();

--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -104,7 +104,7 @@ fn fibo_prove<M: measurement::Measurement>(
             b.iter_batched(
                 || (frames, lang_rc.clone()),
                 |(frames, lang_rc)| {
-                    let result = prover.prove(&pp, frames, &mut store, lang_rc);
+                    let result = prover.prove(&pp, frames, &store, lang_rc);
                     let _ = black_box(result);
                 },
                 BatchSize::LargeInput,

--- a/benches/sha256_ivc.rs
+++ b/benches/sha256_ivc.rs
@@ -54,7 +54,7 @@ fn sha256_ivc<F: LurkField>(
         .map(|i| format!("(sha256 . {i})"))
         .collect::<Vec<String>>()
         .join(" ");
-    let input = format!("'({})", input);
+    let input = format!("'({input})");
     let program = format!(
         r#"
 (letrec ((encode-1 (lambda (term) 

--- a/clutch/src/lib.rs
+++ b/clutch/src/lib.rs
@@ -510,14 +510,14 @@ impl ClutchState<F, Coproc<F>> {
         println!();
         Ok(None)
     }
-    fn proof_claim(&self, store: &mut Store<F>, rest: Ptr<F>) -> Result<Option<Ptr<F>>> {
+    fn proof_claim(&self, store: &Store<F>, rest: Ptr<F>) -> Result<Option<Ptr<F>>> {
         let proof = self.get_proof(store, rest)?;
 
         println!("{0:#?}", proof.claim);
         Ok(None)
     }
 
-    fn get_proof(&self, store: &mut Store<F>, rest: Ptr<F>) -> Result<Proof<'_, F>> {
+    fn get_proof(&self, store: &Store<F>, rest: Ptr<F>) -> Result<Proof<'_, F>> {
         let (proof_cid, _rest1) = store.car_cdr(&rest)?;
         let zptr_string = store
             .fetch_string(&proof_cid)
@@ -579,7 +579,7 @@ impl ClutchState<F, Coproc<F>> {
             bail!("verification of new proof failed");
         }
     }
-    fn verify(&mut self, store: &mut Store<F>, rest: Ptr<F>) -> Result<Option<Ptr<F>>> {
+    fn verify(&mut self, store: &Store<F>, rest: Ptr<F>) -> Result<Option<Ptr<F>>> {
         let (proof_cid, _) = store.car_cdr(&rest)?;
 
         let zptr_string = store

--- a/clutch/src/lib.rs
+++ b/clutch/src/lib.rs
@@ -566,7 +566,7 @@ impl ClutchState<F, Coproc<F>> {
             let zptr_string = proof
                 .claim
                 .proof_key()
-                .map_err(|_| Error::msg("Failed to generate proof key"))?
+                .map_err(|e| Error::msg(format!("Failed to generate proof key: {}", e)))?
                 .to_base32();
             match proof.claim {
                 Claim::Evaluation(_) | Claim::Opening(_) => println!("{0:#?}", proof.claim),

--- a/clutch/src/lib.rs
+++ b/clutch/src/lib.rs
@@ -592,7 +592,7 @@ impl ClutchState<F, Coproc<F>> {
             .ok_or_else(|| anyhow!("proof not found: {zptr_string}"))?;
 
         let pp = public_params(self.reduction_count, true, self.lang(), &public_param_dir())?;
-        let result = proof.verify(&pp, &self.lang()).unwrap();
+        let result = proof.verify(&pp, &self.lang())?;
 
         if result.verified {
             Ok(Some(lurk_sym_ptr!(store, t)))

--- a/examples/circom.rs
+++ b/examples/circom.rs
@@ -109,7 +109,7 @@ fn main() {
         )],
     );
 
-    let coproc_expr = format!("{}", sym_str);
+    let coproc_expr = format!("{sym_str}");
 
     let expr = format!("({coproc_expr})");
     let ptr = store.read(&expr).unwrap();
@@ -129,7 +129,7 @@ fn main() {
     .unwrap();
     let pp_end = pp_start.elapsed();
 
-    println!("Public parameters took {:?}", pp_end);
+    println!("Public parameters took {pp_end:?}");
 
     println!("Beginning proof step...");
 
@@ -139,7 +139,7 @@ fn main() {
         .unwrap();
     let proof_end = proof_start.elapsed();
 
-    println!("Proofs took {:?}", proof_end);
+    println!("Proofs took {proof_end:?}");
 
     println!("Verifying proof...");
 
@@ -147,7 +147,7 @@ fn main() {
     let res = proof.verify(&pp, num_steps, &z0, &zi).unwrap();
     let verify_end = verify_start.elapsed();
 
-    println!("Verify took {:?}", verify_end);
+    println!("Verify took {verify_end:?}");
 
     if res {
         println!(

--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -205,7 +205,7 @@ fn main() {
     .unwrap();
     let pp_end = pp_start.elapsed();
 
-    println!("Public parameters took {:?}", pp_end);
+    println!("Public parameters took {pp_end:?}");
 
     if setup_only {
         return;
@@ -222,7 +222,7 @@ fn main() {
         });
     let proof_end = proof_start.elapsed();
 
-    println!("Proofs took {:?}", proof_end);
+    println!("Proofs took {proof_end:?}");
 
     println!("Verifying proof...");
 
@@ -230,7 +230,7 @@ fn main() {
     let res = proof.verify(&pp, num_steps, &z0, &zi).unwrap();
     let verify_end = verify_start.elapsed();
 
-    println!("Verify took {:?}", verify_end);
+    println!("Verify took {verify_end:?}");
 
     if res {
         println!(

--- a/examples/sha256_ivc.rs
+++ b/examples/sha256_ivc.rs
@@ -36,7 +36,7 @@ fn sha256_ivc<F: LurkField>(store: &mut Store<F>, n: usize, input: Vec<usize>) -
         .map(|i| i.to_string())
         .collect::<Vec<String>>()
         .join(" ");
-    let input = format!("'({})", input);
+    let input = format!("'({input})");
     let program = format!(
         r#"
 (letrec ((encode-1 (lambda (term) 

--- a/fcomm/src/lib.rs
+++ b/fcomm/src/lib.rs
@@ -78,7 +78,7 @@ mod base64 {
 
 pub type NovaProofCache = FileMap<String, Proof<'static, S1>>;
 pub fn nova_proof_cache(reduction_count: usize) -> NovaProofCache {
-    FileMap::<String, Proof<'_, S1>>::new(format!("nova_proofs.{}", reduction_count)).unwrap()
+    FileMap::<String, Proof<'_, S1>>::new(format!("nova_proofs.{reduction_count}")).unwrap()
 }
 
 pub type CommittedExpressionMap = FileMap<Commitment<S1>, CommittedExpression<S1>>;
@@ -1261,7 +1261,7 @@ mod test {
                 Some(c) => commitment = c,
                 _ => panic!("new commitment missing"),
             }
-            println!("Commitment: {:?}", commitment);
+            println!("Commitment: {commitment:?}");
         }
     }
 

--- a/fcomm/src/lib.rs
+++ b/fcomm/src/lib.rs
@@ -969,11 +969,11 @@ impl<'a> Proof<'a, S1> {
         let input_io = {
             let expr = s
                 .read(&evaluation.expr)
-                .map_err(|_| Error::VerificationError("failed to read expr".into()))?;
+                .map_err(|e| Error::VerificationError(format!("failed to read expr: {}", e)))?;
 
             let env = s
                 .read(&evaluation.env)
-                .map_err(|_| Error::VerificationError("failed to read env".into()))?;
+                .map_err(|e| Error::VerificationError(format!("failed to read env: {}", e)))?;
 
             // FIXME: We ignore cont and assume Outermost, since we can't read a Cont.
             let cont = s.intern_cont_outermost();
@@ -984,11 +984,11 @@ impl<'a> Proof<'a, S1> {
         let output_io = {
             let expr = s
                 .read(&evaluation.expr_out)
-                .map_err(|_| Error::VerificationError("failed to read expr out".into()))?;
+                .map_err(|e| Error::VerificationError(format!("failed to read expr out: {}", e)))?;
 
             let env = s
                 .read(&evaluation.env_out)
-                .map_err(|_| Error::VerificationError("failed to read env out".into()))?;
+                .map_err(|e| Error::VerificationError(format!("failed to read env out: {}", e)))?;
             let cont = evaluation
                 .status
                 .to_cont(s)

--- a/fcomm/src/lib.rs
+++ b/fcomm/src/lib.rs
@@ -264,7 +264,7 @@ impl<F: LurkField> Eq for LurkPtr<F> {}
 #[cfg_attr(not(target_arch = "wasm32"), proptest(no_bound))]
 #[cfg_attr(not(target_arch = "wasm32"), serde_test(types(S1), zdata(true)))]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct CommittedExpression<F: LurkField + Serialize> {
+pub struct CommittedExpression<F: LurkField> {
     pub expr: LurkPtr<F>,
     #[cfg_attr(
         not(target_arch = "wasm32"),
@@ -405,7 +405,7 @@ impl ReductionCount {
 
 impl Evaluation {
     fn new<F: LurkField>(
-        s: &mut Store<F>,
+        s: &Store<F>,
         input: IO<F>,
         output: IO<F>,
         iterations: Option<usize>, // This might be padded, so is not quite 'iterations' in the sense of number of actual reduction steps required
@@ -491,7 +491,7 @@ impl<F: LurkField + Serialize + DeserializeOwned> PtrEvaluation<F> {
 }
 
 impl<F: LurkField + Serialize + DeserializeOwned> Commitment<F> {
-    pub fn from_comm(s: &mut Store<F>, ptr: &Ptr<F>) -> Result<Self, Error> {
+    pub fn from_comm(s: &Store<F>, ptr: &Ptr<F>) -> Result<Self, Error> {
         assert_eq!(ExprTag::Comm, ptr.tag);
 
         let digest = *s
@@ -589,7 +589,7 @@ impl<F: LurkField + Serialize + DeserializeOwned> LurkPtr<F> {
         }
     }
 
-    pub fn from_ptr(s: &mut Store<F>, ptr: &Ptr<F>) -> Self {
+    pub fn from_ptr(s: &Store<F>, ptr: &Ptr<F>) -> Self {
         let (z_store, z_ptr) = ZStore::new_with_expr(s, ptr);
         let z_ptr = z_ptr.unwrap();
         Self::ZStorePtr(ZStorePtr { z_store, z_ptr })
@@ -599,7 +599,7 @@ impl<F: LurkField + Serialize + DeserializeOwned> LurkPtr<F> {
 impl LurkCont {
     pub fn cont_ptr<F: LurkField + Serialize + DeserializeOwned>(
         &self,
-        s: &mut Store<F>,
+        s: &Store<F>,
     ) -> ContPtr<F> {
         match self {
             Self::Outermost => s.get_cont_outermost(),

--- a/fcomm/tests/makefile_tests.rs
+++ b/fcomm/tests/makefile_tests.rs
@@ -21,7 +21,7 @@ fn test_make_fcomm_examples() {
 
     let make_output = Command::new("make")
         .current_dir(examples_dir)
-        .arg(format!("-j{}", cpus))
+        .arg(format!("-j{cpus}"))
         .output()
         .expect("Failed to run the make command, is make installed?");
 

--- a/lurk-macros/src/lib.rs
+++ b/lurk-macros/src/lib.rs
@@ -298,10 +298,10 @@ pub fn serde_test(args: TokenStream, input: TokenStream) -> TokenStream {
                     }
                 }
 
-                _ => panic!("invalid attribute {:?}", path),
+                _ => panic!("invalid attribute {path:?}"),
             },
 
-            _ => panic!("invalid argument {:?}", arg),
+            _ => panic!("invalid argument {arg:?}"),
         }
     }
 
@@ -318,7 +318,7 @@ pub fn serde_test(args: TokenStream, input: TokenStream) -> TokenStream {
     for (i, ty) in types.into_iter().enumerate() {
         let serde_test = {
             let test_name = Ident::new(
-                &format!("test_serde_roundtrip_{}_{}", name, i),
+                &format!("test_serde_roundtrip_{name}_{i}"),
                 Span::mixed_site(),
             );
             quote! {
@@ -335,7 +335,7 @@ pub fn serde_test(args: TokenStream, input: TokenStream) -> TokenStream {
 
         let zdata_test = if test_zdata {
             let test_name = Ident::new(
-                &format!("test_zdata_roundtrip_{}_{}", name, i),
+                &format!("test_zdata_roundtrip_{name}_{i}"),
                 Span::mixed_site(),
             );
             quote! {
@@ -398,7 +398,7 @@ fn get_type_from_attrs(attrs: &[syn::Attribute], attr_name: &str) -> syn::Result
     }) else {
         return Err(syn::Error::new(
             proc_macro2::Span::call_site(),
-            format!("Could not find attribute {}", attr_name),
+            format!("Could not find attribute {attr_name}"),
         ));
     };
 
@@ -406,7 +406,7 @@ fn get_type_from_attrs(attrs: &[syn::Attribute], attr_name: &str) -> syn::Result
         NestedMeta::Meta(Meta::Path(path)) => Ok(path),
         bad => Err(syn::Error::new_spanned(
             bad,
-            &format!("Could not parse {} attribute", attr_name)[..],
+            &format!("Could not parse {attr_name} attribute")[..],
         )),
     }
 }
@@ -447,10 +447,7 @@ pub fn derive_try_from_repr(input: TokenStream) -> TokenStream {
     match res_ty {
         Err(e) => {
             // If no explicit repr were given for us, we can't pursue
-            panic!(
-                "TryFromRepr macro requires a repr parameter, which couldn't be parsed: {:?}",
-                e
-            );
+            panic!("TryFromRepr macro requires a repr parameter, which couldn't be parsed: {e:?}");
         }
         Ok(ty) => {
             let match_arms = try_from_match_arms(name, &variants, ty.clone());

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -5194,10 +5194,7 @@ fn car_cdr_named<F: LurkField, CS: ConstraintSystem<F>>(
             maybe_cons.hash().get_value(),
             &allocated_digest.get_value()
         );
-        panic!(
-            "tried to take car_cdr of a non-dummy cons ({:?}) but supplied wrong value",
-            name
-        );
+        panic!("tried to take car_cdr of a non-dummy cons ({name:?}) but supplied wrong value");
     }
 
     implies!(cs, &cons_not_dummy, &real_cons);

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -413,7 +413,7 @@ impl<'a, F: LurkField, C: Coprocessor<F>> MultiFrame<'a, F, C> {
 
         let mut final_output = None;
 
-        for (frames_cs, output) in css.into_iter() {
+        for (frames_cs, output) in css {
             final_output = Some(output);
 
             let aux = frames_cs.aux_slice();

--- a/src/circuit/gadgets/constraints.rs
+++ b/src/circuit/gadgets/constraints.rs
@@ -377,10 +377,7 @@ pub(crate) fn pick<F: PrimeField, CS: ConstraintSystem<F>>(
     condition: &Boolean,
     a: &AllocatedNum<F>,
     b: &AllocatedNum<F>,
-) -> Result<AllocatedNum<F>, SynthesisError>
-where
-    CS: ConstraintSystem<F>,
-{
+) -> Result<AllocatedNum<F>, SynthesisError> {
     let c = AllocatedNum::alloc(cs.namespace(|| "pick result"), || {
         if condition
             .get_value()
@@ -410,10 +407,7 @@ pub(crate) fn pick_const<F: PrimeField, CS: ConstraintSystem<F>>(
     condition: &Boolean,
     a: F,
     b: F,
-) -> Result<AllocatedNum<F>, SynthesisError>
-where
-    CS: ConstraintSystem<F>,
-{
+) -> Result<AllocatedNum<F>, SynthesisError> {
     let c = AllocatedNum::alloc(cs.namespace(|| "pick result"), || {
         if condition
             .get_value()
@@ -441,10 +435,7 @@ where
 pub(crate) fn boolean_to_num<F: PrimeField, CS: ConstraintSystem<F>>(
     mut cs: CS,
     bit: &Boolean,
-) -> Result<AllocatedNum<F>, SynthesisError>
-where
-    CS: ConstraintSystem<F>,
-{
+) -> Result<AllocatedNum<F>, SynthesisError> {
     let num = AllocatedNum::alloc(cs.namespace(|| "Allocate num"), || {
         if bit.get_value().ok_or(SynthesisError::AssignmentMissing)? {
             Ok(F::ONE)

--- a/src/circuit/gadgets/hashes.rs
+++ b/src/circuit/gadgets/hashes.rs
@@ -344,7 +344,7 @@ impl<'a, F: LurkField> AllocatedConsWitness<'a, F> {
         } = &self.slots[index];
         if !expect_dummy {
             match allocated_name {
-                Err(_) => panic!("requested {:?} but found a dummy allocation", name),
+                Err(_) => panic!("requested {name:?} but found a dummy allocation"),
                 Ok(alloc_name) => assert_eq!(
                     name, *alloc_name,
                     "requested and allocated names don't match."
@@ -478,7 +478,7 @@ impl<'a, F: LurkField> AllocatedContWitness<'a, F> {
         if !expect_dummy {
             match allocated_name {
                 Err(_) => {
-                    panic!("requested {:?} but found a dummy allocation", name)
+                    panic!("requested {name:?} but found a dummy allocation")
                 }
                 Ok(alloc_name) => {
                     assert_eq!(

--- a/src/circuit/gadgets/hashes.rs
+++ b/src/circuit/gadgets/hashes.rs
@@ -173,7 +173,7 @@ impl<'a, F: LurkField> HashConst<'a, F> {
     #[allow(dead_code)]
     fn cache_hash_witness<CS: ConstraintSystem<F>>(
         &self,
-        cs: &mut CS,
+        cs: &CS,
         preimage: Vec<F>,
         hash_circuit_witness_cache: &mut HashCircuitWitnessCache<F>,
     ) {
@@ -364,7 +364,7 @@ impl<'a, F: LurkField> AllocatedContWitness<'a, F> {
     // Currently unused, but not necessarily useless.
     #[allow(dead_code)]
     fn make_hash_cache<CS: ConstraintSystem<F>>(
-        cs: &mut CS,
+        cs: &CS,
         names_and_ptrs: &[(ContName, (Option<ContPtr<F>>, Option<Vec<F>>))],
         hash_constants: HashConst<'_, F>,
     ) -> Option<HashCircuitWitnessCache<F>> {

--- a/src/cli/backend.rs
+++ b/src/cli/backend.rs
@@ -25,7 +25,7 @@ impl Backend {
     }
 
     fn compatible_fields(&self) -> Vec<LanguageField> {
-        use LanguageField::*;
+        use LanguageField::{Pallas, Vesta, BLS12_381};
         match self {
             Self::Nova => vec![Pallas, Vesta],
             Self::SnarkPackPlus => vec![BLS12_381],

--- a/src/cli/circom.rs
+++ b/src/cli/circom.rs
@@ -95,10 +95,7 @@ pub(crate) fn create_circom_gadget(circom_folder: Utf8PathBuf, name: String) -> 
         default_field
     };
 
-    println!(
-        "Running circom binary to generate r1cs and witness files to {:?}",
-        circom_gadget
-    );
+    println!("Running circom binary to generate r1cs and witness files to {circom_gadget:?}");
     fs::create_dir_all(&circom_gadget)?;
     let output = get_circom_binary()?
         .args(&[

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -237,7 +237,7 @@ impl Repl<F> {
 
                         info!("Proving");
                         let (proof, public_inputs, public_outputs, num_steps) =
-                            prover.prove(&pp, frames, &mut self.store, self.lang.clone())?;
+                            prover.prove(&pp, frames, &self.store, self.lang.clone())?;
                         info!("Compressing proof");
                         let proof = proof.compress(&pp)?;
                         assert_eq!(self.rc * num_steps, pad(n_frames, self.rc));

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -445,7 +445,7 @@ impl Repl<F> {
 
     pub fn load_file(&mut self, file_path: &Utf8Path) -> Result<()> {
         let input = read_to_string(file_path)?;
-        println!("Loading {}", file_path);
+        println!("Loading {file_path}");
 
         let mut input = parser::Span::new(&input);
         loop {

--- a/src/cli/repl/meta_cmd.rs
+++ b/src/cli/repl/meta_cmd.rs
@@ -276,7 +276,9 @@ impl MetaCmd<F> {
             let Some(secret) = repl.store.fetch_num(&first_io.expr) else {
                 bail!(
                     "Secret must be a number. Got {}",
-                    first_io.expr.fmt_to_string(&repl.store, &repl.state.borrow())
+                    first_io
+                        .expr
+                        .fmt_to_string(&repl.store, &repl.state.borrow())
                 )
             };
             repl.hide(secret.into_scalar(), second_io.expr)?;

--- a/src/coprocessor/circom.rs
+++ b/src/coprocessor/circom.rs
@@ -158,7 +158,7 @@ Then run `lurk coprocessor --name {name} <{}_FOLDER>` to instantiate a new gadge
             let name = gadget.name();
             let circom_folder = circom_dir().join(name);
 
-            let r1cs = circom_folder.join(format!("{}.r1cs", name));
+            let r1cs = circom_folder.join(format!("{name}.r1cs"));
             let wasm = circom_folder.join(name).with_extension("wasm");
 
             let config = CircomConfig::<F>::new(wasm, r1cs)?;

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -55,7 +55,7 @@ impl<F: LurkField> Write<F> for IO<F> {
 
 impl<F: LurkField> std::fmt::Display for IO<F> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/src/eval/reduction.rs
+++ b/src/eval/reduction.rs
@@ -1150,8 +1150,7 @@ fn apply_continuation<F: LurkField>(
                                 Err(control) => return Ok(control),
                             }
                         }
-                        (Expression::Char(_), Expression::EmptyStr)
-                        | (Expression::Char(_), Expression::Str(..))
+                        (Expression::Char(_), Expression::EmptyStr | Expression::Str(..))
                             if matches!(operator, Op2::StrCons) =>
                         {
                             cons_witness.strcons_named(ConsName::TheCons, store, evaled_arg, arg2)

--- a/src/field.rs
+++ b/src/field.rs
@@ -309,7 +309,7 @@ impl<F: LurkField> Hash for FWrap<F> {
 
 impl<F: LurkField> PartialOrd for FWrap<F> {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        (self.0.to_repr().as_ref()).partial_cmp(other.0.to_repr().as_ref())
+        Some(self.cmp(other))
     }
 }
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -84,7 +84,7 @@ pub trait LurkField: PrimeField + PrimeFieldBits {
         let bytes = self.to_bytes();
         let mut s = String::with_capacity(bytes.len() * 2);
         for b in bytes.iter().rev() {
-            s.push_str(&format!("{:02x?}", b));
+            s.push_str(&format!("{b:02x?}"));
         }
         s
     }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -24,7 +24,7 @@ impl From<usize> for HashArity {
             4 => Self::A4,
             6 => Self::A6,
             8 => Self::A8,
-            _ => panic!("unsupported arity: {}", n),
+            _ => panic!("unsupported arity: {n}"),
         }
     }
 }

--- a/src/hash_witness.rs
+++ b/src/hash_witness.rs
@@ -296,28 +296,6 @@ impl<F: LurkField> ConsStub<F> {
         }
     }
 
-    pub fn car_cdr_mut(
-        &mut self,
-        s: &mut Store<F>,
-        cons: &Ptr<F>,
-    ) -> Result<(Ptr<F>, Ptr<F>), store::Error> {
-        match self {
-            Self::Dummy => {
-                let (car, cdr) = Cons::get_car_cdr_mut(s, cons)?;
-
-                *self = Self::Value(Cons {
-                    car,
-                    cdr,
-                    cons: *cons,
-                });
-
-                Ok((car, cdr))
-            }
-            Self::Blank => unreachable!("Blank ConsStub should be used only in blank circuits."),
-            Self::Value(h) => Ok(h.car_cdr(cons)),
-        }
-    }
-
     pub fn cons(&mut self, store: &mut Store<F>, car: Ptr<F>, cdr: Ptr<F>) -> Ptr<F> {
         match self {
             Self::Dummy => {
@@ -572,10 +550,10 @@ impl<F: LurkField> ConsWitness<F> {
     pub fn car_cdr_mut_named(
         &mut self,
         name: ConsName,
-        store: &mut Store<F>,
+        store: &Store<F>,
         cons: &Ptr<F>,
     ) -> Result<(Ptr<F>, Ptr<F>), store::Error> {
-        self.get_assigned_slot(name).car_cdr_mut(store, cons)
+        self.get_assigned_slot(name).car_cdr(store, cons)
     }
 
     pub fn extend_named(
@@ -610,17 +588,13 @@ impl<F: LurkField> Cons<F> {
     fn get_car_cdr(s: &Store<F>, cons: &Ptr<F>) -> Result<(Ptr<F>, Ptr<F>), store::Error> {
         s.car_cdr(cons)
     }
-
-    fn get_car_cdr_mut(s: &mut Store<F>, cons: &Ptr<F>) -> Result<(Ptr<F>, Ptr<F>), store::Error> {
-        s.car_cdr(cons)
-    }
 }
 
 impl<F: LurkField> ContWitness<F> {
     pub fn fetch_named_cont(
         &mut self,
         name: ContName,
-        store: &mut Store<F>,
+        store: &Store<F>,
         cont: &ContPtr<F>,
     ) -> Option<Continuation<F>> {
         self.get_assigned_slot(name).fetch_cont(store, cont)
@@ -638,11 +612,7 @@ impl<F: LurkField> ContWitness<F> {
 }
 
 impl<F: LurkField> ContStub<F> {
-    pub fn fetch_cont(
-        &mut self,
-        store: &mut Store<F>,
-        cont: &ContPtr<F>,
-    ) -> Option<Continuation<F>> {
+    pub fn fetch_cont(&mut self, store: &Store<F>, cont: &ContPtr<F>) -> Option<Continuation<F>> {
         match self {
             Self::Dummy => {
                 let continuation = store.fetch_cont(cont)?;

--- a/src/lem/circuit.rs
+++ b/src/lem/circuit.rs
@@ -43,7 +43,7 @@ use crate::circuit::gadgets::{
 
 use crate::{
     field::{FWrap, LurkField},
-    tag::ExprTag::*,
+    tag::ExprTag::{Comm, Nil, Num, Sym},
 };
 
 use super::{

--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -1,7 +1,12 @@
 use anyhow::Result;
 use once_cell::sync::OnceCell;
 
-use crate::{field::LurkField, func, state::initial_lurk_state, tag::ContTag::*};
+use crate::{
+    field::LurkField,
+    func,
+    state::initial_lurk_state,
+    tag::ContTag::{Error, Outermost, Terminal},
+};
 
 use super::{interpreter::Frame, pointers::Ptr, store::Store, Func, Tag};
 

--- a/src/lem/macros.rs
+++ b/src/lem/macros.rs
@@ -578,7 +578,7 @@ mod tests {
     use crate::{
         lem::{Block, Ctrl, Op, Tag, Var},
         state::lurk_sym,
-        tag::ExprTag::*,
+        tag::ExprTag::{Char, Num, Str},
         Symbol,
     };
 

--- a/src/lem/mod.rs
+++ b/src/lem/mod.rs
@@ -821,7 +821,7 @@ mod tests {
         let log_fmt = |_: usize, _: &[Ptr<Fr>], _: &[Ptr<Fr>], _: &Store<Fr>| String::default();
 
         let mut cs_prev = None;
-        for input in inputs.into_iter() {
+        for input in inputs {
             let input = [input, nil, outermost];
             let (frames, ..) = func
                 .call_until(&input, store, stop_cond, 10, log_fmt)

--- a/src/lem/mod.rs
+++ b/src/lem/mod.rs
@@ -116,14 +116,16 @@ pub enum Tag {
     Op2(Op2),
 }
 
-impl From<u16> for Tag {
-    fn from(val: u16) -> Self {
+impl TryFrom<u16> for Tag {
+    type Error = anyhow::Error;
+
+    fn try_from(val: u16) -> Result<Self, Self::Error> {
         if let Ok(tag) = ExprTag::try_from(val) {
-            Tag::Expr(tag)
+            Ok(Tag::Expr(tag))
         } else if let Ok(tag) = ContTag::try_from(val) {
-            Tag::Cont(tag)
+            Ok(Tag::Cont(tag))
         } else {
-            panic!("Invalid u16 for Tag: {val}")
+            bail!("Invalid u16 for Tag: {val}")
         }
     }
 }

--- a/src/lem/mod.rs
+++ b/src/lem/mod.rs
@@ -165,7 +165,7 @@ impl Tag {
 
 impl std::fmt::Display for Tag {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        use Tag::*;
+        use Tag::{Cont, Expr, Op1, Op2};
         match self {
             Expr(tag) => write!(f, "expr.{}", tag),
             Cont(tag) => write!(f, "cont.{}", tag),
@@ -206,8 +206,8 @@ impl Lit {
     }
 
     pub fn from_ptr<F: LurkField>(ptr: &Ptr<F>, store: &Store<F>) -> Option<Self> {
-        use ExprTag::*;
-        use Tag::*;
+        use ExprTag::{Num, Str, Sym};
+        use Tag::Expr;
         match ptr.tag() {
             Expr(Num) => match ptr {
                 Ptr::Atom(_, f) => {
@@ -806,7 +806,7 @@ mod tests {
     ///   provided expressions.
     ///   - `expected_slots` gives the number of expected slots for each type of hash.
     fn synthesize_test_helper(func: &Func, inputs: Vec<Ptr<Fr>>, expected_num_slots: SlotsCounter) {
-        use crate::tag::ContTag::*;
+        use crate::tag::ContTag::{Error, Outermost, Terminal};
         let store = &mut func.init_store();
         let outermost = Ptr::null(Tag::Cont(Outermost));
         let terminal = Ptr::null(Tag::Cont(Terminal));

--- a/src/lem/path.rs
+++ b/src/lem/path.rs
@@ -85,10 +85,8 @@ impl Path {
 
     /// Computes the number of different paths taken given a list of paths
     pub fn num_paths_taken(paths: &[Self]) -> usize {
-        let mut all_paths: HashSet<Self> = HashSet::default();
-        paths.iter().for_each(|path| {
-            all_paths.insert(path.clone());
-        });
+        let mut all_paths: HashSet<&Self> = HashSet::default();
+        all_paths.extend(paths);
         all_paths.len()
     }
 }

--- a/src/lem/pointers.rs
+++ b/src/lem/pointers.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{field::*, tag::ExprTag::*};
+use crate::{
+    field::*,
+    tag::ExprTag::{Char, Comm, Nil, Num, U64},
+};
 
 use super::Tag;
 

--- a/src/lem/store.rs
+++ b/src/lem/store.rs
@@ -571,17 +571,17 @@ impl<F: LurkField> Store<F> {
 impl<F: LurkField> Ptr<F> {
     pub fn dbg_display(self, store: &Store<F>) -> String {
         if let Some(s) = store.fetch_string(&self) {
-            return format!("\"{}\"", s);
+            return format!("\"{s}\"");
         }
         if let Some(s) = store.fetch_symbol(&self) {
-            return format!("{}", s);
+            return format!("{s}");
         }
         match self {
             Ptr::Atom(tag, f) => {
                 if let Some(x) = f.to_u64() {
-                    format!("{}{}", tag, x)
+                    format!("{tag}{x}")
                 } else {
-                    format!("{}{:?}", tag, f)
+                    format!("{tag}{f:?}")
                 }
             }
             Ptr::Tuple2(tag, x) => {

--- a/src/lem/var_map.rs
+++ b/src/lem/var_map.rs
@@ -8,7 +8,7 @@ use super::Var;
 /// to be more ergonomic under the assumption that a LEM must always define
 /// variables before using them, so we don't expect to need some piece of
 /// information from a variable that hasn't been defined.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct VarMap<V>(HashMap<Var, V>);
 
 impl<V> VarMap<V> {

--- a/src/lem/zstore.rs
+++ b/src/lem/zstore.rs
@@ -50,8 +50,8 @@ pub fn populate_z_store<F: LurkField>(
                 }
                 Ptr::Tuple2(tag, idx) => {
                     let Some((a, b)) = store.fetch_2_ptrs(*idx) else {
-                    bail!("Index {idx} not found on tuple2")
-                };
+                        bail!("Index {idx} not found on tuple2")
+                    };
                     let a = populate_z_store(z_store, a, store)?;
                     let b = populate_z_store(z_store, b, store)?;
                     let z_ptr = ZPtr::from_parts(
@@ -68,8 +68,8 @@ pub fn populate_z_store<F: LurkField>(
                 }
                 Ptr::Tuple3(tag, idx) => {
                     let Some((a, b, c)) = store.fetch_3_ptrs(*idx) else {
-                    bail!("Index {idx} not found on tuple3")
-                };
+                        bail!("Index {idx} not found on tuple3")
+                    };
                     let a = populate_z_store(z_store, a, store)?;
                     let b = populate_z_store(z_store, b, store)?;
                     let c = populate_z_store(z_store, c, store)?;
@@ -89,8 +89,8 @@ pub fn populate_z_store<F: LurkField>(
                 }
                 Ptr::Tuple4(tag, idx) => {
                     let Some((a, b, c, d)) = store.fetch_4_ptrs(*idx) else {
-                    bail!("Index {idx} not found on tuple4")
-                };
+                        bail!("Index {idx} not found on tuple4")
+                    };
                     let a = populate_z_store(z_store, a, store)?;
                     let b = populate_z_store(z_store, b, store)?;
                     let c = populate_z_store(z_store, c, store)?;

--- a/src/lem/zstore.rs
+++ b/src/lem/zstore.rs
@@ -9,7 +9,7 @@ use super::{
     store::Store,
 };
 
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct ZStore<F: LurkField> {
     dag: BTreeMap<ZPtr<F>, ZChildren<F>>,
     comms: BTreeMap<FWrap<F>, (F, ZPtr<F>)>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -44,7 +44,7 @@ impl<F: LurkField> Store<F> {
         .parse(Span::new(input))
         {
             Ok((_i, x)) => Ok(self.intern_syntax(x)),
-            Err(e) => Err(Error::Syntax(format!("{}", e))),
+            Err(e) => Err(Error::Syntax(format!("{e}"))),
         }
     }
 
@@ -60,7 +60,7 @@ impl<F: LurkField> Store<F> {
         .parse(Span::new(input))
         {
             Ok((_i, x)) => Ok(self.intern_syntax(x)),
-            Err(e) => Err(Error::Syntax(format!("{}", e))),
+            Err(e) => Err(Error::Syntax(format!("{e}"))),
         }
     }
 
@@ -73,7 +73,7 @@ impl<F: LurkField> Store<F> {
         match preceded(parse_space, parse_maybe_meta(state, false)).parse(input) {
             Ok((i, Some((is_meta, x)))) => Ok((i, self.intern_syntax(x), is_meta)),
             Ok((_, None)) => Err(Error::NoInput),
-            Err(e) => Err(Error::Syntax(format!("{}", e))),
+            Err(e) => Err(Error::Syntax(format!("{e}"))),
         }
     }
 }

--- a/src/parser/base.rs
+++ b/src/parser/base.rs
@@ -196,19 +196,19 @@ pub mod tests {
         match (expected, p.parse(Span::<'a>::new(i))) {
             (Some(expected), Ok((_i, x))) if x == expected => (),
             (Some(expected), Ok((i, x))) => {
-                println!("input: {:?}", i);
-                println!("expected: {:?}", expected);
-                println!("detected: {:?}", x);
+                println!("input: {i:?}");
+                println!("expected: {expected:?}");
+                println!("detected: {x:?}");
                 unreachable!("unexpected parse result")
             }
             (Some(..), Err(e)) => {
-                println!("{}", e);
+                println!("{e}");
                 unreachable!("unexpected parse result")
             }
             (None, Ok((i, x))) => {
-                println!("input: {:?}", i);
+                println!("input: {i:?}");
                 println!("expected parse error");
-                println!("detected: {:?}", x);
+                println!("detected: {x:?}");
                 unreachable!("unexpected parse result")
             }
             (None, Err(_e)) => (),

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -22,12 +22,12 @@ impl<F: LurkField> fmt::Display for ParseErrorKind<F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::InvalidBase16EscapeSequence(seq, _) => {
-                write!(f, "Unknown base 16 string escape sequence {}.", seq)
+                write!(f, "Unknown base 16 string escape sequence {seq}.")
             }
             Self::ParseIntErr(e) => {
-                write!(f, "Error parsing number: {}", e)
+                write!(f, "Error parsing number: {e}")
             }
-            e => write!(f, "internal parser error {:?}", e),
+            e => write!(f, "internal parser error {e:?}"),
         }
     }
 }
@@ -98,7 +98,7 @@ impl<'a, F: LurkField> fmt::Display for ParseError<Span<'a>, F> {
         writeln!(&mut res, "^")?;
 
         if let Some(exp) = self.expected {
-            writeln!(&mut res, "Expected {}", exp)?;
+            writeln!(&mut res, "Expected {exp}")?;
         }
 
         let mut errs = self.errors.iter().filter(|x| !x.is_nom_err()).peekable();
@@ -109,12 +109,12 @@ impl<'a, F: LurkField> fmt::Display for ParseError<Span<'a>, F> {
             Some(_) => {
                 writeln!(&mut res, "Reported errors:")?;
                 for kind in errs {
-                    writeln!(&mut res, "- {}", kind)?;
+                    writeln!(&mut res, "- {kind}")?;
                 }
             }
         }
 
-        write!(f, "{}", res)
+        write!(f, "{res}")
     }
 }
 

--- a/src/parser/position.rs
+++ b/src/parser/position.rs
@@ -47,8 +47,8 @@ impl Pos {
         upto_column: usize,
     ) -> String {
         let mut res = String::new();
-        let gutter = format!("{}", upto_line).len();
-        let pad = format!("{: >gutter$}", from_line, gutter = gutter).len() + 3 + from_column;
+        let gutter = format!("{upto_line}").len();
+        let pad = format!("{from_line: >gutter$}").len() + 3 + from_column;
         res.push_str(&format!("{}▼\n", " ".to_owned().repeat(pad)));
         for (line_number, line) in input.lines().enumerate() {
             if ((line_number + 1) >= from_line) && ((line_number + 1) <= upto_line) {
@@ -60,7 +60,7 @@ impl Pos {
                 ));
             }
         }
-        let pad = format!("{: >gutter$}", upto_line, gutter = gutter).len() + 3 + upto_column;
+        let pad = format!("{upto_line: >gutter$}").len() + 3 + upto_column;
         res.push_str(&format!("{}▲", " ".to_owned().repeat(pad)));
         res
     }

--- a/src/parser/string.rs
+++ b/src/parser/string.rs
@@ -212,19 +212,19 @@ pub mod tests {
         match (expected, p.parse(Span::new(i))) {
             (Some(expected), Ok((_i, x))) if x == expected => (),
             (Some(expected), Ok((i, x))) => {
-                println!("input: {:?}", i);
-                println!("expected: {:?}", expected);
-                println!("detected: {:?}", x);
+                println!("input: {i:?}");
+                println!("expected: {expected:?}");
+                println!("detected: {x:?}");
                 unreachable!("unexpected parse result")
             }
             (Some(..), Err(e)) => {
-                println!("{}", e);
+                println!("{e}");
                 unreachable!("unexpected parse result")
             }
             (None, Ok((i, x))) => {
-                println!("input: {:?}", i);
+                println!("input: {i:?}");
                 println!("expected parse error");
-                println!("detected: {:?}", x);
+                println!("detected: {x:?}");
                 unreachable!("unexpected parse result")
             }
             (None, Err(_e)) => (),

--- a/src/parser/syntax.rs
+++ b/src/parser/syntax.rs
@@ -451,7 +451,7 @@ pub mod tests {
     {
         match (expected, p.parse(Span::<'a>::new(i))) {
             (Some(expected), Ok((_, x))) if x == expected => true,
-            (Some(_), Ok(..)) | (Some(..), Err(_)) | (None, Ok(..)) => {
+            (Some(_) | None, Ok(..)) | (Some(..), Err(_)) => {
                 // println!("input: {:?}", i);
                 // println!("expected parse error");
                 // println!("detected: {:?}", x);

--- a/src/parser/syntax.rs
+++ b/src/parser/syntax.rs
@@ -1007,7 +1007,7 @@ pub mod tests {
     #[test]
     fn test_minus_zero_symbol() {
         let x: Syntax<Scalar> = symbol!(["-0"]);
-        let text = format!("{}", x);
+        let text = format!("{x}");
         let (_, res) = parse_syntax(State::default().rccell(), false, true)(Span::new(&text))
             .expect("valid parse");
         assert_eq!(x, res)

--- a/src/proof/groth16.rs
+++ b/src/proof/groth16.rs
@@ -156,7 +156,7 @@ impl<C: Coprocessor<Scalar>> Groth16Prover<Bls12, C, Scalar> {
         let mut multiframe_proofs = Vec::with_capacity(multiframes_count);
 
         let last_multiframe = multiframes.last().unwrap().clone();
-        for multiframe in multiframes.into_iter() {
+        for multiframe in multiframes {
             statements.push(multiframe.public_inputs());
             let proof = self.prove(multiframe.clone(), params, &mut rng).unwrap();
 

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -260,7 +260,7 @@ where
         &'a self,
         pp: &'a PublicParams<'_, F, C>,
         frames: &[Frame<IO<F>, Witness<F>, F, C>],
-        store: &'a mut Store<F>,
+        store: &'a Store<F>,
         lang: Arc<Lang<F, C>>,
     ) -> Result<(Proof<'_, F, C>, Vec<F>, Vec<F>, usize), ProofError> {
         let z0 = frames[0].input.to_vector(store)?;

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -97,8 +97,6 @@ where
     <<G1<F> as Group>::Scalar as PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as PrimeField>::Repr: Abomonation,
     <F as PrimeField>::Repr: Abomonation,
-    C: Coprocessor<F>,
-    F: CurveCycleEquipped + LurkField,
     <<<F as CurveCycleEquipped>::G2 as Group>::Scalar as PrimeField>::Repr: Abomonation,
 {
     /// Proves the computation recursively, generating a recursive SNARK proof.

--- a/src/public_parameters/disk_cache.rs
+++ b/src/public_parameters/disk_cache.rs
@@ -13,7 +13,7 @@ use crate::public_parameters::error::Error;
 pub(crate) struct PublicParamDiskCache<F, C>
 where
     F: CurveCycleEquipped,
-    C: Coprocessor<F> + 'static,
+    C: Coprocessor<F>,
 {
     dir: Utf8PathBuf,
     _t: PhantomData<(F, C)>,

--- a/src/public_parameters/mem_cache.rs
+++ b/src/public_parameters/mem_cache.rs
@@ -40,7 +40,7 @@ pub(crate) static PUBLIC_PARAM_MEM_CACHE: Lazy<PublicParamMemCache> =
 impl PublicParamMemCache {
     fn get_from_disk_cache_or_update_with<
         F: CurveCycleEquipped,
-        C: Coprocessor<F> + 'static,
+        C: Coprocessor<F>,
         Fn: FnOnce(Arc<Lang<F, C>>) -> Arc<PublicParams<'static, F, C>>,
     >(
         &'static self,

--- a/src/public_parameters/mem_cache.rs
+++ b/src/public_parameters/mem_cache.rs
@@ -126,7 +126,7 @@ impl PublicParamMemCache {
         // retrieve the per-Coproc public param table
         let entry = mem_cache.entry::<PublicParamMap<F, C>>();
         // deduce the map and populate it if needed
-        let param_entry = entry.or_insert_with(HashMap::new);
+        let param_entry = entry.or_default();
         match param_entry.entry((rc, abomonated)) {
             Entry::Occupied(o) => Ok(o.into_mut()),
             Entry::Vacant(v) => {

--- a/src/public_parameters/mem_cache.rs
+++ b/src/public_parameters/mem_cache.rs
@@ -80,7 +80,7 @@ impl PublicParamMemCache {
                     disk_cache
                         .set_abomonated(&key, &*pp)
                         .tap_ok(|_| info!("writing public params to disk-cache: {}", lang_key))
-                        .map_err(|e| Error::CacheError(format!("Disk write error: {e}")))?;
+                        .map_err(|e| Error::CacheError(format!("Disk write error: {}", e)))?;
                     Ok(pp)
                 }
                 _ => unreachable!(),
@@ -95,7 +95,7 @@ impl PublicParamMemCache {
                 disk_cache
                     .set(&key, &*pp)
                     .tap_ok(|_| info!("writing public params to disk-cache: {}", lang_key))
-                    .map_err(|e| Error::CacheError(format!("Disk write error: {e}")))?;
+                    .map_err(|e| Error::CacheError(format!("Disk write error: {}", e)))?;
                 Ok(pp)
             }
         }

--- a/src/public_parameters/mod.rs
+++ b/src/public_parameters/mod.rs
@@ -78,7 +78,7 @@ where
         Ok(mut bytes) => {
             if let Some((pp, remaining)) = unsafe { decode(&mut bytes) } {
                 assert!(remaining.is_empty());
-                eprintln!("Using disk-cached public params for lang {}", lang_key);
+                eprintln!("Using disk-cached public params for lang {lang_key}");
                 Ok(bind(pp))
             } else {
                 eprintln!("failed to decode bytes");

--- a/src/public_parameters/mod.rs
+++ b/src/public_parameters/mod.rs
@@ -88,7 +88,7 @@ where
                 // maybe just directly write
                 disk_cache
                     .set_abomonated(&key, &pp)
-                    .map_err(|e| Error::CacheError(format!("Disk write error: {e}")))?;
+                    .map_err(|e| Error::CacheError(format!("Disk write error: {}", e)))?;
                 Ok(bind(&pp))
             }
         }
@@ -98,7 +98,7 @@ where
             // maybe just directly write
             disk_cache
                 .set_abomonated(&key, &pp)
-                .map_err(|e| Error::CacheError(format!("Disk write error: {e}")))?;
+                .map_err(|e| Error::CacheError(format!("Disk write error: {}", e)))?;
             Ok(bind(&pp))
         }
     }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -106,8 +106,6 @@ pub trait ReplTrait<F: LurkField, C: Coprocessor<F>> {
         state: Rc<RefCell<State>>,
         file_path: P,
     ) -> Result<()> {
-        let file_path = file_path;
-
         let input = read_to_string(file_path)?;
         eprintln!(
             "Read from {}: {}",
@@ -324,7 +322,7 @@ pub fn run_repl<P: AsRef<Path>, F: LurkField, T: ReplTrait<F, C>, C: Coprocessor
 }
 
 impl<F: LurkField, C: Coprocessor<F>> ReplState<F, C> {
-    pub fn new(s: &mut Store<F>, limit: usize, command: Option<Command>, lang: Lang<F, C>) -> Self {
+    pub fn new(s: &Store<F>, limit: usize, command: Option<Command>, lang: Lang<F, C>) -> Self {
         Self {
             env: empty_sym_env(s),
             limit,

--- a/src/state.rs
+++ b/src/state.rs
@@ -151,15 +151,15 @@ impl State {
 
         // bootstrap the lurk package
         let mut lurk_package = Package::new(root_package.intern(LURK_PACKAGE_SYMBOL_NAME.into()));
-        LURK_PACKAGE_SYMBOLS_NAMES.iter().for_each(|symbol_name| {
+        for symbol_name in LURK_PACKAGE_SYMBOLS_NAMES.iter() {
             lurk_package.intern((*symbol_name).to_string());
-        });
+        }
 
         // bootstrap the meta package
         let mut meta_package = Package::new(lurk_package.intern(META_PACKAGE_SYMBOL_NAME.into()));
-        META_PACKAGE_SYMBOLS_NAMES.iter().for_each(|symbol_name| {
+        for symbol_name in META_PACKAGE_SYMBOLS_NAMES.iter() {
             meta_package.intern((*symbol_name).to_string());
-        });
+        }
 
         // bootstrap the user package
         let mut user_package = Package::new(lurk_package.intern(USER_PACKAGE_SYMBOL_NAME.into()));

--- a/src/store.rs
+++ b/src/store.rs
@@ -798,7 +798,10 @@ impl<F: LurkField> Store<F> {
     }
 
     pub fn fetch_cont(&self, ptr: &ContPtr<F>) -> Option<Continuation<F>> {
-        use ContTag::*;
+        use ContTag::{
+            Binop, Binop2, Call, Call0, Call2, Dummy, Emit, Error, If, Let, LetRec, Lookup,
+            Outermost, Tail, Terminal, Unop,
+        };
         match ptr.tag {
             Outermost => Some(Continuation::Outermost),
             Call0 => self
@@ -1413,7 +1416,9 @@ impl<F: LurkField> Store<F> {
         if let Some(ptr) = self.fetch_z_expr_ptr(z_ptr) {
             Some(ptr)
         } else {
-            use ZExpr::*;
+            use ZExpr::{
+                Char, Comm, Cons, EmptyStr, Fun, Key, Nil, Num, RootSym, Str, Sym, Thunk, UInt,
+            };
             match (z_ptr.tag(), z_store.get_expr(z_ptr)) {
                 (ExprTag::Nil, Some(Nil)) => {
                     let ptr = lurk_sym_ptr!(self, nil);
@@ -1525,7 +1530,10 @@ impl<F: LurkField> Store<F> {
         z_ptr: &ZContPtr<F>,
         z_store: &ZStore<F>,
     ) -> Option<ContPtr<F>> {
-        use ZCont::*;
+        use ZCont::{
+            Binop, Binop2, Call, Call0, Call2, Dummy, Emit, Error, If, Let, LetRec, Lookup,
+            Outermost, Tail, Terminal, Unop,
+        };
         let tag: ContTag = z_ptr.tag();
 
         if let Some(cont) = z_store.get_cont(z_ptr) {
@@ -1891,7 +1899,10 @@ pub mod test {
 
     #[test]
     fn cont_tag_vals() {
-        use super::ContTag::*;
+        use super::ContTag::{
+            Binop, Binop2, Call, Call0, Call2, Dummy, Emit, Error, If, Let, LetRec, Lookup,
+            Outermost, Tail, Terminal, Unop,
+        };
 
         assert_eq!(0b0001_0000_0000_0000, Outermost as u16);
         assert_eq!(0b0001_0000_0000_0001, Call0 as u16);

--- a/src/store.rs
+++ b/src/store.rs
@@ -625,7 +625,7 @@ impl<F: LurkField> Store<F> {
     // fetch a symbol cons or keyword cons
     pub fn fetch_symcons(&self, ptr: &Ptr<F>) -> Option<(Ptr<F>, Ptr<F>)> {
         match (ptr.tag, ptr.raw) {
-            (ExprTag::Sym, RawPtr::Index(x)) | (ExprTag::Key, RawPtr::Index(x)) => {
+            (ExprTag::Sym | ExprTag::Key, RawPtr::Index(x)) => {
                 let (car, cdr) = self.sym_store.get_index(x)?;
                 Some((*car, *cdr))
             }

--- a/src/store.rs
+++ b/src/store.rs
@@ -1295,8 +1295,7 @@ impl<F: LurkField> Store<F> {
             ExprTag::Cons => match self.fetch(ptr) {
                 Some(Expression::Cons(car, cdr)) => Ok((car, cdr)),
                 e => Err(Error(format!(
-                    "Can only extract car_cdr from known Cons, instead got {:?} {:?}",
-                    ptr, e,
+                    "Can only extract car_cdr from known Cons, instead got {ptr:?} {e:?}",
                 ))),
             },
             ExprTag::Str => match self.fetch(ptr) {

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -178,7 +178,7 @@ impl Symbol {
         let mut res = String::new();
         for x in xs.chars() {
             if ESCAPE_CHARS.chars().any(|c| c == x) {
-                res.push_str(&format!("\\{}", x));
+                res.push_str(&format!("\\{x}"));
             } else if Self::is_whitespace(x) {
                 res.push_str(&format!("{}", x.escape_unicode()));
             } else {
@@ -419,8 +419,8 @@ pub mod test {
         let a_b = a.direct_child("b");
         let a_b_path = vec!["a", "b"];
 
-        assert_eq!(".a", format!("{}", a));
-        assert_eq!(".a.b", format!("{}", a_b));
+        assert_eq!(".a", format!("{a}"));
+        assert_eq!(".a.b", format!("{a_b}"));
         assert_eq!(&a_b_path, &a_b.path);
         assert_eq!(Some(a.clone()), a_b.direct_parent());
         assert_eq!(Some(root.clone()), a.direct_parent());
@@ -437,8 +437,8 @@ pub mod test {
 
         assert!(!root.is_keyword());
         assert!(key_root.is_keyword());
-        assert_eq!(".apple", format!("{}", apple));
-        assert_eq!(":orange", format!("{}", orange));
+        assert_eq!(".apple", format!("{apple}"));
+        assert_eq!(":orange", format!("{orange}"));
         assert!(!apple.is_keyword());
         assert!(orange.is_keyword());
         assert_eq!(key_root, orange.direct_parent().unwrap());

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -68,25 +68,25 @@ impl<Fr: LurkField> Arbitrary for Syntax<Fr> {
 impl<F: LurkField> fmt::Display for Syntax<F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Num(_, x) => write!(f, "{}", x),
-            Self::UInt(_, x) => write!(f, "{}u64", x),
-            Self::Symbol(_, x) => write!(f, "{}", x),
+            Self::Num(_, x) => write!(f, "{x}"),
+            Self::UInt(_, x) => write!(f, "{x}u64"),
+            Self::Symbol(_, x) => write!(f, "{x}"),
             Self::String(_, x) => write!(f, "\"{}\"", x.escape_default()),
             Self::Char(_, x) => {
                 if *x == '(' || *x == ')' {
-                    write!(f, "'\\{}'", x)
+                    write!(f, "'\\{x}'")
                 } else {
                     write!(f, "'{}'", x.escape_default())
                 }
             }
-            Self::Quote(_, x) => write!(f, "'{}", x),
+            Self::Quote(_, x) => write!(f, "'{x}"),
             Self::List(_, xs) => {
                 let mut iter = xs.iter().peekable();
                 write!(f, "(")?;
                 while let Some(x) = iter.next() {
                     match iter.peek() {
-                        Some(_) => write!(f, "{} ", x)?,
-                        None => write!(f, "{}", x)?,
+                        Some(_) => write!(f, "{x} ")?,
+                        None => write!(f, "{x}")?,
                     }
                 }
                 write!(f, ")")
@@ -96,7 +96,7 @@ impl<F: LurkField> fmt::Display for Syntax<F> {
                 write!(f, "(")?;
                 while let Some(x) = iter.next() {
                     match iter.peek() {
-                        Some(_) => write!(f, "{} ", x)?,
+                        Some(_) => write!(f, "{x} ")?,
                         None => write!(f, "{} . {}", x, *end)?,
                     }
                 }
@@ -226,28 +226,28 @@ mod test {
         // Quote tests
         let expr = list!(lurk_sym_ptr!(s, quote), list!(sym!(f), sym!(x), sym!(y)));
         let output = s.fetch_syntax(expr).unwrap();
-        assert_eq!("(.lurk.quote (.f .x .y))", &format!("{}", output));
+        assert_eq!("(.lurk.quote (.f .x .y))", &format!("{output}"));
 
         let expr = list!(lurk_sym_ptr!(s, quote), list!(sym!(f), sym!(x), sym!(y)));
         let output = s.fetch_syntax(expr).unwrap();
-        assert_eq!("(.lurk.quote (.f .x .y))", &format!("{}", output));
+        assert_eq!("(.lurk.quote (.f .x .y))", &format!("{output}"));
 
         let expr = list!(lurk_sym_ptr!(s, quote), sym!(f), sym!(x), sym!(y));
         let output = s.fetch_syntax(expr).unwrap();
-        assert_eq!("(.lurk.quote .f .x .y)", &format!("{}", output));
+        assert_eq!("(.lurk.quote .f .x .y)", &format!("{output}"));
 
         // List tests
         let expr = list!();
         let output = s.fetch_syntax(expr).unwrap();
-        assert_eq!(".lurk.nil", &format!("{}", output));
+        assert_eq!(".lurk.nil", &format!("{output}"));
 
         let expr = improper!(sym!(x), sym!(y), sym!(z));
         let output = s.fetch_syntax(expr).unwrap();
-        assert_eq!("(.x .y . .z)", &format!("{}", output));
+        assert_eq!("(.x .y . .z)", &format!("{output}"));
 
         let expr = improper!(sym!(x), sym!(y), lurk_sym_ptr!(s, nil));
         let output = s.fetch_syntax(expr).unwrap();
-        assert_eq!("(.x .y)", &format!("{}", output));
+        assert_eq!("(.x .y)", &format!("{output}"));
     }
 
     #[test]

--- a/src/syntax_macros.rs
+++ b/src/syntax_macros.rs
@@ -1,10 +1,10 @@
 #[macro_export]
 macro_rules! num {
     ($f:ty, $i:literal) => {
-        $crate::syntax::Syntax::<$f>::Num(Pos::No, ($i as u64).into())
+        $crate::syntax::Syntax::<$f>::Num(Pos::No, ($i).into())
     };
     ($i:literal) => {
-        $crate::syntax::Syntax::Num(Pos::No, ($i as u64).into())
+        $crate::syntax::Syntax::Num(Pos::No, ($i).into())
     };
     ($i:expr) => {
         $crate::syntax::Syntax::Num(Pos::No, $i)
@@ -14,10 +14,10 @@ macro_rules! num {
 #[macro_export]
 macro_rules! uint {
     ($f:ty, $i:literal) => {
-        $crate::syntax::Syntax::<$f>::UInt(Pos::No, $crate::uint::UInt::U64($i as u64))
+        $crate::syntax::Syntax::<$f>::UInt(Pos::No, $crate::uint::UInt::U64($i))
     };
     ($i:literal) => {
-        $crate::syntax::Syntax::UInt(Pos::No, $crate::uint::UInt::U64($i as u64))
+        $crate::syntax::Syntax::UInt(Pos::No, $crate::uint::UInt::U64($i))
     };
 }
 

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -7,7 +7,9 @@ use std::{convert::TryFrom, fmt};
 use crate::field::LurkField;
 use crate::ptr::TypePredicates;
 
-pub trait Tag: Into<u16> + TryFrom<u16> + Copy + Sized + std::hash::Hash + Eq + fmt::Debug {
+pub trait Tag:
+    Into<u16> + TryFrom<u16, Error = anyhow::Error> + Copy + Sized + std::hash::Hash + Eq + fmt::Debug
+{
     fn from_field<F: LurkField>(f: &F) -> Option<Self>;
     fn to_field<F: LurkField>(&self) -> F;
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -62,7 +62,9 @@ fn write_symbol<W: io::Write>(w: &mut W, sym: Symbol, state: &State) -> io::Resu
 
 impl<F: LurkField> Write<F> for Expression<F> {
     fn fmt<W: io::Write>(&self, store: &Store<F>, state: &State, w: &mut W) -> io::Result<()> {
-        use Expression::*;
+        use Expression::{
+            Char, Comm, Cons, EmptyStr, Fun, Key, Nil, Num, RootKey, RootSym, Str, Sym, Thunk, UInt,
+        };
 
         match self {
             Nil => write!(w, "nil"),

--- a/src/z_data.rs
+++ b/src/z_data.rs
@@ -62,7 +62,7 @@ impl Display for ZData {
                     .map(|x| format!("{:02x?}", x))
                     .collect::<Vec<_>>()
                     .join(", ");
-                write!(f, "a:{}", xs_str)?;
+                write!(f, "a:{xs_str}")?;
             }
             Self::Cell(xs) => {
                 let xs_str = xs
@@ -70,7 +70,7 @@ impl Display for ZData {
                     .map(|x| format!("{}", x))
                     .collect::<Vec<_>>()
                     .join(", ");
-                write!(f, "c:{}", xs_str)?;
+                write!(f, "c:{xs_str}")?;
             }
         }
         write!(f, "]")?;

--- a/src/z_data.rs
+++ b/src/z_data.rs
@@ -200,7 +200,7 @@ impl ZData {
             (i, ZData::Atom(data.to_vec()))
         } else {
             let (i, xs) = count(ZData::from_bytes_aux, size)(i)?;
-            (i, ZData::Cell(xs.to_vec()))
+            (i, ZData::Cell(xs))
         };
 
         Ok((i, res))

--- a/src/z_data/serde/de.rs
+++ b/src/z_data/serde/de.rs
@@ -49,9 +49,9 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             ZData::Atom(x) if x.len() == 1 => match x[0] {
                 0u8 => visitor.visit_bool(false),
                 1u8 => visitor.visit_bool(true),
-                err => Err(SerdeError::Type(format!("expected bool, got: {}", err))),
+                err => Err(SerdeError::Type(format!("expected bool, got: {err}"))),
             },
-            err => Err(SerdeError::Type(format!("expected bool, got: {}", err))),
+            err => Err(SerdeError::Type(format!("expected bool, got: {err}"))),
         }
     }
 
@@ -105,7 +105,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     {
         match self.input {
             ZData::Atom(x) if x.len() == 1 => visitor.visit_u8(x[0]),
-            err => Err(SerdeError::Type(format!("expected u8, got: {}", err))),
+            err => Err(SerdeError::Type(format!("expected u8, got: {err}"))),
         }
     }
 
@@ -119,7 +119,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 let a: [u8; 2] = x.clone().try_into().unwrap();
                 visitor.visit_u16(u16::from_le_bytes(a))
             }
-            err => Err(SerdeError::Type(format!("expected u16, got: {}", err))),
+            err => Err(SerdeError::Type(format!("expected u16, got: {err}"))),
         }
     }
 
@@ -133,7 +133,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 let a: [u8; 4] = x.clone().try_into().unwrap();
                 visitor.visit_u32(u32::from_le_bytes(a))
             }
-            err => Err(SerdeError::Type(format!("expected u32: got {}", err))),
+            err => Err(SerdeError::Type(format!("expected u32: got {err}"))),
         }
     }
 
@@ -147,7 +147,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 let a: [u8; 8] = x.clone().try_into().unwrap();
                 visitor.visit_u64(u64::from_le_bytes(a))
             }
-            err => Err(SerdeError::Type(format!("expected u64: got {}", err))),
+            err => Err(SerdeError::Type(format!("expected u64: got {err}"))),
         }
     }
 
@@ -182,10 +182,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             .map_err(|e| SerdeError::Type(format!("expected char: {}", e)))?;
         match char::from_u32(num) {
             Some(a) => visitor.visit_char(a),
-            None => Err(SerdeError::Type(format!(
-                "failed to get char from: {}",
-                num
-            ))),
+            None => Err(SerdeError::Type(format!("failed to get char from: {num}"))),
         }
     }
 
@@ -203,12 +200,12 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                             v.push(char::deserialize(&mut Deserializer::from_z_data(zd))?)
                         }
                         err => {
-                            return Err(SerdeError::Type(format!("expected string, got: {}", err)))
+                            return Err(SerdeError::Type(format!("expected string, got: {err}")))
                         }
                     }
                 }
             }
-            err => return Err(SerdeError::Type(format!("expected string, got: {}", err))),
+            err => return Err(SerdeError::Type(format!("expected string, got: {err}"))),
         }
         visitor.visit_str(&v.into_iter().collect::<String>())
     }
@@ -228,7 +225,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     {
         match self.input {
             ZData::Atom(x) => visitor.visit_bytes(x),
-            err => Err(SerdeError::Type(format!("expected bytes, got: {}", err))),
+            err => Err(SerdeError::Type(format!("expected bytes, got: {err}"))),
         }
     }
 
@@ -248,11 +245,11 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         match self.input {
             ZData::Atom(x) => match x.as_slice() {
                 [] => visitor.visit_none(),
-                err => Err(SerdeError::Type(format!("expected Option, got: {:?}", err))),
+                err => Err(SerdeError::Type(format!("expected Option, got: {err:?}"))),
             },
             ZData::Cell(xs) => match xs.as_slice() {
                 [a] => visitor.visit_some(&mut Deserializer::from_z_data(a)),
-                err => Err(SerdeError::Type(format!("expected Option, got: {:?}", err))),
+                err => Err(SerdeError::Type(format!("expected Option, got: {err:?}"))),
             },
         }
     }
@@ -265,12 +262,9 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         match self.input {
             ZData::Atom(x) => match x.as_slice() {
                 [] => visitor.visit_none(),
-                err => Err(SerdeError::Type(format!(
-                    "expected Unit (), got: {:?}",
-                    err
-                ))),
+                err => Err(SerdeError::Type(format!("expected Unit (), got: {err:?}"))),
             },
-            err => Err(SerdeError::Type(format!("expected Unit (), got: {}", err))),
+            err => Err(SerdeError::Type(format!("expected Unit (), got: {err}"))),
         }
     }
 
@@ -305,7 +299,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     {
         match self.input {
             ZData::Cell(xs) => visitor.visit_seq(SeqAccess::new(xs, 0)),
-            err => Err(SerdeError::Type(format!("expected sequence, got: {}", err))),
+            err => Err(SerdeError::Type(format!("expected sequence, got: {err}"))),
         }
     }
 
@@ -337,7 +331,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     {
         match self.input {
             ZData::Cell(xs) => visitor.visit_map(MapAccess::new(xs)),
-            err => Err(SerdeError::Type(format!("expected map, got: {}", err))),
+            err => Err(SerdeError::Type(format!("expected map, got: {err}"))),
         }
     }
 
@@ -370,9 +364,9 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                     let variant = String::from(variants[idx_vec[0] as usize]);
                     visitor.visit_enum(Enum::new(self, variant, 1))
                 }
-                err => Err(SerdeError::Type(format!("expected enum, got: {}", err))),
+                err => Err(SerdeError::Type(format!("expected enum, got: {err}"))),
             },
-            err => Err(SerdeError::Type(format!("expected enum, got: {}", err))),
+            err => Err(SerdeError::Type(format!("expected enum, got: {err}"))),
         }
     }
 
@@ -515,8 +509,7 @@ impl<'de, 'a> de::VariantAccess<'de> for Enum<'a, 'de> {
             ZData::Cell(xs) if xs.len() > 1 => Deserializer::from_z_data(&xs[1]),
             err => {
                 return Err(SerdeError::Type(format!(
-                    "expected newtype variant, got: {}",
-                    err
+                    "expected newtype variant, got: {err}"
                 )))
             }
         };
@@ -529,7 +522,7 @@ impl<'de, 'a> de::VariantAccess<'de> for Enum<'a, 'de> {
     {
         match self.de.input {
             ZData::Cell(xs) => visitor.visit_seq(SeqAccess::new(xs, self.index)),
-            err => Err(SerdeError::Type(format!("expected sequence, got: {}", err))),
+            err => Err(SerdeError::Type(format!("expected sequence, got: {err}"))),
         }
     }
 

--- a/src/z_data/z_expr.rs
+++ b/src/z_data/z_expr.rs
@@ -55,25 +55,25 @@ impl<F: LurkField> std::fmt::Display for ZExpr<F> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ZExpr::Nil => write!(f, "nil"),
-            ZExpr::Cons(x, y) => write!(f, "({} . {})", x, y),
-            ZExpr::Str(x, y) => write!(f, "(str {} {})", x, y),
-            ZExpr::Sym(x, y) => write!(f, "(sym {} {})", x, y),
-            ZExpr::Key(x, y) => write!(f, "(key {} {})", x, y),
+            ZExpr::Cons(x, y) => write!(f, "({x} . {y})"),
+            ZExpr::Str(x, y) => write!(f, "(str {x} {y})"),
+            ZExpr::Sym(x, y) => write!(f, "(sym {x} {y})"),
+            ZExpr::Key(x, y) => write!(f, "(key {x} {y})"),
             ZExpr::Comm(ff, x) => {
                 write!(f, "(comm {} {})", ff.trimmed_hex_digits(), x)
             }
             ZExpr::EmptyStr => write!(f, "emptystr"),
             ZExpr::RootSym => write!(f, "rootsym"),
             ZExpr::RootKey => write!(f, "rootkey"),
-            ZExpr::Thunk(val, cont) => write!(f, "(thunk {} {})", val, cont),
+            ZExpr::Thunk(val, cont) => write!(f, "(thunk {val} {cont})"),
             ZExpr::Fun {
                 arg,
                 body,
                 closed_env,
-            } => write!(f, "(fun {} {} {})", arg, body, closed_env),
-            ZExpr::Char(x) => write!(f, "(char {})", x),
-            ZExpr::Num(x) => write!(f, "(num  {:?})", x),
-            ZExpr::UInt(x) => write!(f, "(uint {})", x),
+            } => write!(f, "(fun {arg} {body} {closed_env})"),
+            ZExpr::Char(x) => write!(f, "(char {x})"),
+            ZExpr::Num(x) => write!(f, "(num  {x:?})"),
+            ZExpr::UInt(x) => write!(f, "(uint {x})"),
         }
     }
 }

--- a/src/z_data/z_ptr.rs
+++ b/src/z_data/z_ptr.rs
@@ -116,11 +116,11 @@ impl<E: Tag, F: LurkField> ZPtr<E, F> {
     /// Converts a base32-encoded string to a ZPtr
     pub fn from_base32(zptr: &str) -> Result<Self, anyhow::Error> {
         let tag_bytes = Base32Unpadded::decode_vec(&zptr[0..4])
-            .map_err(|_| anyhow!("Failed to decode base32"))?;
+            .map_err(|e| anyhow!(format!("Failed to decode base32: {}", e)))?;
         let val_bytes = Base32Unpadded::decode_vec(&zptr[5..])
-            .map_err(|_| anyhow!("Failed to decode base32"))?;
+            .map_err(|e| anyhow!(format!("Failed to decode base32: {}", e)))?;
         let tag = E::try_from(u16::from_le_bytes(tag_bytes[..2].try_into().unwrap()))
-            .map_err(|_| anyhow!("Failed to decode tag"))?;
+            .map_err(|e| anyhow!(format!("Failed to decode tag: {}", e)))?;
         let val = F::from_bytes(&val_bytes).ok_or_else(|| anyhow!("Failed to decode field"))?;
         Ok(Self::from_parts(tag, val))
     }
@@ -135,7 +135,7 @@ impl<F: LurkField> ZExprPtr<F> {
         let mut store = Store::<F>::default();
         let ptr = store
             .read(value)
-            .map_err(|_| store::Error("Parse error".into()))?;
+            .map_err(|e| store::Error(format!("Parse error: {}", e)))?;
         let zptr = store
             .hash_expr(&ptr)
             .ok_or(store::Error("Invalid ptr".into()))?;

--- a/src/z_data/z_ptr.rs
+++ b/src/z_data/z_ptr.rs
@@ -54,21 +54,20 @@ impl<E: Tag + Display, F: LurkField> Display for ZPtr<E, F> {
 
 impl<E: Tag, F: LurkField> PartialOrd for ZPtr<E, F> {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        (
-            self.0.to_field_bytes::<F>().as_ref(),
-            self.1.to_repr().as_ref(),
-        )
-            .partial_cmp(&(
-                other.0.to_field_bytes::<F>().as_ref(),
-                other.1.to_repr().as_ref(),
-            ))
+        Some(self.cmp(other))
     }
 }
 
 impl<E: Tag, F: LurkField> Ord for ZPtr<E, F> {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        self.partial_cmp(other)
-            .expect("ZPtr::cmp: partial_cmp domain invariant violation")
+        (
+            self.0.to_field_bytes::<F>().as_ref(),
+            self.1.to_repr().as_ref(),
+        )
+            .cmp(&(
+                other.0.to_field_bytes::<F>().as_ref(),
+                other.1.to_repr().as_ref(),
+            ))
     }
 }
 

--- a/src/z_data/z_ptr.rs
+++ b/src/z_data/z_ptr.rs
@@ -110,7 +110,7 @@ impl<E: Tag, F: LurkField> ZPtr<E, F> {
     pub fn to_base32(&self) -> String {
         let tag_b32 = Base32Unpadded::encode_string(&self.0.into().to_le_bytes());
         let val_b32 = Base32Unpadded::encode_string(self.1.to_repr().as_ref());
-        format!("{}z{}", tag_b32, val_b32)
+        format!("{tag_b32}z{val_b32}")
     }
 
     /// Converts a base32-encoded string to a ZPtr

--- a/tests/lurk-cli-tests.rs
+++ b/tests/lurk-cli-tests.rs
@@ -65,13 +65,13 @@ fn test_config_file() {
 
     let mut config_file = File::create(&config_dir).unwrap();
     config_file
-        .write_all(format!("public_params = \"{}\"\n", public_params_dir).as_bytes())
+        .write_all(format!("public_params = \"{public_params_dir}\"\n").as_bytes())
         .unwrap();
     config_file
-        .write_all(format!("proofs = \"{}\"\n", proofs_dir).as_bytes())
+        .write_all(format!("proofs = \"{proofs_dir}\"\n").as_bytes())
         .unwrap();
     config_file
-        .write_all(format!("commits = \"{}\"\n", commits_dir).as_bytes())
+        .write_all(format!("commits = \"{commits_dir}\"\n").as_bytes())
         .unwrap();
 
     // Overwrite proof dir with env var


### PR DESCRIPTION
- Enhanced error messages in multiple modules (`clutch/src/lib.rs`, `fcomm/src/lib.rs`, `src/z_data/z_ptr.rs`, and `src/public_parameters/mem_cache.rs`).
- This includes displaying previously-silenced specific errors in proof key generation, expression/environment reading, base32 decoding, and disk write errors in the public parameters module.
- Included `map_err_ignore` in project-wide Clippy lints in `.cargo/config` to increase overall quality of error handling.
- ran a pass of inlining format arguments (using clippy)

## Edit (Sept 17)
This now includes #673 :
- removing an unnecessary panic,
- removing global imports from LEM,
- removing trivial numeric cases,
- turning single-case matches into `if let`s in cases where it's more concise, and assorted `Option`/`Result` combinators

## Edit (Sept 19)
- clippy-driven removal of unused `&mut` parameters