### PR TITLE
Fix new REPL

### DIFF
--- a/src/cli/backend.rs
+++ b/src/cli/backend.rs
@@ -1,0 +1,49 @@
+use anyhow::{bail, Result};
+
+use crate::field::LanguageField;
+
+pub enum Backend {
+    Nova,
+    SnarkPackPlus,
+}
+
+impl std::fmt::Display for Backend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Nova => write!(f, "Nova"),
+            Self::SnarkPackPlus => write!(f, "SnarkPack+"),
+        }
+    }
+}
+
+impl Backend {
+    pub(crate) fn default_field(&self) -> LanguageField {
+        match self {
+            Self::Nova => LanguageField::Pallas,
+            Self::SnarkPackPlus => LanguageField::BLS12_381,
+        }
+    }
+
+    fn compatible_fields(&self) -> Vec<LanguageField> {
+        use LanguageField::*;
+        match self {
+            Self::Nova => vec![Pallas, Vesta],
+            Self::SnarkPackPlus => vec![BLS12_381],
+        }
+    }
+
+    pub(crate) fn validate_field(&self, field: &LanguageField) -> Result<()> {
+        let compatible_fields = self.compatible_fields();
+        if !compatible_fields.contains(field) {
+            bail!(
+                "Backend {self} is incompatible with field {field}. Compatible fields are:\n  {}",
+                compatible_fields
+                    .iter()
+                    .map(|f| f.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        }
+        Ok(())
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,9 +1,10 @@
+pub mod backend;
 mod circom;
 mod commitment;
 mod field_data;
 mod lurk_proof;
 pub mod paths;
-mod repl;
+pub mod repl;
 
 use anyhow::{bail, Context, Result};
 use camino::Utf8PathBuf;
@@ -22,10 +23,10 @@ use crate::{
 
 use crate::cli::{
     paths::set_lurk_dirs,
-    repl::{validate_non_zero, Backend, Repl},
+    repl::{validate_non_zero, Repl},
 };
 
-use crate::lurk_sym_ptr;
+use self::backend::Backend;
 
 const DEFAULT_LIMIT: usize = 100_000_000;
 const DEFAULT_RC: usize = 10;
@@ -349,8 +350,7 @@ fn get_store<F: LurkField + for<'a> serde::de::Deserialize<'a>>(
 macro_rules! new_repl {
     ( $cli: expr, $rc: expr, $limit: expr, $field: path, $backend: expr ) => {{
         let store = get_store(&$cli.zstore).with_context(|| "reading store from file")?;
-        let env = lurk_sym_ptr!(store, nil);
-        Repl::<$field>::new(store, env, $rc, $limit, $backend)
+        Repl::<$field>::new(store, $rc, $limit, $backend)
     }};
 }
 

--- a/tests/lurk-lib-tests.rs
+++ b/tests/lurk-lib-tests.rs
@@ -1,6 +1,9 @@
+use camino::Utf8PathBuf;
 use lurk::{
+    cli::{backend::Backend, repl::Repl},
     eval::lang::{Coproc, Lang},
     repl::{repl, ReplState},
+    store::Store,
 };
 use pasta_curves::pallas::Scalar as S1;
 use std::path::Path;
@@ -33,10 +36,13 @@ fn lurk_cli_tests() {
                 git submodule update"
         );
     }
+    let mut repl_new = Repl::new(Store::default(), 10, 100000000, Backend::Nova);
 
     for f in test_files {
         let joined = example_dir.join(f);
+        let joined_new = Utf8PathBuf::from_path_buf(joined.clone()).unwrap();
 
         repl::<S1, ReplState<S1, Coproc<S1>>, _, Coproc<S1>>(Some(joined), Lang::new()).unwrap();
+        let _ = repl_new.load_file(&joined_new);
     }
 }


### PR DESCRIPTION
The new REPL doesn't implement `assert-error` correctly. I noticed it while working on the `lem-integration` branch.

This PR fixes this issue and subjects the new REPL to the test suite from `lurk-lib`.

Extra: it also removes padding from the REPL because it's already done by `MultiFrame::from_frames`.