### PR TITLE
Give more meaningful names to LEM type variants and struct fields

### DIFF
--- a/src/lem/macros.rs
+++ b/src/lem/macros.rs
@@ -124,38 +124,38 @@ macro_rules! op {
     ( emit($v:ident) ) => {
         $crate::lem::Op::Emit($crate::var!($v))
     };
-    ( let $tgt:ident : $kind:ident::$tag:ident = hash2($src1:ident, $src2:ident) ) => {
-        $crate::lem::Op::Hash2(
+    ( let $tgt:ident : $kind:ident::$tag:ident = cons2($src1:ident, $src2:ident) ) => {
+        $crate::lem::Op::Cons2(
             $crate::var!($tgt),
             $crate::tag!($kind::$tag),
             $crate::vars!($src1, $src2),
         )
     };
-    ( let $tgt:ident : $kind:ident::$tag:ident = hash3($src1:ident, $src2:ident, $src3:ident) ) => {
-        $crate::lem::Op::Hash3(
+    ( let $tgt:ident : $kind:ident::$tag:ident = cons3($src1:ident, $src2:ident, $src3:ident) ) => {
+        $crate::lem::Op::Cons3(
             $crate::var!($tgt),
             $crate::tag!($kind::$tag),
             $crate::vars!($src1, $src2, $src3),
         )
     };
-    ( let $tgt:ident : $kind:ident::$tag:ident = hash4($src1:ident, $src2:ident, $src3:ident, $src4:ident) ) => {
-        $crate::lem::Op::Hash4(
+    ( let $tgt:ident : $kind:ident::$tag:ident = cons4($src1:ident, $src2:ident, $src3:ident, $src4:ident) ) => {
+        $crate::lem::Op::Cons4(
             $crate::var!($tgt),
             $crate::tag!($kind::$tag),
             $crate::vars!($src1, $src2, $src3, $src4),
         )
     };
-    ( let ($tgt1:ident, $tgt2:ident) = unhash2($src:ident) ) => {
-        $crate::lem::Op::Unhash2(
+    ( let ($tgt1:ident, $tgt2:ident) = decons2($src:ident) ) => {
+        $crate::lem::Op::Decons2(
             $crate::vars!($tgt1, $tgt2),
             $crate::var!($src),
         )
     };
-    ( let ($tgt1:ident, $tgt2:ident, $tgt3:ident) = unhash3($src:ident) ) => {
-        $crate::lem::Op::Unhash3($crate::vars!($tgt1, $tgt2, $tgt3), $crate::var!($src))
+    ( let ($tgt1:ident, $tgt2:ident, $tgt3:ident) = decons3($src:ident) ) => {
+        $crate::lem::Op::Decons3($crate::vars!($tgt1, $tgt2, $tgt3), $crate::var!($src))
     };
-    ( let ($tgt1:ident, $tgt2:ident, $tgt3:ident, $tgt4:ident) = unhash4($src:ident) ) => {
-        $crate::lem::Op::Unhash4(
+    ( let ($tgt1:ident, $tgt2:ident, $tgt3:ident, $tgt4:ident) = decons4($src:ident) ) => {
+        $crate::lem::Op::Decons4(
             $crate::vars!($tgt1, $tgt2, $tgt3, $tgt4),
             $crate::var!($src),
         )
@@ -408,62 +408,62 @@ macro_rules! block {
             $($tail)*
         )
     };
-    (@seq {$($limbs:expr)*}, let $tgt:ident : $kind:ident::$tag:ident = hash2($src1:ident, $src2:ident) ; $($tail:tt)*) => {
+    (@seq {$($limbs:expr)*}, let $tgt:ident : $kind:ident::$tag:ident = cons2($src1:ident, $src2:ident) ; $($tail:tt)*) => {
         $crate::block! (
             @seq
             {
                 $($limbs)*
-                $crate::op!(let $tgt: $kind::$tag = hash2($src1, $src2) )
+                $crate::op!(let $tgt: $kind::$tag = cons2($src1, $src2) )
             },
             $($tail)*
         )
     };
-    (@seq {$($limbs:expr)*}, let $tgt:ident : $kind:ident::$tag:ident = hash3($src1:ident, $src2:ident, $src3:ident) ; $($tail:tt)*) => {
+    (@seq {$($limbs:expr)*}, let $tgt:ident : $kind:ident::$tag:ident = cons3($src1:ident, $src2:ident, $src3:ident) ; $($tail:tt)*) => {
         $crate::block! (
             @seq
             {
                 $($limbs)*
-                $crate::op!(let $tgt: $kind::$tag = hash3($src1, $src2, $src3) )
+                $crate::op!(let $tgt: $kind::$tag = cons3($src1, $src2, $src3) )
             },
             $($tail)*
         )
     };
-    (@seq {$($limbs:expr)*}, let $tgt:ident : $kind:ident::$tag:ident = hash4($src1:ident, $src2:ident, $src3:ident, $src4:ident) ; $($tail:tt)*) => {
+    (@seq {$($limbs:expr)*}, let $tgt:ident : $kind:ident::$tag:ident = cons4($src1:ident, $src2:ident, $src3:ident, $src4:ident) ; $($tail:tt)*) => {
         $crate::block! (
             @seq
             {
                 $($limbs)*
-                $crate::op!(let $tgt: $kind::$tag = hash4($src1, $src2, $src3, $src4))
+                $crate::op!(let $tgt: $kind::$tag = cons4($src1, $src2, $src3, $src4))
             },
             $($tail)*
         )
     };
-    (@seq {$($limbs:expr)*}, let ($tgt1:ident, $tgt2:ident) = unhash2($src:ident) ; $($tail:tt)*) => {
+    (@seq {$($limbs:expr)*}, let ($tgt1:ident, $tgt2:ident) = decons2($src:ident) ; $($tail:tt)*) => {
         $crate::block! (
             @seq
             {
                 $($limbs)*
-                $crate::op!(let ($tgt1, $tgt2) = unhash2($src) )
+                $crate::op!(let ($tgt1, $tgt2) = decons2($src) )
             },
             $($tail)*
         )
     };
-    (@seq {$($limbs:expr)*}, let ($tgt1:ident, $tgt2:ident, $tgt3:ident) = unhash3($src:ident) ; $($tail:tt)*) => {
+    (@seq {$($limbs:expr)*}, let ($tgt1:ident, $tgt2:ident, $tgt3:ident) = decons3($src:ident) ; $($tail:tt)*) => {
         $crate::block! (
             @seq
             {
                 $($limbs)*
-                $crate::op!(let ($tgt1, $tgt2, $tgt3) = unhash3($src) )
+                $crate::op!(let ($tgt1, $tgt2, $tgt3) = decons3($src) )
             },
             $($tail)*
         )
     };
-    (@seq {$($limbs:expr)*}, let ($tgt1:ident, $tgt2:ident, $tgt3:ident, $tgt4:ident) = unhash4($src:ident) ; $($tail:tt)*) => {
+    (@seq {$($limbs:expr)*}, let ($tgt1:ident, $tgt2:ident, $tgt3:ident, $tgt4:ident) = decons4($src:ident) ; $($tail:tt)*) => {
         $crate::block! (
             @seq
             {
                 $($limbs)*
-                $crate::op!(let ($tgt1, $tgt2, $tgt3, $tgt4) = unhash4($src) )
+                $crate::op!(let ($tgt1, $tgt2, $tgt3, $tgt4) = decons4($src) )
             },
             $($tail)*
         )
@@ -598,20 +598,20 @@ mod tests {
     fn test_macros() {
         let lemops = [
             Op::Null(mptr("foo"), Tag::Expr(Num)),
-            Op::Hash2(mptr("foo"), Tag::Expr(Char), [mptr("bar"), mptr("baz")]),
-            Op::Hash3(
+            Op::Cons2(mptr("foo"), Tag::Expr(Char), [mptr("bar"), mptr("baz")]),
+            Op::Cons3(
                 mptr("foo"),
                 Tag::Expr(Char),
                 [mptr("bar"), mptr("baz"), mptr("bazz")],
             ),
-            Op::Hash4(
+            Op::Cons4(
                 mptr("foo"),
                 Tag::Expr(Char),
                 [mptr("bar"), mptr("baz"), mptr("bazz"), mptr("baxx")],
             ),
-            Op::Unhash2([mptr("foo"), mptr("goo")], mptr("aaa")),
-            Op::Unhash3([mptr("foo"), mptr("goo"), mptr("moo")], mptr("aaa")),
-            Op::Unhash4(
+            Op::Decons2([mptr("foo"), mptr("goo")], mptr("aaa")),
+            Op::Decons3([mptr("foo"), mptr("goo"), mptr("moo")], mptr("aaa")),
+            Op::Decons4(
                 [mptr("foo"), mptr("goo"), mptr("moo"), mptr("noo")],
                 mptr("aaa"),
             ),
@@ -620,12 +620,12 @@ mod tests {
         ];
         let lemops_macro = vec![
             op!(let foo: Expr::Num),
-            op!(let foo: Expr::Char = hash2(bar, baz)),
-            op!(let foo: Expr::Char = hash3(bar, baz, bazz)),
-            op!(let foo: Expr::Char = hash4(bar, baz, bazz, baxx)),
-            op!(let (foo, goo) = unhash2(aaa)),
-            op!(let (foo, goo, moo) = unhash3(aaa)),
-            op!(let (foo, goo, moo, noo) = unhash4(aaa)),
+            op!(let foo: Expr::Char = cons2(bar, baz)),
+            op!(let foo: Expr::Char = cons3(bar, baz, bazz)),
+            op!(let foo: Expr::Char = cons4(bar, baz, bazz, baxx)),
+            op!(let (foo, goo) = decons2(aaa)),
+            op!(let (foo, goo, moo) = decons3(aaa)),
+            op!(let (foo, goo, moo, noo) = decons4(aaa)),
             op!(let bar = hide(baz, bazz)),
             op!(let (bar, baz) = open(bazz)),
         ];
@@ -641,12 +641,12 @@ mod tests {
         };
         let lem_macro_seq = block!({
             let foo: Expr::Num;
-            let foo: Expr::Char = hash2(bar, baz);
-            let foo: Expr::Char = hash3(bar, baz, bazz);
-            let foo: Expr::Char = hash4(bar, baz, bazz, baxx);
-            let (foo, goo) = unhash2(aaa);
-            let (foo, goo, moo) = unhash3(aaa);
-            let (foo, goo, moo, noo) = unhash4(aaa);
+            let foo: Expr::Char = cons2(bar, baz);
+            let foo: Expr::Char = cons3(bar, baz, bazz);
+            let foo: Expr::Char = cons4(bar, baz, bazz, baxx);
+            let (foo, goo) = decons2(aaa);
+            let (foo, goo, moo) = decons3(aaa);
+            let (foo, goo, moo, noo) = decons4(aaa);
             let bar = hide(baz, bazz);
             let (bar, baz) = open(bazz);
             return (bar, baz, bazz);

--- a/src/lem/mod.rs
+++ b/src/lem/mod.rs
@@ -21,7 +21,7 @@
 //! operations `Op` followed by a control `Ctrl` statement.
 //!
 //! Operations are much like `let` statements in functional languages. For
-//! example, a `Op::Hash2(x, t, ys)` is to be understood as `let x = hash2(ys)`.
+//! example, a `Op::Cons2(x, t, ys)` is to be understood as `let x = cons2(ys)`.
 //! If a second operation binds its result to the same variable as a previous
 //! operation, we shadow the previous value. There is no mutation, thus the
 //! language is referentially transparent.
@@ -281,18 +281,18 @@ pub enum Op {
     DivRem64([Var; 2], Var, Var),
     /// `Emit(v)` simply prints out the value of `v` when interpreting the code
     Emit(Var),
-    /// `Hash2(x, t, ys)` binds `x` to a `Ptr` with tag `t` and 2 children `ys`
-    Hash2(Var, Tag, [Var; 2]),
-    /// `Hash3(x, t, ys)` binds `x` to a `Ptr` with tag `t` and 3 children `ys`
-    Hash3(Var, Tag, [Var; 3]),
-    /// `Hash4(x, t, ys)` binds `x` to a `Ptr` with tag `t` and 4 children `ys`
-    Hash4(Var, Tag, [Var; 4]),
-    /// `Unhash2([a, b], x)` binds `a` and `b` to the 2 children of `x`
-    Unhash2([Var; 2], Var),
-    /// `Unhash3([a, b, c], x)` binds `a`, `b` and `c` to the 3 children of `x`
-    Unhash3([Var; 3], Var),
-    /// `Unhash4([a, b, c, d], x)` binds `a`, `b`, `c` and `d` to the 4 children of `x`
-    Unhash4([Var; 4], Var),
+    /// `Cons2(x, t, ys)` binds `x` to a `Ptr` with tag `t` and 2 children `ys`
+    Cons2(Var, Tag, [Var; 2]),
+    /// `Cons3(x, t, ys)` binds `x` to a `Ptr` with tag `t` and 3 children `ys`
+    Cons3(Var, Tag, [Var; 3]),
+    /// `Cons4(x, t, ys)` binds `x` to a `Ptr` with tag `t` and 4 children `ys`
+    Cons4(Var, Tag, [Var; 4]),
+    /// `Decons2([a, b], x)` binds `a` and `b` to the 2 children of `x`
+    Decons2([Var; 2], Var),
+    /// `Decons3([a, b, c], x)` binds `a`, `b` and `c` to the 3 children of `x`
+    Decons3([Var; 3], Var),
+    /// `Decons4([a, b, c, d], x)` binds `a`, `b`, `c` and `d` to the 4 children of `x`
+    Decons4([Var; 4], Var),
     /// `Hide(x, s, p)` binds `x` to a (comm) `Ptr` resulting from hiding the
     /// payload `p` with (num) secret `s`
     Hide(Var, Var, Var),
@@ -404,27 +404,27 @@ impl Func {
                     Op::Emit(a) => {
                         is_bound(a, map)?;
                     }
-                    Op::Hash2(img, _tag, preimg) => {
+                    Op::Cons2(img, _tag, preimg) => {
                         preimg.iter().try_for_each(|arg| is_bound(arg, map))?;
                         is_unique(img, map);
                     }
-                    Op::Hash3(img, _tag, preimg) => {
+                    Op::Cons3(img, _tag, preimg) => {
                         preimg.iter().try_for_each(|arg| is_bound(arg, map))?;
                         is_unique(img, map);
                     }
-                    Op::Hash4(img, _tag, preimg) => {
+                    Op::Cons4(img, _tag, preimg) => {
                         preimg.iter().try_for_each(|arg| is_bound(arg, map))?;
                         is_unique(img, map);
                     }
-                    Op::Unhash2(preimg, img) => {
+                    Op::Decons2(preimg, img) => {
                         is_bound(img, map)?;
                         preimg.iter().for_each(|var| is_unique(var, map))
                     }
-                    Op::Unhash3(preimg, img) => {
+                    Op::Decons3(preimg, img) => {
                         is_bound(img, map)?;
                         preimg.iter().for_each(|var| is_unique(var, map))
                     }
-                    Op::Unhash4(preimg, img) => {
+                    Op::Decons4(preimg, img) => {
                         is_bound(img, map)?;
                         preimg.iter().for_each(|var| is_unique(var, map))
                     }
@@ -649,35 +649,35 @@ impl Block {
                     let a = map.get_cloned(&a)?;
                     ops.push(Op::Emit(a))
                 }
-                Op::Hash2(img, tag, preimg) => {
+                Op::Cons2(img, tag, preimg) => {
                     let preimg = map.get_many_cloned(&preimg)?.try_into().unwrap();
                     let img = insert_one(map, uniq, &img);
-                    ops.push(Op::Hash2(img, tag, preimg))
+                    ops.push(Op::Cons2(img, tag, preimg))
                 }
-                Op::Hash3(img, tag, preimg) => {
+                Op::Cons3(img, tag, preimg) => {
                     let preimg = map.get_many_cloned(&preimg)?.try_into().unwrap();
                     let img = insert_one(map, uniq, &img);
-                    ops.push(Op::Hash3(img, tag, preimg))
+                    ops.push(Op::Cons3(img, tag, preimg))
                 }
-                Op::Hash4(img, tag, preimg) => {
+                Op::Cons4(img, tag, preimg) => {
                     let preimg = map.get_many_cloned(&preimg)?.try_into().unwrap();
                     let img = insert_one(map, uniq, &img);
-                    ops.push(Op::Hash4(img, tag, preimg))
+                    ops.push(Op::Cons4(img, tag, preimg))
                 }
-                Op::Unhash2(preimg, img) => {
+                Op::Decons2(preimg, img) => {
                     let img = map.get_cloned(&img)?;
                     let preimg = insert_many(map, uniq, &preimg);
-                    ops.push(Op::Unhash2(preimg.try_into().unwrap(), img))
+                    ops.push(Op::Decons2(preimg.try_into().unwrap(), img))
                 }
-                Op::Unhash3(preimg, img) => {
+                Op::Decons3(preimg, img) => {
                     let img = map.get_cloned(&img)?;
                     let preimg = insert_many(map, uniq, &preimg);
-                    ops.push(Op::Unhash3(preimg.try_into().unwrap(), img))
+                    ops.push(Op::Decons3(preimg.try_into().unwrap(), img))
                 }
-                Op::Unhash4(preimg, img) => {
+                Op::Decons4(preimg, img) => {
                     let img = map.get_cloned(&img)?;
                     let preimg = insert_many(map, uniq, &preimg);
-                    ops.push(Op::Unhash4(preimg.try_into().unwrap(), img))
+                    ops.push(Op::Decons4(preimg.try_into().unwrap(), img))
                 }
                 Op::Hide(tgt, sec, pay) => {
                     let sec = map.get_cloned(&sec)?;
@@ -894,10 +894,10 @@ mod tests {
     #[test]
     fn handles_non_ssa() {
         let func = func!(foo(expr_in, _env_in, _cont_in): 3 => {
-            let x: Expr::Cons = hash2(expr_in, expr_in);
+            let x: Expr::Cons = cons2(expr_in, expr_in);
             // The next line rewrites `x` and it should move on smoothly, matching
             // the expected number of constraints accordingly
-            let x: Expr::Cons = hash2(x, x);
+            let x: Expr::Cons = cons2(x, x);
             let cont_out_terminal: Cont::Terminal;
             return (x, x, cont_out_terminal);
         });
@@ -939,16 +939,16 @@ mod tests {
     #[test]
     fn test_hash_slots() {
         let lem = func!(foo(expr_in, env_in, cont_in): 3 => {
-            let _x: Expr::Cons = hash2(expr_in, env_in);
-            let _y: Expr::Cons = hash3(expr_in, env_in, cont_in);
-            let _z: Expr::Cons = hash4(expr_in, env_in, cont_in, cont_in);
+            let _x: Expr::Cons = cons2(expr_in, env_in);
+            let _y: Expr::Cons = cons3(expr_in, env_in, cont_in);
+            let _z: Expr::Cons = cons4(expr_in, env_in, cont_in, cont_in);
             let t: Cont::Terminal;
             let p: Expr::Nil;
             match expr_in.tag {
                 Expr::Num => {
-                    let m: Expr::Cons = hash2(env_in, expr_in);
-                    let n: Expr::Cons = hash3(cont_in, env_in, expr_in);
-                    let _k: Expr::Cons = hash4(expr_in, cont_in, env_in, expr_in);
+                    let m: Expr::Cons = cons2(env_in, expr_in);
+                    let n: Expr::Cons = cons3(cont_in, env_in, expr_in);
+                    let _k: Expr::Cons = cons4(expr_in, cont_in, env_in, expr_in);
                     return (m, n, t);
                 }
                 Expr::Char => {
@@ -970,19 +970,19 @@ mod tests {
     #[test]
     fn test_unhash_slots() {
         let lem = func!(foo(expr_in, env_in, cont_in): 3 => {
-            let _x: Expr::Cons = hash2(expr_in, env_in);
-            let _y: Expr::Cons = hash3(expr_in, env_in, cont_in);
-            let _z: Expr::Cons = hash4(expr_in, env_in, cont_in, cont_in);
+            let _x: Expr::Cons = cons2(expr_in, env_in);
+            let _y: Expr::Cons = cons3(expr_in, env_in, cont_in);
+            let _z: Expr::Cons = cons4(expr_in, env_in, cont_in, cont_in);
             let t: Cont::Terminal;
             let p: Expr::Nil;
             match expr_in.tag {
                 Expr::Num => {
-                    let m: Expr::Cons = hash2(env_in, expr_in);
-                    let n: Expr::Cons = hash3(cont_in, env_in, expr_in);
-                    let k: Expr::Cons = hash4(expr_in, cont_in, env_in, expr_in);
-                    let (_m1, _m2) = unhash2(m);
-                    let (_n1, _n2, _n3) = unhash3(n);
-                    let (_k1, _k2, _k3, _k4) = unhash4(k);
+                    let m: Expr::Cons = cons2(env_in, expr_in);
+                    let n: Expr::Cons = cons3(cont_in, env_in, expr_in);
+                    let k: Expr::Cons = cons4(expr_in, cont_in, env_in, expr_in);
+                    let (_m1, _m2) = decons2(m);
+                    let (_n1, _n2, _n3) = decons3(n);
+                    let (_k1, _k2, _k3, _k4) = decons4(k);
                     return (m, n, t);
                 }
                 Expr::Char => {
@@ -1004,30 +1004,30 @@ mod tests {
     #[test]
     fn test_unhash_nested_slots() {
         let lem = func!(foo(expr_in, env_in, cont_in): 3 => {
-            let _x: Expr::Cons = hash2(expr_in, env_in);
-            let _y: Expr::Cons = hash3(expr_in, env_in, cont_in);
-            let _z: Expr::Cons = hash4(expr_in, env_in, cont_in, cont_in);
+            let _x: Expr::Cons = cons2(expr_in, env_in);
+            let _y: Expr::Cons = cons3(expr_in, env_in, cont_in);
+            let _z: Expr::Cons = cons4(expr_in, env_in, cont_in, cont_in);
             let t: Cont::Terminal;
             let p: Expr::Nil;
             match expr_in.tag {
                 Expr::Num => {
-                    let m: Expr::Cons = hash2(env_in, expr_in);
-                    let n: Expr::Cons = hash3(cont_in, env_in, expr_in);
-                    let k: Expr::Cons = hash4(expr_in, cont_in, env_in, expr_in);
-                    let (_m1, _m2) = unhash2(m);
-                    let (_n1, _n2, _n3) = unhash3(n);
-                    let (_k1, _k2, _k3, _k4) = unhash4(k);
+                    let m: Expr::Cons = cons2(env_in, expr_in);
+                    let n: Expr::Cons = cons3(cont_in, env_in, expr_in);
+                    let k: Expr::Cons = cons4(expr_in, cont_in, env_in, expr_in);
+                    let (_m1, _m2) = decons2(m);
+                    let (_n1, _n2, _n3) = decons3(n);
+                    let (_k1, _k2, _k3, _k4) = decons4(k);
                     match cont_in.tag {
                         Cont::Outermost => {
-                            let _a: Expr::Cons = hash2(env_in, expr_in);
-                            let _b: Expr::Cons = hash3(cont_in, env_in, expr_in);
-                            let _c: Expr::Cons = hash4(expr_in, cont_in, env_in, expr_in);
+                            let _a: Expr::Cons = cons2(env_in, expr_in);
+                            let _b: Expr::Cons = cons3(cont_in, env_in, expr_in);
+                            let _c: Expr::Cons = cons4(expr_in, cont_in, env_in, expr_in);
                             return (m, n, t);
                         }
                         Cont::Terminal => {
-                            let _d: Expr::Cons = hash2(env_in, expr_in);
-                            let _e: Expr::Cons = hash3(cont_in, env_in, expr_in);
-                            let _f: Expr::Cons = hash4(expr_in, cont_in, env_in, expr_in);
+                            let _d: Expr::Cons = cons2(env_in, expr_in);
+                            let _e: Expr::Cons = cons3(cont_in, env_in, expr_in);
+                            let _f: Expr::Cons = cons4(expr_in, cont_in, env_in, expr_in);
                             return (m, n, t);
                         }
                     }

--- a/src/lem/slot.rs
+++ b/src/lem/slot.rs
@@ -107,9 +107,9 @@ use super::{Block, Ctrl, Op};
 
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SlotsCounter {
-    pub hash2: usize,
-    pub hash3: usize,
     pub hash4: usize,
+    pub hash6: usize,
+    pub hash8: usize,
     pub commitment: usize,
     pub less_than: usize,
 }
@@ -119,30 +119,30 @@ impl SlotsCounter {
     #[inline]
     pub fn new(num_slots: (usize, usize, usize, usize, usize)) -> Self {
         Self {
-            hash2: num_slots.0,
-            hash3: num_slots.1,
-            hash4: num_slots.2,
+            hash4: num_slots.0,
+            hash6: num_slots.1,
+            hash8: num_slots.2,
             commitment: num_slots.3,
             less_than: num_slots.4,
         }
     }
 
     #[inline]
-    pub fn consume_hash2(&mut self) -> usize {
-        self.hash2 += 1;
-        self.hash2 - 1
-    }
-
-    #[inline]
-    pub fn consume_hash3(&mut self) -> usize {
-        self.hash3 += 1;
-        self.hash3 - 1
-    }
-
-    #[inline]
     pub fn consume_hash4(&mut self) -> usize {
         self.hash4 += 1;
         self.hash4 - 1
+    }
+
+    #[inline]
+    pub fn consume_hash6(&mut self) -> usize {
+        self.hash6 += 1;
+        self.hash6 - 1
+    }
+
+    #[inline]
+    pub fn consume_hash8(&mut self) -> usize {
+        self.hash8 += 1;
+        self.hash8 - 1
     }
 
     #[inline]
@@ -161,9 +161,9 @@ impl SlotsCounter {
     pub fn max(&self, other: Self) -> Self {
         use std::cmp::max;
         Self {
-            hash2: max(self.hash2, other.hash2),
-            hash3: max(self.hash3, other.hash3),
             hash4: max(self.hash4, other.hash4),
+            hash6: max(self.hash6, other.hash6),
+            hash8: max(self.hash8, other.hash8),
             commitment: max(self.commitment, other.commitment),
             less_than: max(self.less_than, other.less_than),
         }
@@ -172,9 +172,9 @@ impl SlotsCounter {
     #[inline]
     pub fn add(&self, other: Self) -> Self {
         Self {
-            hash2: self.hash2 + other.hash2,
-            hash3: self.hash3 + other.hash3,
             hash4: self.hash4 + other.hash4,
+            hash6: self.hash6 + other.hash6,
+            hash8: self.hash8 + other.hash8,
             commitment: self.commitment + other.commitment,
             less_than: self.less_than + other.less_than,
         }
@@ -190,9 +190,9 @@ impl Block {
     pub fn count_slots(&self) -> SlotsCounter {
         let ops_slots = self.ops.iter().fold(SlotsCounter::default(), |acc, op| {
             let val = match op {
-                Op::Hash2(..) | Op::Unhash2(..) => SlotsCounter::new((1, 0, 0, 0, 0)),
-                Op::Hash3(..) | Op::Unhash3(..) => SlotsCounter::new((0, 1, 0, 0, 0)),
-                Op::Hash4(..) | Op::Unhash4(..) => SlotsCounter::new((0, 0, 1, 0, 0)),
+                Op::Cons2(..) | Op::Decons2(..) => SlotsCounter::new((1, 0, 0, 0, 0)),
+                Op::Cons3(..) | Op::Decons3(..) => SlotsCounter::new((0, 1, 0, 0, 0)),
+                Op::Cons4(..) | Op::Decons4(..) => SlotsCounter::new((0, 0, 1, 0, 0)),
                 Op::Hide(..) | Op::Open(..) => SlotsCounter::new((0, 0, 0, 1, 0)),
                 Op::Lt(..) => SlotsCounter::new((0, 0, 0, 0, 1)),
                 Op::Call(_, func, _) => func.slot,
@@ -229,9 +229,9 @@ impl Block {
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum SlotType {
-    Hash2,
-    Hash3,
     Hash4,
+    Hash6,
+    Hash8,
     Commitment,
     LessThan,
 }
@@ -239,9 +239,9 @@ pub(crate) enum SlotType {
 impl SlotType {
     pub(crate) fn preimg_size(&self) -> usize {
         match self {
-            Self::Hash2 => 4,
-            Self::Hash3 => 6,
-            Self::Hash4 => 8,
+            Self::Hash4 => 4,
+            Self::Hash6 => 6,
+            Self::Hash8 => 8,
             Self::Commitment => 3,
             Self::LessThan => 2,
         }
@@ -251,9 +251,9 @@ impl SlotType {
 impl std::fmt::Display for SlotType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Hash2 => write!(f, "Hash2"),
-            Self::Hash3 => write!(f, "Hash3"),
             Self::Hash4 => write!(f, "Hash4"),
+            Self::Hash6 => write!(f, "Hash6"),
+            Self::Hash8 => write!(f, "Hash8"),
             Self::Commitment => write!(f, "Commitment"),
             Self::LessThan => write!(f, "LessThan"),
         }


### PR DESCRIPTION
As we've discussed on Zulip, slot-related entities should be named after their hashing arities and LEM operators should be called "cons" and "decons"