### PR TITLE
ci: Integrate Codecov for test coverage analysis

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,35 @@
+name: Codecov
+on:
+    push: 
+      branches: [master]
+    pull_request:
+      types: [opened, synchronize, reopened, ready_for_review]
+      branches: [master]
+    
+jobs:
+  codecov-grcov:
+    name: Generate code coverage
+    runs-on: buildjet-16vcpu-ubuntu-2204
+    strategy:
+      fail-fast: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@nextest
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Clean the workspace
+        run: cargo llvm-cov clean --workspace
+      - name: Build
+        run: cargo build --profile dev-ci
+      - name: Collect coverage data
+        run: cargo llvm-cov nextest --lcov --output-path lcov.info --profile ci --release --workspace --run-ignored ignored-only -E 'all() - test(groth16::tests::outer_prove_recursion) - test(test_make_fcomm_examples) - test(test_functional_commitments_demo) - test(test_chained_functional_commitments_demo)'
+      - name: Upload coverage data to codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: lcov.info


### PR DESCRIPTION
- Implemented a new `Codecov` workflow for code coverage analysis.
- Configured the system to generate and upload coverage data to codecov.io when a push or pull request event occurs in the `master` branch.
- Used the grcov tool for test coverage data generation.