### PR TITLE
Stable coprocessor order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ dashmap = "5.5.0"
 ff = { workspace = true }
 generic-array = "0.14.7"
 hex = { version = "0.4.3", features = ["serde"] }
-indexmap = { version = "1.9.3", features = ["rayon"] }
+indexmap = { version = "1.9.3", features = ["rayon", "serde"] }
 itertools = "0.9"
 lurk-macros = { path = "lurk-macros" }
 lurk-metrics = { path = "lurk-metrics" }


### PR DESCRIPTION
Use an `IndexMap` to stabilize the order of coprocessors in a Lang.

This stable order is needed in order to make LEM code generation for a Lang consistent, regardless of the internal algorithm that `HashMap` would use.

The `IndexMap` also comes in handy when we want to efficiently retrieve the index of a coprocessor. This will be useful for the implementation of NIVC.