### PR TITLE
Unify configuration structure for Lurk library and CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ bellpepper-core = { workspace = true }
 bincode = { workspace = true }
 blstrs = { workspace = true }
 bytecount = "=0.6.4"
-camino = { workspace = true }
+camino = { workspace = true, features = ["serde1"] }
 clap = { workspace = true, features = ["derive"] }
 config = "0.13.3"
 dashmap = "5.5.0"
@@ -34,7 +34,7 @@ itertools = "0.9"
 lurk-macros = { path = "lurk-macros" }
 lurk-metrics = { path = "lurk-metrics" }
 metrics = { workspace = true }
-neptune = { workspace = true, features = ["arity2","arity4","arity8","arity16","pasta","bls"] }
+neptune = { workspace = true, features = ["arity2", "arity4", "arity8", "arity16", "pasta", "bls"] }
 nom = "7.1.3"
 nom_locate = "4.1.0"
 nova = { workspace = true }
@@ -58,7 +58,7 @@ serde_repr = "0.1.14"
 tap = "1.0.1"
 stable_deref_trait = "1.2.0"
 thiserror = { workspace = true }
-abomonation = { workspace = true}
+abomonation = { workspace = true }
 abomonation_derive = { git = "https://github.com/lurk-lab/abomonation_derive.git" }
 crossbeam = "0.8.2"
 byteorder = "1.4.3"
@@ -69,7 +69,7 @@ ansi_term = "0.12.1"
 tracing = { workspace = true }
 tracing-texray = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
-elsa = { version = "1.9.0", git="https://github.com/lurk-lab/elsa", branch = "sync_index_map", features = ["indexmap"] }
+elsa = { version = "1.9.0", git = "https://github.com/lurk-lab/elsa", branch = "sync_index_map", features = ["indexmap"] }
 arc-swap = "1.6.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -78,7 +78,10 @@ pasta-msm = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 rand = "0.8.5"
-rustyline = { version = "11.0", features = ["derive", "with-file-history"], default-features = false }
+rustyline = { version = "11.0", features = [
+    "derive",
+    "with-file-history",
+], default-features = false }
 home = "0.5.5"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -110,12 +113,7 @@ vergen = { version = "8", features = ["build", "git", "gitcl"] }
 
 [workspace]
 resolver = "2"
-members = [
-    "clutch",
-    "fcomm",
-    "lurk-macros",
-    "lurk-metrics"
-]
+members = ["clutch", "fcomm", "lurk-macros", "lurk-metrics"]
 
 # Dependencies that should be kept in sync through the whole workspace
 [workspace.dependencies]
@@ -199,4 +197,4 @@ harness = false
 
 [patch.crates-io]
 # This is needed to ensure halo2curves, which imports pasta-curves, uses the *same* traits in bn256_grumpkin
-pasta_curves = { git="https://github.com/lurk-lab/pasta_curves", branch="dev" }
+pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch = "dev" }

--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -1,0 +1,14 @@
+use camino::Utf8PathBuf;
+use lurk::cli::paths::lurk_default_dir;
+use lurk::config::lurk_config;
+use once_cell::sync::Lazy;
+
+/// Edit this path to use a config file specific to benchmarking
+/// E.g. `Utf8PathBuf::from("/home/<user>/lurk-rs/lurk-bench.toml");`
+pub static BENCH_CONFIG_PATH: Lazy<Utf8PathBuf> =
+    Lazy::new(|| lurk_default_dir().join("lurk.toml"));
+
+/// Sets the config settings with the given file
+pub fn set_bench_config() {
+    lurk_config(Some(&BENCH_CONFIG_PATH), None);
+}

--- a/benches/end2end.rs
+++ b/benches/end2end.rs
@@ -1,4 +1,3 @@
-use camino::Utf8Path;
 use criterion::{
     black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, SamplingMode,
 };
@@ -25,7 +24,9 @@ use lurk::{
 use std::time::Duration;
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 
-const PUBLIC_PARAMS_PATH: &str = "/var/tmp/lurk_benches/public_params";
+mod common;
+use common::set_bench_config;
+
 const DEFAULT_REDUCTION_COUNT: usize = 10;
 
 fn go_base<F: LurkField>(store: &Store<F>, state: Rc<RefCell<State>>, a: u64, b: u64) -> Ptr<F> {
@@ -57,6 +58,7 @@ fn end2end_benchmark(c: &mut Criterion) {
         .measurement_time(Duration::from_secs(120))
         .sample_size(10);
 
+    set_bench_config();
     let limit = 1_000_000_000;
     let lang_pallas = Lang::<Fq, Coproc<Fq>>::new();
     let lang_pallas_rc = Arc::new(lang_pallas.clone());
@@ -74,11 +76,7 @@ fn end2end_benchmark(c: &mut Criterion) {
         true,
         Kind::NovaPublicParams,
     );
-    let pp = public_parameters::public_params::<_, _, MultiFrame<'_, _, _>>(
-        &instance,
-        Utf8Path::new(PUBLIC_PARAMS_PATH),
-    )
-    .unwrap();
+    let pp = public_parameters::public_params::<_, _, MultiFrame<'_, _, _>>(&instance).unwrap();
 
     let size = (10, 0);
     let benchmark_id = BenchmarkId::new("end2end_go_base_nova", format!("_{}_{}", size.0, size.1));
@@ -241,6 +239,7 @@ fn prove_benchmark(c: &mut Criterion) {
         .measurement_time(Duration::from_secs(120))
         .sample_size(10);
 
+    set_bench_config();
     let limit = 1_000_000_000;
     let lang_pallas = Lang::<Fq, Coproc<Fq>>::new();
     let lang_pallas_rc = Arc::new(lang_pallas.clone());
@@ -251,17 +250,15 @@ fn prove_benchmark(c: &mut Criterion) {
     let benchmark_id = BenchmarkId::new("prove_go_base_nova", format!("_{}_{}", size.0, size.1));
 
     let state = State::init_lurk_state().rccell();
+
+    // use cached public params
     let instance = Instance::new(
         reduction_count,
         lang_pallas_rc.clone(),
         true,
         Kind::NovaPublicParams,
     );
-    let pp = public_parameters::public_params::<_, _, MultiFrame<'_, _, _>>(
-        &instance,
-        Utf8Path::new(PUBLIC_PARAMS_PATH),
-    )
-    .unwrap();
+    let pp = public_parameters::public_params::<_, _, MultiFrame<'_, _, _>>(&instance).unwrap();
 
     group.bench_with_input(benchmark_id, &size, |b, &s| {
         let ptr = go_base::<Fq>(&store, state.clone(), s.0, s.1);
@@ -293,6 +290,7 @@ fn prove_compressed_benchmark(c: &mut Criterion) {
         .measurement_time(Duration::from_secs(120))
         .sample_size(10);
 
+    set_bench_config();
     let limit = 1_000_000_000;
     let lang_pallas = Lang::<Fq, Coproc<Fq>>::new();
     let lang_pallas_rc = Arc::new(lang_pallas.clone());
@@ -306,17 +304,15 @@ fn prove_compressed_benchmark(c: &mut Criterion) {
     );
 
     let state = State::init_lurk_state().rccell();
+
+    // use cached public params
     let instance = Instance::new(
         reduction_count,
         lang_pallas_rc.clone(),
         true,
         Kind::NovaPublicParams,
     );
-    let pp = public_parameters::public_params::<_, _, MultiFrame<'_, _, _>>(
-        &instance,
-        Utf8Path::new(PUBLIC_PARAMS_PATH),
-    )
-    .unwrap();
+    let pp = public_parameters::public_params::<_, _, MultiFrame<'_, _, _>>(&instance).unwrap();
 
     group.bench_with_input(benchmark_id, &size, |b, &s| {
         let ptr = go_base::<Fq>(&store, state.clone(), s.0, s.1);
@@ -349,6 +345,7 @@ fn verify_benchmark(c: &mut Criterion) {
         .measurement_time(Duration::from_secs(10))
         .sample_size(10);
 
+    set_bench_config();
     let limit = 1_000_000_000;
     let lang_pallas = Lang::<Fq, Coproc<Fq>>::new();
     let lang_pallas_rc = Arc::new(lang_pallas.clone());
@@ -356,17 +353,15 @@ fn verify_benchmark(c: &mut Criterion) {
     let reduction_count = DEFAULT_REDUCTION_COUNT;
 
     let state = State::init_lurk_state().rccell();
+
+    // use cached public params
     let instance = Instance::new(
         reduction_count,
         lang_pallas_rc.clone(),
         true,
         Kind::NovaPublicParams,
     );
-    let pp = public_parameters::public_params::<_, _, MultiFrame<'_, _, _>>(
-        &instance,
-        Utf8Path::new(PUBLIC_PARAMS_PATH),
-    )
-    .unwrap();
+    let pp = public_parameters::public_params::<_, _, MultiFrame<'_, _, _>>(&instance).unwrap();
 
     let sizes = vec![(10, 0)];
     for size in sizes {
@@ -411,6 +406,7 @@ fn verify_compressed_benchmark(c: &mut Criterion) {
         .measurement_time(Duration::from_secs(10))
         .sample_size(10);
 
+    set_bench_config();
     let limit = 1_000_000_000;
     let lang_pallas = Lang::<Fq, Coproc<Fq>>::new();
     let lang_pallas_rc = Arc::new(lang_pallas.clone());
@@ -418,17 +414,15 @@ fn verify_compressed_benchmark(c: &mut Criterion) {
     let reduction_count = DEFAULT_REDUCTION_COUNT;
 
     let state = State::init_lurk_state().rccell();
+
+    // use cached public params
     let instance = Instance::new(
         reduction_count,
         lang_pallas_rc.clone(),
         true,
         Kind::NovaPublicParams,
     );
-    let pp = public_parameters::public_params::<_, _, MultiFrame<'_, _, _>>(
-        &instance,
-        Utf8Path::new(PUBLIC_PARAMS_PATH),
-    )
-    .unwrap();
+    let pp = public_parameters::public_params::<_, _, MultiFrame<'_, _, _>>(&instance).unwrap();
 
     let sizes = vec![(10, 0)];
     for size in sizes {

--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -1,6 +1,5 @@
 use std::{cell::RefCell, rc::Rc, sync::Arc, time::Duration};
 
-use camino::Utf8Path;
 use criterion::{
     black_box, criterion_group, criterion_main, measurement, BatchSize, BenchmarkGroup,
     BenchmarkId, Criterion, SamplingMode,
@@ -21,7 +20,8 @@ use lurk::{
 };
 use pasta_curves::pallas;
 
-const PUBLIC_PARAMS_PATH: &str = "/var/tmp/lurk_benches/public_params";
+mod common;
+use common::set_bench_config;
 
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Copy, Debug, Clone, PartialEq, Eq)]
@@ -86,11 +86,7 @@ mod alpha {
             true,
             Kind::NovaPublicParams,
         );
-        let pp = public_params::<_, _, MultiFrame<'_, _, _>>(
-            &instance,
-            Utf8Path::new(PUBLIC_PARAMS_PATH),
-        )
-        .unwrap();
+        let pp = public_params::<_, _, MultiFrame<'_, _, _>>(&instance).unwrap();
 
         let date = env!("VERGEN_GIT_COMMIT_DATE");
         let sha = env!("VERGEN_GIT_SHA");
@@ -186,11 +182,7 @@ mod lem {
             true,
             Kind::NovaPublicParams,
         );
-        let pp = public_params::<_, _, MultiFrame<'_, _, _>>(
-            &instance,
-            Utf8Path::new(PUBLIC_PARAMS_PATH),
-        )
-        .unwrap();
+        let pp = public_params::<_, _, MultiFrame<'_, _, _>>(&instance).unwrap();
 
         let date = env!("VERGEN_GIT_COMMIT_DATE");
         let sha = env!("VERGEN_GIT_SHA");
@@ -239,8 +231,8 @@ mod lem {
 }
 
 fn fib_bench(c: &mut Criterion) {
-    tracing::debug!("{:?}", &*lurk::config::CONFIG);
-
+    set_bench_config();
+    tracing::debug!("{:?}", lurk::config::LURK_CONFIG);
     let reduction_counts = [100, 600, 700, 800, 900];
     let folding_step_sizes = [2, 4, 8];
 

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -5,8 +5,6 @@
 //!
 //! Note: The example [example/sha256_ivc.rs] is this same benchmark but as an example
 //! that's easier to play with and run.
-
-use camino::Utf8Path;
 use criterion::{
     black_box, criterion_group, criterion_main, measurement, BatchSize, BenchmarkGroup,
     BenchmarkId, Criterion, SamplingMode,
@@ -29,7 +27,8 @@ use lurk::{
     store::Store,
 };
 
-const PUBLIC_PARAMS_PATH: &str = "/var/tmp/lurk_benches/public_params";
+mod common;
+use common::set_bench_config;
 
 fn sha256_ivc<F: LurkField>(
     store: &Store<F>,
@@ -108,7 +107,6 @@ fn sha256_ivc_prove<M: measurement::Measurement>(
     let lang_rc = Arc::new(lang.clone());
 
     // use cached public params
-
     let instance: Instance<
         '_,
         pasta_curves::Fq,
@@ -120,9 +118,7 @@ fn sha256_ivc_prove<M: measurement::Measurement>(
         true,
         Kind::NovaPublicParams,
     );
-    let pp =
-        public_params::<_, _, MultiFrame<'_, _, _>>(&instance, Utf8Path::new(PUBLIC_PARAMS_PATH))
-            .unwrap();
+    let pp = public_params::<_, _, MultiFrame<'_, _, _>>(&instance).unwrap();
 
     c.bench_with_input(
         BenchmarkId::new(prove_params.name(), arity),
@@ -156,7 +152,8 @@ fn sha256_ivc_prove<M: measurement::Measurement>(
 }
 
 fn ivc_prove_benchmarks(c: &mut Criterion) {
-    tracing::debug!("{:?}", &*lurk::config::CONFIG);
+    set_bench_config();
+    tracing::debug!("{:?}", &lurk::config::LURK_CONFIG);
     let reduction_counts = [10, 100];
     let batch_sizes = [1, 2, 5, 10, 20];
     let mut group: BenchmarkGroup<'_, _> = c.benchmark_group("prove");
@@ -205,9 +202,7 @@ fn sha256_ivc_prove_compressed<M: measurement::Measurement>(
         true,
         Kind::NovaPublicParams,
     );
-    let pp =
-        public_params::<_, _, MultiFrame<'_, _, _>>(&instance, Utf8Path::new(PUBLIC_PARAMS_PATH))
-            .unwrap();
+    let pp = public_params::<_, _, MultiFrame<'_, _, _>>(&instance).unwrap();
 
     c.bench_with_input(
         BenchmarkId::new(prove_params.name(), arity),
@@ -243,7 +238,8 @@ fn sha256_ivc_prove_compressed<M: measurement::Measurement>(
 }
 
 fn ivc_prove_compressed_benchmarks(c: &mut Criterion) {
-    tracing::debug!("{:?}", &*lurk::config::CONFIG);
+    set_bench_config();
+    tracing::debug!("{:?}", &lurk::config::LURK_CONFIG);
     let reduction_counts = [10, 100];
     let batch_sizes = [1, 2, 5, 10, 20];
     let mut group: BenchmarkGroup<'_, _> = c.benchmark_group("prove_compressed");
@@ -292,11 +288,7 @@ fn sha256_nivc_prove<M: measurement::Measurement>(
         true,
         Kind::SuperNovaAuxParams,
     );
-    let pp = supernova_public_params::<_, _, MultiFrame<'_, _, _>>(
-        &instance,
-        Utf8Path::new(PUBLIC_PARAMS_PATH),
-    )
-    .unwrap();
+    let pp = supernova_public_params::<_, _, MultiFrame<'_, _, _>>(&instance).unwrap();
 
     c.bench_with_input(
         BenchmarkId::new(prove_params.name(), arity),
@@ -330,7 +322,8 @@ fn sha256_nivc_prove<M: measurement::Measurement>(
 }
 
 fn nivc_prove_benchmarks(c: &mut Criterion) {
-    tracing::debug!("{:?}", &*lurk::config::CONFIG);
+    set_bench_config();
+    tracing::debug!("{:?}", &lurk::config::LURK_CONFIG);
     let reduction_counts = [10, 100];
     let batch_sizes = [1, 2, 5, 10, 20];
     let mut group: BenchmarkGroup<'_, _> = c.benchmark_group("prove");

--- a/benches/sha256_lem.rs
+++ b/benches/sha256_lem.rs
@@ -6,7 +6,6 @@
 //! Note: The example [example/sha256_ivc.rs] is this same benchmark but as an example
 //! that's easier to play with and run.
 
-use camino::Utf8Path;
 use criterion::{
     black_box, criterion_group, criterion_main, measurement, BatchSize, BenchmarkGroup,
     BenchmarkId, Criterion, SamplingMode,
@@ -32,7 +31,8 @@ use lurk::{
     state::{user_sym, State},
 };
 
-const PUBLIC_PARAMS_PATH: &str = "/var/tmp/lurk_benches/public_params";
+mod common;
+use common::set_bench_config;
 
 fn sha256_ivc<F: LurkField>(
     store: &Store<F>,
@@ -111,16 +111,13 @@ fn sha256_ivc_prove<M: measurement::Measurement>(
     let lurk_step = make_eval_step_from_lang(&lang, true);
 
     // use cached public params
-
     let instance: Instance<'_, Fr, Sha256Coproc<Fr>, MultiFrame<'_, _, _>> = Instance::new(
         reduction_count,
         lang_rc.clone(),
         true,
         Kind::NovaPublicParams,
     );
-    let pp =
-        public_params::<_, _, MultiFrame<'_, _, _>>(&instance, Utf8Path::new(PUBLIC_PARAMS_PATH))
-            .unwrap();
+    let pp = public_params::<_, _, MultiFrame<'_, _, _>>(&instance).unwrap();
 
     c.bench_with_input(
         BenchmarkId::new(prove_params.name(), arity),
@@ -153,7 +150,8 @@ fn sha256_ivc_prove<M: measurement::Measurement>(
 }
 
 fn ivc_prove_benchmarks(c: &mut Criterion) {
-    tracing::debug!("{:?}", &*lurk::config::CONFIG);
+    set_bench_config();
+    tracing::debug!("{:?}", &lurk::config::LURK_CONFIG);
     let reduction_counts = [10, 100];
     let batch_sizes = [1, 2, 5, 10, 20];
     let mut group: BenchmarkGroup<'_, _> = c.benchmark_group("prove");
@@ -202,9 +200,7 @@ fn sha256_ivc_prove_compressed<M: measurement::Measurement>(
         true,
         Kind::NovaPublicParams,
     );
-    let pp =
-        public_params::<_, _, MultiFrame<'_, _, _>>(&instance, Utf8Path::new(PUBLIC_PARAMS_PATH))
-            .unwrap();
+    let pp = public_params::<_, _, MultiFrame<'_, _, _>>(&instance).unwrap();
 
     c.bench_with_input(
         BenchmarkId::new(prove_params.name(), arity),
@@ -239,7 +235,8 @@ fn sha256_ivc_prove_compressed<M: measurement::Measurement>(
 }
 
 fn ivc_prove_compressed_benchmarks(c: &mut Criterion) {
-    tracing::debug!("{:?}", &*lurk::config::CONFIG);
+    set_bench_config();
+    tracing::debug!("{:?}", &lurk::config::LURK_CONFIG);
     let reduction_counts = [10, 100];
     let batch_sizes = [1, 2, 5, 10, 20];
     let mut group: BenchmarkGroup<'_, _> = c.benchmark_group("prove_compressed");
@@ -288,11 +285,7 @@ fn sha256_nivc_prove<M: measurement::Measurement>(
         true,
         Kind::SuperNovaAuxParams,
     );
-    let pp = supernova_public_params::<_, _, MultiFrame<'_, _, _>>(
-        &instance,
-        Utf8Path::new(PUBLIC_PARAMS_PATH),
-    )
-    .unwrap();
+    let pp = supernova_public_params::<_, _, MultiFrame<'_, _, _>>(&instance).unwrap();
 
     c.bench_with_input(
         BenchmarkId::new(prove_params.name(), arity),
@@ -325,7 +318,8 @@ fn sha256_nivc_prove<M: measurement::Measurement>(
 }
 
 fn nivc_prove_benchmarks(c: &mut Criterion) {
-    tracing::debug!("{:?}", &*lurk::config::CONFIG);
+    set_bench_config();
+    tracing::debug!("{:?}", &lurk::config::LURK_CONFIG);
     let reduction_counts = [10, 100];
     let batch_sizes = [1, 2, 5, 10, 20];
     let mut group: BenchmarkGroup<'_, _> = c.benchmark_group("prove");

--- a/examples/circom.rs
+++ b/examples/circom.rs
@@ -45,7 +45,7 @@ use lurk::lem::{pointers::Ptr as LEMPtr, store::Store as LEMStore};
 use lurk::proof::{nova::NovaProver, Prover};
 use lurk::ptr::Ptr;
 use lurk::public_parameters::instance::{Instance, Kind};
-use lurk::public_parameters::{public_params, public_params_default_dir};
+use lurk::public_parameters::public_params;
 use lurk::store::Store;
 use lurk::{Num, Symbol};
 use lurk_macros::Coproc;
@@ -135,8 +135,7 @@ fn main() {
         true,
         Kind::NovaPublicParams,
     );
-    let pp = public_params::<_, _, MultiFrame<'_, _, _>>(&instance, &public_params_default_dir())
-        .unwrap();
+    let pp = public_params::<_, _, MultiFrame<'_, _, _>>(&instance).unwrap();
     let pp_end = pp_start.elapsed();
 
     println!("Public parameters took {pp_end:?}");

--- a/examples/sha256_ivc.rs
+++ b/examples/sha256_ivc.rs
@@ -12,7 +12,7 @@ use lurk::{
     ptr::Ptr,
     public_parameters::{
         instance::{Instance, Kind},
-        public_params, public_params_default_dir,
+        public_params,
     },
     state::user_sym,
     store::Store,
@@ -88,7 +88,7 @@ fn main() {
         Kind::NovaPublicParams,
     );
     // see the documentation on `with_public_params`
-    let pp = public_params(&instance, &public_params_default_dir()).unwrap();
+    let pp = public_params(&instance).unwrap();
     let pp_end = pp_start.elapsed();
     println!("Public parameters took {:?}", pp_end);
 

--- a/examples/sha256_nivc.rs
+++ b/examples/sha256_nivc.rs
@@ -12,7 +12,7 @@ use lurk::{
     ptr::Ptr,
     public_parameters::{
         instance::{Instance, Kind},
-        public_params_default_dir, supernova_public_params,
+        supernova_public_params,
     },
     state::user_sym,
     store::Store,
@@ -87,11 +87,7 @@ fn main() {
         true,
         Kind::SuperNovaAuxParams,
     );
-    let pp = supernova_public_params::<_, _, MultiFrame<'_, _, _>>(
-        &instance_primary,
-        &public_params_default_dir(),
-    )
-    .unwrap();
+    let pp = supernova_public_params::<_, _, MultiFrame<'_, _, _>>(&instance_primary).unwrap();
 
     let pp_end = pp_start.elapsed();
     println!("Running claim parameters took {:?}", pp_end);

--- a/examples/sha256_nivc_lem.rs
+++ b/examples/sha256_nivc_lem.rs
@@ -16,7 +16,7 @@ use lurk::{
     proof::{supernova::SuperNovaProver, Prover},
     public_parameters::{
         instance::{Instance, Kind},
-        public_params_default_dir, supernova_public_params,
+        supernova_public_params,
     },
     state::user_sym,
 };
@@ -91,11 +91,7 @@ fn main() {
         true,
         Kind::SuperNovaAuxParams,
     );
-    let pp = supernova_public_params::<_, _, MultiFrame<'_, _, _>>(
-        &instance_primary,
-        &public_params_default_dir(),
-    )
-    .unwrap();
+    let pp = supernova_public_params::<_, _, MultiFrame<'_, _, _>>(&instance_primary).unwrap();
 
     let pp_end = pp_start.elapsed();
     println!("Running claim parameters took {:?}", pp_end);

--- a/src/circuit/gadgets/hashes.rs
+++ b/src/circuit/gadgets/hashes.rs
@@ -8,7 +8,7 @@ use neptune::circuit2_witness::{poseidon_hash_allocated_witness, poseidon_hash_s
 
 use crate::circuit::gadgets::pointer::{AllocatedPtr, AsAllocatedHashComponents};
 
-use crate::config::CONFIG;
+use crate::config::lurk_config;
 use crate::field::{FWrap, LurkField};
 use crate::hash::{HashConst, HashConstants};
 use crate::hash_witness::{
@@ -280,12 +280,16 @@ impl<'a, F: LurkField> AllocatedConsWitness<'a, F> {
         let names_and_ptrs = cons_circuit_witness.names_and_ptrs(s);
         let cons_constants: HashConst<'_, F> = s.poseidon_constants().constants(4.into());
 
-        let circuit_witness_blocks =
-            if cs.is_witness_generator() && CONFIG.witness_generation.precompute_neptune {
-                Some(cons_circuit_witness.circuit_witness_blocks(s, cons_constants))
-            } else {
-                None
-            };
+        let circuit_witness_blocks = if cs.is_witness_generator()
+            && lurk_config(None, None)
+                .perf
+                .witness_generation
+                .precompute_neptune
+        {
+            Some(cons_circuit_witness.circuit_witness_blocks(s, cons_constants))
+        } else {
+            None
+        };
 
         for (i, (name, spr)) in names_and_ptrs.iter().enumerate() {
             let cs = &mut cs.namespace(|| format!("slot-{i}"));
@@ -403,12 +407,16 @@ impl<'a, F: LurkField> AllocatedContWitness<'a, F> {
         let names_and_ptrs = cont_circuit_witness.names_and_ptrs(s);
         let cont_constants: HashConst<'_, F> = s.poseidon_constants().constants(8.into());
 
-        let circuit_witness_blocks =
-            if cs.is_witness_generator() && CONFIG.witness_generation.precompute_neptune {
-                Some(cont_circuit_witness.circuit_witness_blocks(s, cont_constants))
-            } else {
-                None
-            };
+        let circuit_witness_blocks = if cs.is_witness_generator()
+            && lurk_config(None, None)
+                .perf
+                .witness_generation
+                .precompute_neptune
+        {
+            Some(cont_circuit_witness.circuit_witness_blocks(s, cont_constants))
+        } else {
+            None
+        };
 
         for (i, (name, spr)) in names_and_ptrs.iter().enumerate() {
             let cs = &mut cs.namespace(|| format!("slot-{i}"));

--- a/src/cli/backend.rs
+++ b/src/cli/backend.rs
@@ -1,8 +1,12 @@
 use anyhow::{bail, Result};
+use clap::ValueEnum;
+use serde::Deserialize;
 
 use crate::field::LanguageField;
 
+#[derive(Clone, Default, Debug, Deserialize, ValueEnum, PartialEq, Eq)]
 pub enum Backend {
+    #[default]
     Nova,
 }
 
@@ -15,12 +19,6 @@ impl std::fmt::Display for Backend {
 }
 
 impl Backend {
-    pub(crate) fn default_field(&self) -> LanguageField {
-        match self {
-            Self::Nova => LanguageField::Pallas,
-        }
-    }
-
     fn compatible_fields(&self) -> Vec<LanguageField> {
         use LanguageField::{Pallas, Vesta};
         match self {

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,0 +1,181 @@
+//! Global config for the CLI
+//! Includes settings for cache locations and proof backend
+use std::collections::HashMap;
+
+use crate::config::{lurk_config_file, Settings, LURK_CONFIG};
+use crate::field::LanguageField;
+use camino::Utf8PathBuf;
+use config::{Config, ConfigError, Environment, File};
+use once_cell::sync::OnceCell;
+use serde::Deserialize;
+
+use super::backend::Backend;
+use super::paths::{circom_default_dir, commits_default_dir, proofs_default_dir};
+
+/// Global config varable for `CliSettings`
+pub static CLI_CONFIG: OnceCell<CliSettings> = OnceCell::new();
+
+/// Gets the `CLI_CONFIG` settings. If uninitialized, sets the global variable
+/// in the following order (greatest to least precedence):
+/// - `settings` map if provided, e.g. with key ("proofs", "$HOME/lurk-rs/proofs")
+///   This contains any CLI args, set e.g. by `lurk --proofs-dir /path/to/proofs_dir`
+/// - Env var per setting, e.g. `LURK_PROOFS_DIR`
+/// - Config file, which also has a configurable location (see `lurk_config_file()`),
+///   and has the following syntax for e.g. TOML:
+///   ```toml
+///   proofs_dir = "/path/to/proofs_dir"
+///   ```
+///   Other file formats are supported by the `config` crate, but only TOML is tested
+/// - Default values, e.g. `$HOME/.lurk/proofs`
+pub fn cli_config(
+    config_file: Option<&Utf8PathBuf>,
+    settings: Option<&HashMap<&str, String>>,
+) -> &'static CliSettings {
+    LURK_CONFIG
+        .set(Settings::from_config(lurk_config_file(config_file), settings).unwrap_or_default())
+        .unwrap_or(());
+    CLI_CONFIG.get_or_init(|| {
+        CliSettings::from_config(lurk_config_file(config_file), settings).unwrap_or_default()
+    })
+}
+
+/// Contains the CLI configuration settings
+// NOTE: Config settings share the same file for both the Lurk library and the CLI.
+// It's good practice to avoid duplication of shared settings like `public_params_dir`
+// in downstream configs like these to prevent conflicts.
+#[derive(Debug, Deserialize)]
+pub struct CliSettings {
+    /// Cache directory for proofs
+    pub proofs_dir: Utf8PathBuf,
+    /// Cache directory for commitments
+    pub commits_dir: Utf8PathBuf,
+    /// Cache directory for Circom files
+    pub circom_dir: Utf8PathBuf,
+    /// Proof generation and verification system
+    pub backend: Backend,
+    /// Finite field used for evaluation and proving
+    pub field: LanguageField,
+    /// Reduction count, which is the number of circuit reductions per step
+    pub rc: usize,
+    /// Iteration limit for the program, which is arbitrary to user preferences
+    /// Used mainly as a safety check, similar to default stack size
+    pub limit: usize,
+}
+
+impl CliSettings {
+    /// Loads config settings from a file or env var, or CLI arg if applicable
+    pub fn from_config(
+        config_file: &Utf8PathBuf,
+        cli_settings: Option<&HashMap<&str, String>>,
+    ) -> Result<Self, ConfigError> {
+        let (proofs, commits, circom, backend, field, rc, limit) = (
+            "proofs_dir",
+            "commits_dir",
+            "circom_dir",
+            "backend",
+            "field",
+            "rc",
+            "limit",
+        );
+        Config::builder()
+            .set_default(proofs, proofs_default_dir().to_string())?
+            .set_default(commits, commits_default_dir().to_string())?
+            .set_default(circom, circom_default_dir().to_string())?
+            .set_default(backend, Backend::default().to_string())?
+            .set_default(field, LanguageField::default().to_string())?
+            .set_default(rc, 10)?
+            .set_default(limit, 100_000_000)?
+            .add_source(File::with_name(config_file.as_str()).required(false))
+            // Then overwrite with any `LURK` environment variables
+            .add_source(Environment::with_prefix("LURK"))
+            // TODO: Derive config::Source for `cli_settings` and use `add_source` instead
+            .set_override_option(proofs, cli_settings.and_then(|s| s.get(proofs).map(|v| v.to_owned())))?
+            .set_override_option(commits, cli_settings.and_then(|s| s.get(commits).map(|v| v.to_owned())))?
+            .set_override_option(circom, cli_settings.and_then(|s| s.get(circom).map(|v| v.to_owned())))?
+            .set_override_option(backend, cli_settings.and_then(|s| s.get(backend).map(|v| v.to_owned())))?
+            .set_override_option(field, cli_settings.and_then(|s| s.get(field).map(|v| v.to_owned())))?
+            .set_override_option(rc, cli_settings.and_then(|s| s.get(rc).map(|v| v.to_owned())))?
+            .set_override_option(limit, cli_settings.and_then(|s| s.get(limit).map(|v| v.to_owned())))?
+            .build()
+            .and_then(|c| c.try_deserialize())
+    }
+}
+
+impl Default for CliSettings {
+    fn default() -> Self {
+        Self {
+            proofs_dir: proofs_default_dir(),
+            commits_dir: commits_default_dir(),
+            circom_dir: circom_default_dir(),
+            backend: Backend::default(),
+            field: LanguageField::default(),
+            rc: 10,
+            limit: 100_000_000,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use camino::Utf8Path;
+    use std::io::prelude::*;
+    use tempfile::Builder;
+
+    use crate::cli::backend::Backend;
+    use crate::cli::config::CliSettings;
+    use crate::config::Settings;
+    use crate::field::LanguageField;
+
+    // Tests a generic config file with identical syntax to that used in `CLI_CONFIG`
+    #[test]
+    fn test_config_cli() {
+        let tmp_dir = Builder::new().prefix("tmp").tempdir().unwrap();
+        let tmp_dir = Utf8Path::from_path(tmp_dir.path()).unwrap();
+        let config_dir = tmp_dir.join("lurk.toml");
+        let public_params_dir = tmp_dir.join("public_params").into_string();
+        let proofs_dir = tmp_dir.join("proofs").into_string();
+        let commits_dir = tmp_dir.join("commits").into_string();
+        let circom_dir = tmp_dir.join("circom").into_string();
+        let backend = "Nova";
+        let field = "Pallas";
+        let rc = 100;
+        let limit = 100_000;
+
+        let mut config_file = std::fs::File::create(config_dir.clone()).unwrap();
+        config_file
+            .write_all(format!("public_params_dir = \"{public_params_dir}\"\n").as_bytes())
+            .unwrap();
+        config_file
+            .write_all(format!("proofs_dir = \"{proofs_dir}\"\n").as_bytes())
+            .unwrap();
+        config_file
+            .write_all(format!("commits_dir = \"{commits_dir}\"\n").as_bytes())
+            .unwrap();
+        config_file
+            .write_all(format!("circom_dir = \"{circom_dir}\"\n").as_bytes())
+            .unwrap();
+        config_file
+            .write_all(format!("backend = \"{backend}\"\n").as_bytes())
+            .unwrap();
+        config_file
+            .write_all(format!("field = \"{field}\"\n").as_bytes())
+            .unwrap();
+        config_file
+            .write_all(format!("rc = {rc}\n").as_bytes())
+            .unwrap();
+        config_file
+            .write_all(format!("limit = {limit}\n").as_bytes())
+            .unwrap();
+
+        let cli_config = CliSettings::from_config(&config_dir, None).unwrap();
+        let lurk_config = Settings::from_config(&config_dir, None).unwrap();
+        assert_eq!(lurk_config.public_params_dir, public_params_dir);
+        assert_eq!(cli_config.proofs_dir, proofs_dir);
+        assert_eq!(cli_config.commits_dir, commits_dir);
+        assert_eq!(cli_config.circom_dir, circom_dir);
+        assert_eq!(cli_config.backend, Backend::Nova);
+        assert_eq!(cli_config.field, LanguageField::Pallas);
+        assert_eq!(cli_config.rc, rc);
+        assert_eq!(cli_config.limit, limit);
+    }
+}

--- a/src/cli/lurk_proof.rs
+++ b/src/cli/lurk_proof.rs
@@ -26,7 +26,7 @@ use crate::{
 
 use super::{
     field_data::{dump, load, HasFieldModulus},
-    paths::{proof_meta_path, proof_path, public_params_dir},
+    paths::{proof_meta_path, proof_path},
     zstore::ZStore,
 };
 
@@ -144,7 +144,7 @@ where
             } => {
                 tracing::info!("Loading public parameters");
                 let instance = Instance::new(rc, Arc::new(lang), true, Kind::NovaPublicParams);
-                let pp = public_params(&instance, &public_params_dir())?;
+                let pp = public_params(&instance)?;
                 Ok(proof.verify(&pp, num_steps, &public_inputs, &public_outputs)?)
             }
         }

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -13,7 +13,7 @@ use std::{cell::RefCell, collections::HashMap, fs::read_to_string, rc::Rc, sync:
 use tracing::info;
 
 use crate::{
-    cli::paths::{proof_path, public_params_dir},
+    cli::paths::proof_path,
     eval::lang::{Coproc, Lang},
     field::LurkField,
     lem::{
@@ -244,7 +244,7 @@ impl Repl<F> {
                         info!("Loading public parameters");
                         let instance =
                             Instance::new(self.rc, self.lang.clone(), true, Kind::NovaPublicParams);
-                        let pp = public_params(&instance, &public_params_dir())?;
+                        let pp = public_params(&instance)?;
 
                         let prover = NovaProver::<F, Coproc<F>, MultiFrame<'_, F, Coproc<F>>>::new(
                             self.rc,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,80 +1,127 @@
-//! Global config for parallelism.
-use anyhow::bail;
-use once_cell::sync::Lazy;
+//! Global config for Lurk
+//! Includes settings for cache locations, public parameters, and parallelism.
+use std::collections::HashMap;
 
-pub static CONFIG: Lazy<Config> = Lazy::new(init_config);
+use camino::Utf8PathBuf;
+use config::{Config, ConfigError, Environment, File};
+use once_cell::sync::OnceCell;
+use serde::Deserialize;
 
-fn canned_config_from_env() -> Option<CannedConfig> {
-    if let Ok(x) = std::env::var("LURK_CANNED_CONFIG") {
-        let canned = CannedConfig::try_from(x.as_str()).ok();
+use crate::cli::paths::lurk_default_dir;
 
-        tracing::debug!("{:?}", &canned);
+/// Global config variable for `Settings`
+pub static LURK_CONFIG: OnceCell<Settings> = OnceCell::new();
 
-        canned
-    } else {
-        None
-    }
+/// Global path variable for configuration file
+pub static LURK_CONFIG_FILE: OnceCell<Utf8PathBuf> = OnceCell::new();
+
+/// Gets the `LURK_CONFIG` settings. If uninitialized, sets the global variable
+/// in the following order (greatest to least precedence):
+/// - `settings` map if provided, e.g. with key ("public_params_dir", "$HOME/lurk-rs/public_params")
+/// - Env var per setting, e.g. `LURK_PUBLIC_PARAMS_DIR`
+/// - Config file, which also has a configurable location (see `lurk_config_file()`),
+///   and has the following syntax for e.g. TOML:
+///   ```toml
+///   public_params_dir = "/path/to/params"
+///   ```
+///   Other file formats are supported by the `config` crate, but only TOML is tested
+/// - Default values, e.g. `$HOME/.lurk/public_params`
+pub fn lurk_config(
+    file: Option<&Utf8PathBuf>,
+    settings: Option<&HashMap<&str, String>>,
+) -> &'static Settings {
+    LURK_CONFIG
+        .get_or_init(|| Settings::from_config(lurk_config_file(file), settings).unwrap_or_default())
 }
 
-#[derive(Default, Debug)]
-pub enum Flow {
-    #[default]
-    Sequential,
-    Parallel,         // Try to be smart.
-    ParallelN(usize), // How many threads to use? (Advisory, might be ignored.)
-}
-
-impl Flow {
-    pub fn is_sequential(&self) -> bool {
-        matches!(self, Self::Sequential)
-    }
-
-    pub fn is_parallel(&self) -> bool {
-        !self.is_sequential()
-    }
-
-    pub fn num_threads(&self) -> usize {
-        match self {
-            Self::Sequential => 1,
-            Self::Parallel => num_cpus::get(),
-            Self::ParallelN(threads) => *threads,
-        }
-    }
-
-    pub fn chunk_size(&self, total_n: usize, min_chunk_size: usize) -> usize {
-        if self.is_sequential() {
-            total_n
+/// Gets the `LURK_CONFIG_FILE` path. If uninitialized, sets the global variable
+/// in the following order (greatest to least precedence):
+/// - `config_file` parameter if provided, e.g. "$HOME/lurk-rs/lurk-local.toml"
+/// - `LURK_CONFIG_FILE` env var
+/// - Default location at `$HOME/.lurk/lurk.toml` or `<current_dir>/.config/lurk.toml` on WASM.
+pub fn lurk_config_file(config_file: Option<&Utf8PathBuf>) -> &'static Utf8PathBuf {
+    LURK_CONFIG_FILE.get_or_init(|| {
+        if let Some(file) = config_file {
+            file.clone()
+        } else if let Ok(file) = std::env::var("LURK_CONFIG_FILE") {
+            Utf8PathBuf::from(file)
         } else {
-            let num_threads = self.num_threads();
-            let divides_evenly = total_n % num_threads == 0;
+            lurk_default_dir().join("lurk.toml")
+        }
+    })
+}
 
-            ((total_n / num_threads) + usize::from(!divides_evenly)).max(min_chunk_size)
+/// Contains the Lurk config settings
+/// The `public_params_dir` setting can also be overriden by a CLI arg if in use
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+pub struct Settings {
+    /// Public parameter disk cache location
+    pub public_params_dir: Utf8PathBuf,
+
+    /// Parallelism & witness gen configs
+    pub perf: PerfConfig,
+}
+
+impl Settings {
+    /// Loads config settings from a file or env vars
+    /// The public parameter disk cache can also be overriden by a CLI arg if applicable
+    pub fn from_config(
+        config_file: &Utf8PathBuf,
+        settings: Option<&HashMap<&str, String>>,
+    ) -> Result<Self, ConfigError> {
+        let public_params = "public_params_dir";
+        // Settings are read first to last, in order of increasing precedence.
+        // Hence, default values must come first so they are overriden by all other methods.
+        Config::builder()
+            // Default settings if unspecified in the config file
+            .set_default(public_params, public_params_default_dir().to_string())?
+            .set_default("perf", "fully-sequential".to_string())?
+            .add_source(File::with_name(config_file.as_str()).required(false))
+            // Then override with any `LURK` environment variables
+            .add_source(Environment::with_prefix("LURK"))
+            // Optionally override if settings were specified via CLI arg
+            .set_override_option(public_params, settings.and_then(|s| s.get(public_params).map(|v| v.to_owned())))?
+            .build()
+            .and_then(|c| c.try_deserialize())
+    }
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            public_params_dir: public_params_default_dir(),
+            perf: PerfConfig::default(),
         }
     }
 }
 
-#[derive(Default, Debug)]
-pub struct ParallelConfig {
-    pub recursive_steps: Flow,    // Multiple `StepCircuit`s.
-    pub synthesis: Flow,          // Synthesis (within one `StepCircuit`)
-    pub poseidon_witnesses: Flow, // The poseidon witness part of synthesis.
+pub fn public_params_default_dir() -> Utf8PathBuf {
+    #[cfg(not(target_arch = "wasm32"))]
+    let params_path = home_dir();
+    #[cfg(target_arch = "wasm32")]
+    let params_path = Utf8PathBuf::new();
+    params_path.join(".lurk/public_params")
 }
 
-/// Should we use optimized witness-generation when possible?
-#[derive(Debug, Default)]
-pub struct WitnessGeneration {
-    // NOTE: Neptune itself *will* do this transparently at the level of individual hashes, where possible.
-    // so this configuration is only required for higher-level decisions.
-    pub precompute_neptune: bool,
+// TODO: Should we crash if the user has no home dir?
+/// Returns the home directory used by `cargo`` and `rustup`
+#[cfg(not(target_arch = "wasm32"))]
+pub fn home_dir() -> Utf8PathBuf {
+    Utf8PathBuf::from_path_buf(home::home_dir().expect("missing home directory"))
+        .expect("path contains invalid Unicode")
 }
 
-#[derive(Default, Debug)]
-pub struct Config {
+/// Performance-related configuration settings
+#[derive(Default, Debug, PartialEq, Eq, Deserialize)]
+#[serde(from = "CannedConfig")]
+pub struct PerfConfig {
+    /// Parallelism settings
     pub parallelism: ParallelConfig,
+    /// Witness generation settings
     pub witness_generation: WitnessGeneration,
 }
 
-impl Config {
+impl PerfConfig {
     fn fully_sequential() -> Self {
         Self {
             parallelism: ParallelConfig {
@@ -128,15 +175,82 @@ impl Config {
     }
 }
 
-#[derive(Debug)]
+/// Parallel configuration settings
+#[derive(Default, Debug, PartialEq, Eq)]
+pub struct ParallelConfig {
+    /// Multiple `StepCircuit`s.
+    pub recursive_steps: Flow,
+    /// Synthesis (within one `StepCircuit`)
+    pub synthesis: Flow,
+    /// The poseidon witness part of synthesis.
+    pub poseidon_witnesses: Flow,
+}
+
+/// Should we use optimized witness-generation when possible?
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct WitnessGeneration {
+    /// NOTE: Neptune itself *will* do this transparently at the level of individual hashes, where possible.
+    /// so this configuration is only required for higher-level decisions.
+    pub precompute_neptune: bool,
+}
+
+/// The level of parallelism used when synthesizing the Lurk circuit
+#[derive(Default, Debug, PartialEq, Eq)]
+pub enum Flow {
+    /// Runs without parallelism (default)
+    #[default]
+    Sequential,
+    /// Try to be smart about thread management based on # of cpus
+    Parallel,
+    /// How many threads to use? (Advisory, might be ignored.)
+    ParallelN(usize),
+}
+
+impl Flow {
+    /// Returns `true` on `Flow::Sequential`
+    pub fn is_sequential(&self) -> bool {
+        matches!(self, Self::Sequential)
+    }
+
+    /// Returns `true` on `Flow::Parallel` or `Flow::ParallelN`
+    pub fn is_parallel(&self) -> bool {
+        !self.is_sequential()
+    }
+
+    /// Returns the number of parallel threads to run
+    pub fn num_threads(&self) -> usize {
+        match self {
+            Self::Sequential => 1,
+            Self::Parallel => num_cpus::get(),
+            Self::ParallelN(threads) => *threads,
+        }
+    }
+
+    /// Returns the number of parallel steps to run per thread with `rayon::prelude::par_chunks()`
+    pub fn chunk_size(&self, total_n: usize, min_chunk_size: usize) -> usize {
+        if self.is_sequential() {
+            total_n
+        } else {
+            let num_threads = self.num_threads();
+            let divides_evenly = total_n % num_threads == 0;
+
+            ((total_n / num_threads) + usize::from(!divides_evenly)).max(min_chunk_size)
+        }
+    }
+}
+
+/// Shortcut to easily set `PerfConfig`
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 enum CannedConfig {
+    #[default]
     FullySequential,
     MaxParallelSimple,
     ParallelStepsOnly,
     ParallelSynthesis,
 }
 
-impl From<CannedConfig> for Config {
+impl From<CannedConfig> for PerfConfig {
     fn from(canned: CannedConfig) -> Self {
         match canned {
             CannedConfig::FullySequential => Self::fully_sequential(),
@@ -147,20 +261,84 @@ impl From<CannedConfig> for Config {
     }
 }
 
-impl TryFrom<&str> for CannedConfig {
-    type Error = anyhow::Error;
+#[cfg(test)]
+mod tests {
+    use camino::Utf8Path;
+    use std::io::prelude::*;
+    use std::{collections::HashMap, fs::File};
+    use tempfile::Builder;
 
-    fn try_from(s: &str) -> Result<Self, Self::Error> {
-        match s {
-            "FULLY-SEQUENTIAL" => Ok(Self::FullySequential),
-            "MAX-PARALLEL-SIMPLE" => Ok(Self::MaxParallelSimple),
-            "PARALLEL-SYNTHESIS" => Ok(Self::ParallelSynthesis),
-            "PARALLEL-STEPS-ONLY" => Ok(Self::ParallelStepsOnly),
-            _ => bail!("Invalid CannedConfig: {s}"),
-        }
+    use crate::config::{CannedConfig, PerfConfig, Settings};
+
+    // Tests a generic config file with identical syntax to that used in `LURK_CONFIG`
+    // Doesn't test `OnceCell` behavior as the tests seem to share memory
+    #[test]
+    fn test_config_lurk() {
+        let tmp_dir = Builder::new().prefix("tmp").tempdir().unwrap();
+        let tmp_dir = Utf8Path::from_path(tmp_dir.path()).unwrap();
+        let config_dir = tmp_dir.join("lurk.toml");
+        let public_params_dir = tmp_dir.join("public_params").into_string();
+        let perf_config = PerfConfig::from(CannedConfig::MaxParallelSimple);
+
+        let mut config_file = File::create(config_dir.clone()).unwrap();
+        config_file
+            .write_all(format!("public_params_dir = \"{public_params_dir}\"\n").as_bytes())
+            .unwrap();
+        config_file
+            .write_all("perf = \"max-parallel-simple\"\n".as_bytes())
+            .unwrap();
+
+        let config = Settings::from_config(&config_dir, None).unwrap();
+
+        assert_eq!(config.public_params_dir, public_params_dir);
+        assert_eq!(config.perf, perf_config);
     }
-}
 
-fn init_config() -> Config {
-    canned_config_from_env().map_or_else(Config::fully_sequential, |x| x.into())
+    // Tests overwriting the config file and CLI argument
+    // Doesn't test env var as it can overwrite other tests when run in parallel
+    #[test]
+    fn test_config_override() {
+        let tmp_dir = Builder::new().prefix("tmp").tempdir().unwrap();
+        let tmp_dir = Utf8Path::from_path(tmp_dir.path()).unwrap();
+        let config_dir = tmp_dir.join("lurk.toml");
+        let public_params_dir = tmp_dir.join("public_params").into_string();
+
+        let mut config_file = File::create(config_dir.clone()).unwrap();
+        config_file
+            .write_all(format!("public_params_dir = \"{public_params_dir}\"\n").as_bytes())
+            .unwrap();
+        config_file
+            .write_all("perf = \"parallel-steps-only\"\n".as_bytes())
+            .unwrap();
+
+        // Overwrite public params dir to simulate CLI setting
+        let public_params_dir_cli = tmp_dir.join("public_params_cli");
+        let mut overrides = HashMap::new();
+        overrides.insert("public_params_dir", public_params_dir_cli.to_string());
+
+        let config = Settings::from_config(&config_dir, Some(&overrides)).unwrap();
+
+        assert_eq!(config.public_params_dir, public_params_dir_cli);
+        assert_eq!(config.perf, PerfConfig::parallel_steps_only());
+    }
+
+    // Tests that duplicate config keys result in an error
+    #[test]
+    fn test_config_duplicate() {
+        let tmp_dir = Builder::new().prefix("tmp").tempdir().unwrap();
+        let tmp_dir = Utf8Path::from_path(tmp_dir.path()).unwrap();
+        let config_dir = tmp_dir.join("lurk.toml");
+        let public_params_dir = tmp_dir.join("public_params").into_string();
+        let public_params_dir_dup = tmp_dir.join("public_params_dup").into_string();
+
+        let mut config_file = File::create(config_dir.clone()).unwrap();
+        config_file
+            .write_all(format!("public_params_dir = \"{public_params_dir}\"\n").as_bytes())
+            .unwrap();
+        config_file
+            .write_all(format!("public_params_dir = \"{public_params_dir_dup}\"\n").as_bytes())
+            .unwrap();
+
+        assert!(Settings::from_config(&config_dir, None).is_err())
+    }
 }

--- a/src/coprocessor/circom.rs
+++ b/src/coprocessor/circom.rs
@@ -6,7 +6,7 @@
 #[cfg(not(target_arch = "wasm32"))]
 pub mod non_wasm {
     use core::fmt::Debug;
-    use std::{collections::HashMap, fs::read_dir};
+    use std::fs::read_dir;
 
     use ansi_term::Colour::Red;
     use anyhow::{bail, Result};
@@ -20,7 +20,7 @@ pub mod non_wasm {
             data::GlobalAllocations,
             pointer::{AllocatedContPtr, AllocatedPtr},
         },
-        cli::paths::{circom_dir, set_lurk_dirs},
+        cli::paths::circom_dir,
         coprocessor::{CoCircuit, Coprocessor},
         field::LurkField,
         lem::{pointers::Ptr as LEMPtr, store::Store as LEMStore, Tag},
@@ -49,9 +49,6 @@ Then run `lurk coprocessor --name {name} <{}_FOLDER>` to instantiate a new gadge
     }
 
     fn validate_gadget<F: LurkField, C: CircomGadget<F>>(gadget: &C) -> Result<()> {
-        // TODO: This is a temporary hack, see: https://github.com/lurk-lab/lurk-rs/issues/621
-        set_lurk_dirs(&HashMap::new(), &None, &None, &None, &None);
-
         if !circom_dir().exists() {
             std::fs::create_dir_all(circom_dir())?;
             return print_error(gadget.name(), vec![]);

--- a/src/field.rs
+++ b/src/field.rs
@@ -4,6 +4,7 @@
 //! This defines the LurkField trait used pervasively in the code base
 //! as an extension of the ff::PrimeField trait, with conveniance methods
 //! relating this field to the expresions of the language.
+use clap::ValueEnum;
 use ff::{PrimeField, PrimeFieldBits};
 use nova::provider::bn256_grumpkin::bn256;
 use serde::{Deserialize, Serialize};
@@ -31,11 +32,12 @@ use crate::tag::{ContTag, ExprTag, Op1, Op2};
 /// Because confusion on this point, perhaps combined with cargo-cult copying of incorrect previous usage has led to
 /// inconsistencies and inaccuracies in the code base, please prefer the named Scalar forms when correspondence to a
 /// named `LanguageField` is important.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ValueEnum)]
 #[cfg_attr(not(target_arch = "wasm32"), derive(Arbitrary))]
 #[cfg_attr(not(target_arch = "wasm32"), serde_test)]
 pub enum LanguageField {
     /// The Pallas field,
+    #[default]
     Pallas,
     /// The Vesta field,
     Vesta,

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -32,7 +32,7 @@ use crate::{
         },
         CircuitFrame, MultiFrame,
     },
-    config::CONFIG,
+    config::lurk_config,
     coprocessor::Coprocessor,
     error::ProofError,
     eval::{lang::Lang, Meta},
@@ -425,7 +425,12 @@ where
         let mut recursive_snark: Option<RecursiveSNARK<G1<F>, G2<F>, M, C2<F>>> = recursive_snark;
 
         // the shadowing here is voluntary
-        let recursive_snark = if CONFIG.parallelism.recursive_steps.is_parallel() {
+        let recursive_snark = if lurk_config(None, None)
+            .perf
+            .parallelism
+            .recursive_steps
+            .is_parallel()
+        {
             let cc = circuits
                 .iter()
                 .map(|c| Mutex::new(c.clone()))

--- a/src/public_parameters/disk_cache.rs
+++ b/src/public_parameters/disk_cache.rs
@@ -6,12 +6,19 @@ use abomonation::{encode, Abomonation};
 use camino::{Utf8Path, Utf8PathBuf};
 use nova::traits::Group;
 
+use crate::config::lurk_config;
 use crate::coprocessor::Coprocessor;
 use crate::proof::nova::{CurveCycleEquipped, PublicParams, G1, G2};
 use crate::proof::MultiFrameTrait;
 use crate::public_parameters::error::Error;
 
 use super::instance::Instance;
+
+/// Returns the public parameter disk cache directory, which has
+/// either been configured or defaults to `$HOME/.lurk/public_params`
+pub(crate) fn public_params_dir() -> &'static Utf8PathBuf {
+    &lurk_config(None, None).public_params_dir
+}
 
 pub(crate) struct DiskCache<'a, F, C, M>
 where

--- a/tests/lurk-cli-tests.rs
+++ b/tests/lurk-cli-tests.rs
@@ -4,8 +4,6 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::process::Command;
 use tempfile::Builder;
-use tracing_subscriber::{fmt, prelude::*, EnvFilter, Registry};
-use tracing_texray::TeXRayLayer;
 
 fn lurk_cmd() -> Command {
     Command::cargo_bin("lurk").unwrap()
@@ -43,47 +41,6 @@ fn test_bad_command() {
     let mut cmd = lurk_cmd();
     cmd.arg(bad_file.to_str().unwrap());
     cmd.assert().failure();
-}
-
-#[test]
-fn test_config_file() {
-    let subscriber = Registry::default()
-        .with(fmt::layer().pretty().with_test_writer())
-        .with(EnvFilter::from_default_env())
-        // note: we don't `tracing_texray::examine` anything below, so no spans are printed
-        // but we add the layer to allow the option in the future, maybe with a feature?
-        .with(TeXRayLayer::new());
-
-    tracing::subscriber::set_global_default(subscriber).unwrap();
-
-    let tmp_dir = Builder::new().prefix("tmp").tempdir().unwrap();
-    let tmp_dir = Utf8Path::from_path(tmp_dir.path()).unwrap();
-    let config_dir = tmp_dir.join("lurk.toml");
-    let public_params_dir = tmp_dir.join("public_params").into_string();
-    let proofs_dir = tmp_dir.join("proofs").into_string();
-    let commits_dir = tmp_dir.join("commits").into_string();
-
-    let mut config_file = File::create(&config_dir).unwrap();
-    config_file
-        .write_all(format!("public_params = \"{public_params_dir}\"\n").as_bytes())
-        .unwrap();
-    config_file
-        .write_all(format!("proofs = \"{proofs_dir}\"\n").as_bytes())
-        .unwrap();
-    config_file
-        .write_all(format!("commits = \"{commits_dir}\"\n").as_bytes())
-        .unwrap();
-
-    // Overwrite proof dir with env var
-    let proofs_dir_env = tmp_dir.join("proofs_env").into_string();
-
-    std::env::set_var("LURK_PROOFS", proofs_dir_env.clone());
-
-    let config = lurk::cli::get_config(&Some(config_dir)).unwrap();
-
-    assert_eq!(config.get("public_params").unwrap(), &public_params_dir);
-    assert_eq!(config.get("proofs").unwrap(), &proofs_dir_env);
-    assert_eq!(config.get("commits").unwrap(), &commits_dir);
 }
 
 // TODO: Use a snapshot test for the proof ID and/or test the REPL process


### PR DESCRIPTION
- Moves the `LURK_DIRS` global variable to `config.rs` as `LURK_CONFIG: OnceCell<Settings>`. This enables the configuration of the public parameter cache location in the following ways:
  - Lurk as a library:
    - Add `public_params_dir = "/path/to/public_params"` into the config file located at `$HOME/.lurk/lurk.toml` or a configurable location (lowest priority)
    - Set the `LURK_PUBLIC_PARAMS_DIR` env var (higher priority)
  - Lurk CLI:
    - Pass the `--public-params-dir /path/to/public_params` arg to the `lurk` binary to override the env var and config file (highest priority).
- The CLI mirrors the above settings in its own `CLI_CONFIG: OnceCell<CliSettings>`, while sharing the `lurk.toml` config file for now:
  - Config file key: `proofs_dir`, `commits_dir`, `circom_dir`
  - Env var: `LURK_PROOFS_DIR`, `LURK_COMMITS_DIR`, `LURK_CIRCOM_DIR`
  - CLI args: `--proofs-dir`, `--commits-dir`, `--circom-dir`
- Removes the cache path arg from the `public_params` function in favor of the new config
- Refactors the CLI's `set_lurk_dirs()` function to `lurk_config()` and `cli_config()`, which use the `OnceCell::get_or_init()` function to remove the prior reliance on function call order.

- [x] Disambiguate/merge configs with the preexisting `src/config.rs` concerning parallelism. If merged, the configs would all be contained in `$HOME/.lurk/lurk.toml` with the source in `src/config.rs`
- [x] Add doc comments, particularly regarding the config options explained above

Fixes #621 