### PR TITLE
Fix soundness and optimize divrem

### DIFF
--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -5071,7 +5071,7 @@ fn to_u64<F: LurkField, CS: ConstraintSystem<F>>(
 // equal to False. But even if cond is True, we output correct
 // q and r, as if arg1 and arg2 were indeed u64 elements,
 // which is obtained by ignoring most significant bits from arg1
-// and arg2, respectivelly.
+// and arg2, respectively.
 fn enforce_u64_div_mod<F: LurkField, CS: ConstraintSystem<F>>(
     mut cs: CS,
     cond: &Boolean,

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -3955,7 +3955,9 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             &arg2_is_num,
         )?;
         let arg1_is_u64 = arg1.is_u64(&mut cs.namespace(|| "arg1_is_u64"))?;
+        implies_u64(cs.namespace(|| "arg1 fits in u64"), &arg1_is_u64, arg1.hash())?;
         let arg2_is_u64 = arg2.is_u64(&mut cs.namespace(|| "arg2_is_u64"))?;
+        implies_u64(cs.namespace(|| "arg2 fits in u64"), &arg2_is_u64, arg2.hash())?;
         let both_args_are_u64s = Boolean::and(
             &mut cs.namespace(|| "both_args_are_u64s"),
             &arg1_is_u64,
@@ -5560,9 +5562,9 @@ mod tests {
             assert!(delta == Delta::Equal);
 
             // println!("{}", print_cs(&cs));
-            assert_eq!(11839, cs.num_constraints());
+            assert_eq!(11969, cs.num_constraints());
             assert_eq!(13, cs.num_inputs());
-            assert_eq!(11494, cs.aux().len());
+            assert_eq!(11622, cs.aux().len());
 
             let public_inputs = multiframe.public_inputs();
             let mut rng = rand::thread_rng();

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -5099,16 +5099,12 @@ fn enforce_u64_div_mod<F: LurkField, CS: ConstraintSystem<F>>(
         AllocatedNum::alloc_infallible(&mut cs.namespace(|| "r num"), || F::from_u64(r));
     let alloc_q_num =
         AllocatedNum::alloc_infallible(&mut cs.namespace(|| "q num"), || F::from_u64(q));
-    let alloc_arg1_num =
-        AllocatedNum::alloc_infallible(&mut cs.namespace(|| "arg1 num"), || F::from_u64(arg1_u64));
-    let alloc_arg2_num =
-        AllocatedNum::alloc_infallible(&mut cs.namespace(|| "arg2 num"), || F::from_u64(arg2_u64));
 
     // a = b * q + r
     let product_u64mod = mul(
         &mut cs.namespace(|| "product(q,arg2)"),
         &alloc_q_num,
-        &alloc_arg2_num,
+        arg2.hash(),
     )?;
     let sum_u64mod = add(
         &mut cs.namespace(|| "sum remainder mod u64"),
@@ -5118,7 +5114,7 @@ fn enforce_u64_div_mod<F: LurkField, CS: ConstraintSystem<F>>(
     let u64mod_decomp = alloc_equal(
         &mut cs.namespace(|| "check u64 mod decomposition"),
         &sum_u64mod,
-        &alloc_arg1_num,
+        arg1.hash(),
     )?;
     let b_is_zero = alloc_is_zero(&mut cs.namespace(|| "b is zero"), arg2.hash())?;
     let b_is_not_zero_and_cond = Boolean::and(
@@ -5134,7 +5130,7 @@ fn enforce_u64_div_mod<F: LurkField, CS: ConstraintSystem<F>>(
 
     let diff = sub(
         cs.namespace(|| "diff for b and rem"),
-        &alloc_arg2_num,
+        arg2.hash(),
         &alloc_r_num,
     )?;
     implies_u64(cs.namespace(|| "div_u64"), cond, &alloc_q_num)?;
@@ -5564,7 +5560,7 @@ mod tests {
             // println!("{}", print_cs(&cs));
             assert_eq!(11969, cs.num_constraints());
             assert_eq!(13, cs.num_inputs());
-            assert_eq!(11622, cs.aux().len());
+            assert_eq!(11620, cs.aux().len());
 
             let public_inputs = multiframe.public_inputs();
             let mut rng = rand::thread_rng();

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -5115,7 +5115,7 @@ fn enforce_u64_div_mod<F: LurkField, CS: ConstraintSystem<F>>(
 
     let diff = sub(
         cs.namespace(|| "diff for b and rem"),
-        arg2.hash(),
+        &alloc_arg2_num,
         &alloc_r_num,
     )?;
     implies_u64(cs.namespace(|| "div_u64"), cond, &alloc_q_num)?;

--- a/src/eval/tests/mod.rs
+++ b/src/eval/tests/mod.rs
@@ -2197,6 +2197,7 @@ fn test_u64_mod() {
     let res2 = s.uint64(1);
 
     let expr3 = "(% 100u64 0u64)";
+    let expr4 = "(% 18446744073709551617u64 8u64)";
 
     let terminal = s.get_cont_terminal();
     let error = s.get_cont_error();
@@ -2204,6 +2205,7 @@ fn test_u64_mod() {
     test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 3, None);
     test_aux::<Coproc<Fr>>(s, expr2, Some(res2), None, Some(terminal), None, 3, None);
     test_aux::<Coproc<Fr>>(s, expr3, None, None, Some(error), None, 3, None);
+    test_aux::<Coproc<Fr>>(s, expr4, None, None, Some(error), None, 2, None);
 }
 
 #[test]

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -3630,6 +3630,7 @@ pub mod tests {
         let res2 = s.uint64(1);
 
         let expr3 = "(% 100u64 0u64)";
+        let expr4 = "(% 18446744073709551617u64 8u64)";
 
         let terminal = s.get_cont_terminal();
         let error = s.get_cont_error();
@@ -3637,6 +3638,7 @@ pub mod tests {
         test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 3, None);
         test_aux::<Coproc<Fr>>(s, expr2, Some(res2), None, Some(terminal), None, 3, None);
         test_aux::<Coproc<Fr>>(s, expr3, None, None, Some(error), None, 3, None);
+        test_aux::<Coproc<Fr>>(s, expr4, None, None, Some(error), None, 3, None);
     }
 
     #[test]

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -3638,7 +3638,7 @@ pub mod tests {
         test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 3, None);
         test_aux::<Coproc<Fr>>(s, expr2, Some(res2), None, Some(terminal), None, 3, None);
         test_aux::<Coproc<Fr>>(s, expr3, None, None, Some(error), None, 3, None);
-        test_aux::<Coproc<Fr>>(s, expr4, None, None, Some(error), None, 3, None);
+        test_aux::<Coproc<Fr>>(s, expr4, None, None, Some(error), None, 2, None);
     }
 
     #[test]


### PR DESCRIPTION
As @gabriel-barrett pointed out, we need to be careful while constraining Division with Remainder since the input `a` and `b` are field elements. 

When `a` and `b` are unsigned integers, we just need to check `0 <= rem < b`, and this condition is the classical condition present in all algebra books.  

However, in a field we need to check the quotient is well behaved, otherwise an adversary could choose a quotient that when multiplied by `b` gives him an arbitrary number **of his choice**, therefore allowing him to choose an invalid remainder as well.

In LEM we introduced a different way to non-deterministically check u64 range, which is more efficient. This way we avoided the soundness problem by enforcing u64 three times (`div`, `rem` and `b - rem`). 

By reusing the same ideas as in LEM we solved the soundness problem in the original hand-made circuit. We also optimized it, since three non-deterministic u64 range-checks  is still more efficient than one `to_bits_le_strict` or even `to_bits_le`.  

Function `enforce_less_than_bound` would only work for positive input (allowing the attacker to play with negative numbers to find the malicious quotient). Since it was only used for that purpose, and was unsound even for that specific usage, it was removed. 