### PR TITLE
Correctly handle head/rest in standalone coprocessor circuit.

### DIFF
--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -5386,6 +5386,7 @@ fn destructure_list_aux<F: LurkField, CS: ConstraintSystem<F>>(
     )
 }
 
+/// Returns allocated car and cdr of `maybe_cons` if `not_dummy`.  If `maybe_cons` is not a cons and `not_dummy` is true, the circuit will not be satisfied.
 pub(crate) fn car_cdr<F: LurkField, CS: ConstraintSystem<F>>(
     mut cs: CS,
     g: &GlobalAllocations<F>,

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -5386,7 +5386,7 @@ fn destructure_list_aux<F: LurkField, CS: ConstraintSystem<F>>(
     )
 }
 
-fn car_cdr<F: LurkField, CS: ConstraintSystem<F>>(
+pub(crate) fn car_cdr<F: LurkField, CS: ConstraintSystem<F>>(
     mut cs: CS,
     g: &GlobalAllocations<F>,
     maybe_cons: &AllocatedPtr<F>,

--- a/src/circuit/gadgets/constraints.rs
+++ b/src/circuit/gadgets/constraints.rs
@@ -52,6 +52,28 @@ pub(crate) fn enforce_equal_zero<F: PrimeField, A, AR, CS: ConstraintSystem<F>>(
     );
 }
 
+/// Adds a constraint to CS, enforcing an equality relationship between an allocated number a and constant k.
+///
+/// a == k
+#[allow(dead_code)]
+pub(crate) fn enforce_equal_const<F: PrimeField, A, AR, CS: ConstraintSystem<F>>(
+    cs: &mut CS,
+    annotation: A,
+    k: F,
+    a: &AllocatedNum<F>,
+) where
+    A: FnOnce() -> AR,
+    AR: Into<String>,
+{
+    // a * 1 = k
+    cs.enforce(
+        annotation,
+        |lc| lc + a.get_variable(),
+        |lc| lc + CS::one(),
+        |lc| lc + (k, CS::one()),
+    );
+}
+
 /// Adds a constraint to CS, enforcing a add relationship between the allocated numbers a, b, and sum.
 ///
 /// a + b = sum

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -81,6 +81,8 @@ pub trait Coprocessor<F: LurkField>: Clone + Debug + Sync + Send + CoCircuit<F> 
         // Refactor to share.
         let arity = self.arity();
 
+        // If `input_expr` is not a cons, the circuit will not be satisified, per `car_cdr`'s contract.
+        // That is also the desired behavior for the coprocessor circuit's validation, so this is fine.
         let (head, rest) = car_cdr(
             &mut cs.namespace(|| "coprocessor_input car_cdr"),
             g,

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -1,15 +1,18 @@
 use std::fmt::Debug;
 
+use bellpepper::gadgets::boolean::Boolean;
 use bellpepper_core::{ConstraintSystem, SynthesisError};
 
-use crate::circuit::circuit_frame::destructure_list;
-use crate::circuit::gadgets::constraints::alloc_equal_const;
+use crate::circuit::circuit_frame::{car_cdr, destructure_list};
+use crate::circuit::gadgets::constraints::{alloc_equal_const, enforce_equal_const};
 use crate::circuit::gadgets::data::GlobalAllocations;
 use crate::circuit::gadgets::pointer::{AllocatedContPtr, AllocatedPtr, AsAllocatedHashComponents};
 use crate::eval::IO;
 use crate::field::LurkField;
 use crate::ptr::{ContPtr, Ptr};
 use crate::store::Store;
+use crate::tag::Tag;
+use crate::z_data::z_ptr::ZExprPtr;
 
 pub mod circom;
 pub mod trie;
@@ -69,6 +72,7 @@ pub trait Coprocessor<F: LurkField>: Clone + Debug + Sync + Send + CoCircuit<F> 
         cs: &mut CS,
         store: &Store<F>,
         g: &GlobalAllocations<F>,
+        coprocessor_zptr: &ZExprPtr<F>,
         input_expr: &AllocatedPtr<F>,
         input_env: &AllocatedPtr<F>,
         input_cont: &AllocatedContPtr<F>,
@@ -76,24 +80,49 @@ pub trait Coprocessor<F: LurkField>: Clone + Debug + Sync + Send + CoCircuit<F> 
         // TODO: This code is almost identical to that in circuit_frame.rs (the arg destructuring is factored out and shared there).
         // Refactor to share.
         let arity = self.arity();
-        let (form, actual_length) = destructure_list(
+
+        let (head, rest) = car_cdr(
+            &mut cs.namespace(|| "coprocessor_input car_cdr"),
+            g,
+            input_expr,
+            store,
+            &Boolean::Constant(true),
+        )?;
+
+        {
+            // The NIVC coprocessor contract requires that a proof (of any kind, including error) will be generated only if
+            // the control expression can be correctly handled by the coprocessor. This means each circuit must validate its
+            // input to ensure it matches the coprocessor.
+            enforce_equal_const(
+                cs,
+                || "coprocessor head tag matches",
+                coprocessor_zptr.tag().to_field(),
+                head.tag(),
+            );
+            enforce_equal_const(
+                cs,
+                || "coprocessor head val matches",
+                *coprocessor_zptr.value(),
+                head.hash(),
+            );
+        }
+
+        let (inputs, actual_length) = destructure_list(
             &mut cs.namespace(|| "coprocessor form"),
             store,
             g,
-            arity + 1,
-            input_expr,
+            arity,
+            &rest,
         )?;
-        let _head = &form[0];
-        let inputs = &form[1..];
 
         let arity_is_correct = alloc_equal_const(
             &mut cs.namespace(|| "arity_is_correct"),
             &actual_length,
-            F::from(1 + arity as u64),
+            F::from(arity as u64),
         )?;
 
         let (result_expr, result_env, result_cont) =
-            self.synthesize(cs, g, store, &inputs[..arity], input_env, input_cont)?;
+            self.synthesize(cs, g, store, &inputs, input_env, input_cont)?;
 
         let quoted_expr = AllocatedPtr::construct_list(
             &mut cs.namespace(|| "quote coprocessor result"),
@@ -119,10 +148,7 @@ pub trait Coprocessor<F: LurkField>: Clone + Debug + Sync + Send + CoCircuit<F> 
             tail_components,
         )?;
 
-        // FIXME: technically, the error is defined to be rest -- which is the cdr of input_expr.
-        //let new_expr = pick_ptr!(cs, &arity_is_correct, &quoted_expr, &rest)?;
-        let new_expr = pick_ptr!(cs, &arity_is_correct, &quoted_expr, &input_expr)?;
-
+        let new_expr = pick_ptr!(cs, &arity_is_correct, &quoted_expr, &rest)?;
         let new_env = pick_ptr!(cs, &arity_is_correct, &result_env, &input_env)?;
         let new_cont = pick_cont_ptr!(cs, &arity_is_correct, &tail_cont, &g.error_ptr_cont)?;
 

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -399,7 +399,15 @@ impl<'a, F: LurkField, C: Coprocessor<F>> StepCircuit<F> for MultiFrame<'a, F, C
                         let g =
                             GlobalAllocations::new(&mut cs.namespace(|| "global_allocations"), s)?;
 
-                        c.synthesize_step_circuit(cs, s, &g, &input_expr, &input_env, &input_cont)?
+                        c.synthesize_step_circuit(
+                            cs,
+                            s,
+                            &g,
+                            &z_ptr,
+                            &input_expr,
+                            &input_env,
+                            &input_cont,
+                        )?
                     }
                     None => {
                         assert!(self.store.is_none());
@@ -408,7 +416,15 @@ impl<'a, F: LurkField, C: Coprocessor<F>> StepCircuit<F> for MultiFrame<'a, F, C
                         let g =
                             GlobalAllocations::new(&mut cs.namespace(|| "global_allocations"), &s)?;
 
-                        c.synthesize_step_circuit(cs, &s, &g, &input_expr, &input_env, &input_cont)?
+                        c.synthesize_step_circuit(
+                            cs,
+                            &s,
+                            &g,
+                            &z_ptr,
+                            &input_expr,
+                            &input_env,
+                            &input_cont,
+                        )?
                     }
                 }
             }


### PR DESCRIPTION
Closes #693.

This PR addresses the previous failure to properly destructure the standalone coprocessor circuit's arguments. This manifested in two ways:

1. The expr (the whole coprocessor expression rather than just the argument list) was returned in the case of an error.
2. The head itself was not checked against that specified by the `Lang` in the coprocessor's binding.

The second point is actually very important. Since we non-deterministically choose the next coprocessor circuit, it is critical that this circuit validates the context in which it is called. Put differently, the Lurk circuit contract requires that *every satisfiable circuit* correctly performs zero or more reduction steps. This allows for  no-ops (stuttering) in the allowed cases, for errors, for reduction-count > 1, and even for fused cycles. However, it also means that if a given circuit cannot produce a correct reduction for a given input, it must either produce a no-op or else be unprovable.

When the expression does not describe the target coprocessor, 'failure to prove' is the only valid response. A no-op would be inappropriate because the target circuit is not equipped to judge whether that would be a valid reduction step. We *could* allow coprocessors to stutter on errors and terminal continuations, but this would amount to inlining more reduction logic than necessary. Simply enforcing correctness, as this PR does, is the designed behavior.
