### PR TITLE
Remove padding hack.

### DIFF
--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -514,9 +514,7 @@ where
 
         for frame in frames {
             if frame.meta == last_meta {
-                let mut padding_frame = frame.clone();
-                // is this right, or should it be unmodified?
-                padding_frame.output = padding_frame.input;
+                let padding_frame = frame.clone();
                 consecutive_frames.push(padding_frame);
             } else {
                 if last_meta == Meta::Lurk {


### PR DESCRIPTION
This PR removes the redundant padding code (forcibly making the padding frame a no-op). This is unnecessary, since a correctly-selected padding frame must always be a provable no-op already. This wasn't yet the case of reduction when this shim was used in development.