### PR TITLE
feat: prove through a Multiframe trait

### DIFF
--- a/benches/end2end.rs
+++ b/benches/end2end.rs
@@ -301,7 +301,7 @@ fn prove_benchmark(c: &mut Criterion) {
             .get_evaluation_frames(
                 ptr,
                 empty_sym_env(&store),
-                &mut store,
+                &store,
                 limit,
                 lang_pallas_rc.clone(),
             )
@@ -354,7 +354,7 @@ fn prove_compressed_benchmark(c: &mut Criterion) {
             .get_evaluation_frames(
                 ptr,
                 empty_sym_env(&store),
-                &mut store,
+                &store,
                 limit,
                 lang_pallas_rc.clone(),
             )
@@ -406,7 +406,7 @@ fn verify_benchmark(c: &mut Criterion) {
                 .get_evaluation_frames(
                     ptr,
                     empty_sym_env(&store),
-                    &mut store,
+                    &store,
                     limit,
                     lang_pallas_rc.clone(),
                 )
@@ -464,7 +464,7 @@ fn verify_compressed_benchmark(c: &mut Criterion) {
                 .get_evaluation_frames(
                     ptr,
                     empty_sym_env(&store),
-                    &mut store,
+                    &store,
                     limit,
                     lang_pallas_rc.clone(),
                 )

--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -9,6 +9,7 @@ use criterion::{
 use pasta_curves::pallas;
 
 use lurk::{
+    circuit::circuit_frame::MultiFrame,
     eval::{
         empty_sym_env,
         lang::{Coproc, Lang},
@@ -75,7 +76,7 @@ fn fibo_prove<M: measurement::Measurement>(
     let lang_rc = Arc::new(lang_pallas.clone());
 
     // use cached public params
-    let pp = public_params(
+    let pp = public_params::<_, _, MultiFrame<'_, _, _>>(
         prove_params.reduction_count,
         true,
         lang_rc.clone(),
@@ -104,7 +105,7 @@ fn fibo_prove<M: measurement::Measurement>(
             b.iter_batched(
                 || (frames, lang_rc.clone()),
                 |(frames, lang_rc)| {
-                    let result = prover.prove(&pp, frames, &store, lang_rc);
+                    let result = prover.prove(&pp, frames, &store, &lang_rc);
                     let _ = black_box(result);
                 },
                 BatchSize::LargeInput,

--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -98,7 +98,7 @@ fn fibo_prove<M: measurement::Measurement>(
             let prover = NovaProver::new(prove_params.reduction_count, lang_pallas.clone());
 
             let frames = &prover
-                .get_evaluation_frames(ptr, env, &mut store, limit, lang_rc.clone())
+                .get_evaluation_frames(ptr, env, &store, limit, lang_rc.clone())
                 .unwrap();
 
             b.iter_batched(

--- a/benches/public_params.rs
+++ b/benches/public_params.rs
@@ -1,6 +1,7 @@
 use blstrs::Scalar as Fr;
 use criterion::{black_box, criterion_group, criterion_main, Criterion, SamplingMode};
 use lurk::{
+    circuit::circuit_frame::MultiFrame,
     eval::lang::{Coproc, Lang},
     proof::groth16::Groth16Prover,
     proof::nova,
@@ -26,15 +27,26 @@ fn public_params_benchmark(c: &mut Criterion) {
 
     group.bench_function("public_params_nova", |b| {
         b.iter(|| {
-            let result = nova::public_params(reduction_count, lang_pallas_rc.clone());
+            let result = nova::public_params::<_, _, MultiFrame<'_, _, _>>(
+                reduction_count,
+                lang_pallas_rc.clone(),
+            );
             black_box(result)
         })
     });
 
     group.bench_function("public_params_groth", |b| {
         b.iter(|| {
-            let result =
-                Groth16Prover::create_groth_params(DEFAULT_REDUCTION_COUNT, lang_bls_rc.clone());
+            let result = Groth16Prover::<
+                _,
+                Coproc<Fr>,
+                Fr,
+                MultiFrame<'_, Fr, Coproc<Fr>>,
+            >::create_groth_params(
+                DEFAULT_REDUCTION_COUNT,
+                lang_bls_rc.clone(),
+            )
+            .unwrap();
             black_box(result)
         })
     });

--- a/benches/sha256_ivc.rs
+++ b/benches/sha256_ivc.rs
@@ -6,6 +6,7 @@
 //! Note: The example [example/sha256_ivc.rs] is this same benchmark but as an example
 //! that's easier to play with and run.
 
+use lurk::circuit::circuit_frame::MultiFrame;
 use lurk::circuit::gadgets::data::GlobalAllocations;
 use lurk::state::user_sym;
 use lurk::{circuit::gadgets::pointer::AllocatedContPtr, tag::Tag};
@@ -226,7 +227,7 @@ fn sha256_ivc_prove<M: measurement::Measurement>(
     let lang_rc = Arc::new(lang.clone());
 
     // use cached public params
-    let pp = public_params(
+    let pp = public_params::<_, _, MultiFrame<'_, _, _>>(
         reduction_count,
         true,
         lang_rc.clone(),
@@ -256,7 +257,7 @@ fn sha256_ivc_prove<M: measurement::Measurement>(
             b.iter_batched(
                 || (frames, lang_rc.clone()),
                 |(frames, lang_rc)| {
-                    let result = prover.prove(&pp, frames, store, lang_rc);
+                    let result = prover.prove(&pp, frames, store, &lang_rc);
                     let _ = black_box(result);
                 },
                 BatchSize::LargeInput,
@@ -309,7 +310,7 @@ fn sha256_ivc_prove_compressed<M: measurement::Measurement>(
     let lang_rc = Arc::new(lang.clone());
 
     // use cached public params
-    let pp = public_params(
+    let pp = public_params::<_, _, MultiFrame<'_, _, _>>(
         reduction_count,
         true,
         lang_rc.clone(),
@@ -339,7 +340,7 @@ fn sha256_ivc_prove_compressed<M: measurement::Measurement>(
             b.iter_batched(
                 || (frames, lang_rc.clone()),
                 |(frames, lang_rc)| {
-                    let (proof, _, _, _) = prover.prove(&pp, frames, store, lang_rc).unwrap();
+                    let (proof, _, _, _) = prover.prove(&pp, frames, store, &lang_rc).unwrap();
                     let compressed_result = proof.compress(&pp).unwrap();
 
                     let _ = black_box(compressed_result);

--- a/benches/synthesis.rs
+++ b/benches/synthesis.rs
@@ -58,7 +58,10 @@ fn synthesize<M: measurement::Measurement>(
             let env = empty_sym_env(&store);
             let fib_n = (reduction_count / 3) as u64; // Heuristic, since one fib is 35 iterations.
             let ptr = fib::<pasta_curves::Fq>(&mut store, state.clone(), black_box(fib_n));
-            let prover = NovaProver::new(*reduction_count, lang_pallas.clone());
+            let prover = NovaProver::<_, _, MultiFrame<'_, _, _>>::new(
+                *reduction_count,
+                lang_pallas.clone(),
+            );
 
             let frames = prover
                 .get_evaluation_frames(ptr, env, &store, limit, lang_rc.clone())

--- a/benches/synthesis.rs
+++ b/benches/synthesis.rs
@@ -61,7 +61,7 @@ fn synthesize<M: measurement::Measurement>(
             let prover = NovaProver::new(*reduction_count, lang_pallas.clone());
 
             let frames = prover
-                .get_evaluation_frames(ptr, env, &mut store, limit, lang_rc.clone())
+                .get_evaluation_frames(ptr, env, &store, limit, lang_rc.clone())
                 .unwrap();
             let folding_config =
                 Arc::new(FoldingConfig::new_ivc(lang_rc.clone(), *reduction_count));

--- a/examples/circom.rs
+++ b/examples/circom.rs
@@ -32,6 +32,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Instant;
 
+use lurk::circuit::circuit_frame::MultiFrame;
 use lurk::circuit::gadgets::circom::CircomGadget;
 use lurk::circuit::gadgets::pointer::AllocatedPtr;
 
@@ -114,13 +115,16 @@ fn main() {
     let expr = format!("({coproc_expr})");
     let ptr = store.read(&expr).unwrap();
 
-    let nova_prover = NovaProver::<Fr, Sha256Coproc<Fr>>::new(REDUCTION_COUNT, lang.clone());
+    let nova_prover = NovaProver::<Fr, Sha256Coproc<Fr>, MultiFrame<'_, _, _>>::new(
+        REDUCTION_COUNT,
+        lang.clone(),
+    );
     let lang_rc = Arc::new(lang);
 
     println!("Setting up public parameters...");
 
     let pp_start = Instant::now();
-    let pp = public_params::<_, Sha256Coproc<Fr>>(
+    let pp = public_params::<_, Sha256Coproc<Fr>, MultiFrame<'_, _, _>>(
         REDUCTION_COUNT,
         true,
         lang_rc.clone(),
@@ -135,7 +139,7 @@ fn main() {
 
     let proof_start = Instant::now();
     let (proof, z0, zi, num_steps) = nova_prover
-        .evaluate_and_prove(&pp, ptr, empty_sym_env(store), store, 10000, lang_rc)
+        .evaluate_and_prove(&pp, ptr, empty_sym_env(store), store, 10000, &lang_rc)
         .unwrap();
     let proof_end = proof_start.elapsed();
 

--- a/examples/sha256_ivc.rs
+++ b/examples/sha256_ivc.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Instant;
 
+use lurk::circuit::circuit_frame::MultiFrame;
 use lurk::circuit::gadgets::data::GlobalAllocations;
 use lurk::circuit::gadgets::pointer::{AllocatedContPtr, AllocatedPtr};
 use lurk::coprocessor::{CoCircuit, Coprocessor};
@@ -193,7 +194,8 @@ fn main() {
     );
     let lang_rc = Arc::new(lang.clone());
 
-    let nova_prover = NovaProver::<Fr, Sha256Coproc<Fr>>::new(REDUCTION_COUNT, lang);
+    let nova_prover =
+        NovaProver::<Fr, Sha256Coproc<Fr>, MultiFrame<'_, _, _>>::new(REDUCTION_COUNT, lang);
 
     println!("Setting up public parameters (rc = {REDUCTION_COUNT})...");
 
@@ -207,7 +209,7 @@ fn main() {
         println!("Beginning proof step...");
         let proof_start = Instant::now();
         let (proof, z0, zi, num_steps) = nova_prover
-            .evaluate_and_prove(pp, call, empty_sym_env(store), store, 10000, lang_rc)
+            .evaluate_and_prove(pp, call, empty_sym_env(store), store, 10000, &lang_rc)
             .unwrap();
         let proof_end = proof_start.elapsed();
 

--- a/fcomm/src/bin/fcomm.rs
+++ b/fcomm/src/bin/fcomm.rs
@@ -1,4 +1,5 @@
 use abomonation::Abomonation;
+use lurk::circuit::circuit_frame::MultiFrame;
 use lurk::lurk_sym_ptr;
 use lurk::proof::nova::{CurveCycleEquipped, G1, G2};
 use nova::traits::Group;
@@ -231,7 +232,10 @@ impl Open {
 
         let s = &mut Store::<S1>::default();
         let rc = ReductionCount::try_from(self.reduction_count).expect("reduction count");
-        let prover = NovaProver::<S1, Coproc<S1>>::new(rc.count(), lang.clone());
+        let prover = NovaProver::<'_, S1, Coproc<S1>, MultiFrame<'_, S1, Coproc<S1>>>::new(
+            rc.count(),
+            lang.clone(),
+        );
         let lang_rc = Arc::new(lang.clone());
         let pp =
             public_params(rc.count(), true, lang_rc, &public_param_dir()).expect("public params");
@@ -336,7 +340,10 @@ impl Prove {
     fn prove(&self, limit: usize, lang: &Lang<S1, Coproc<S1>>) {
         let s = &mut Store::<S1>::default();
         let rc = ReductionCount::try_from(self.reduction_count).unwrap();
-        let prover = NovaProver::<S1, Coproc<S1>>::new(rc.count(), lang.clone());
+        let prover = NovaProver::<'_, S1, Coproc<S1>, MultiFrame<'_, S1, Coproc<S1>>>::new(
+            rc.count(),
+            lang.clone(),
+        );
         let lang_rc = Arc::new(lang.clone());
         let pp = public_params(rc.count(), true, lang_rc.clone(), &public_param_dir()).unwrap();
 

--- a/fcomm/src/lib.rs
+++ b/fcomm/src/lib.rs
@@ -14,7 +14,7 @@ use hex::FromHex;
 #[cfg(not(target_arch = "wasm32"))]
 use lurk::field::FWrap;
 use lurk::{
-    circuit::ToInputs,
+    circuit::{circuit_frame::MultiFrame, ToInputs},
     eval::{
         empty_sym_env,
         lang::{Coproc, Lang},
@@ -286,7 +286,7 @@ where
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     pub claim: Claim<F>,
-    pub proof: nova::Proof<'a, F, Coproc<F>>,
+    pub proof: nova::Proof<'a, F, Coproc<F>, MultiFrame<'a, F, Coproc<F>>>,
     pub num_steps: usize,
     pub reduction_count: ReductionCount,
 }
@@ -645,8 +645,8 @@ impl<'a> Opening<S1> {
         limit: usize,
         chain: bool,
         only_use_cached_proofs: bool,
-        nova_prover: &'a NovaProver<S1, Coproc<S1>>,
-        pp: &'a PublicParams<'_, S1, Coproc<S1>>,
+        nova_prover: &'a NovaProver<'_, S1, Coproc<S1>, MultiFrame<'a, S1, Coproc<S1>>>,
+        pp: &'a PublicParams<S1, MultiFrame<'_, S1, Coproc<S1>>>,
         lang: Arc<Lang<S1, Coproc<S1>>>,
     ) -> Result<Proof<'a, S1>, Error> {
         let claim = Self::apply(s, input, function, limit, chain, &lang)?;
@@ -666,8 +666,8 @@ impl<'a> Opening<S1> {
         request: &OpeningRequest<S1>,
         limit: usize,
         only_use_cached_proofs: bool,
-        nova_prover: &'a NovaProver<S1, Coproc<S1>>,
-        pp: &'a PublicParams<'_, S1, Coproc<S1>>,
+        nova_prover: &'a NovaProver<'_, S1, Coproc<S1>, MultiFrame<'a, S1, Coproc<S1>>>,
+        pp: &'a PublicParams<S1, MultiFrame<'_, S1, Coproc<S1>>>,
         lang: Arc<Lang<S1, Coproc<S1>>>,
     ) -> Result<Proof<'a, S1>, Error> {
         let input = request.input.expr.ptr(s, limit, &lang);
@@ -799,8 +799,8 @@ impl<'a> Proof<'a, S1> {
         supplied_env: Option<Ptr<S1>>,
         limit: usize,
         only_use_cached_proofs: bool,
-        nova_prover: &'a NovaProver<S1, Coproc<S1>>,
-        pp: &'a PublicParams<'_, S1, Coproc<S1>>,
+        nova_prover: &'a NovaProver<'_, S1, Coproc<S1>, MultiFrame<'a, S1, Coproc<S1>>>,
+        pp: &'a PublicParams<S1, MultiFrame<'_, S1, Coproc<S1>>>,
         lang: Arc<Lang<S1, Coproc<S1>>>,
     ) -> Result<Self, Error> {
         let env = supplied_env.unwrap_or_else(|| empty_sym_env(s));
@@ -837,8 +837,8 @@ impl<'a> Proof<'a, S1> {
         claim: &Claim<S1>,
         limit: usize,
         only_use_cached_proofs: bool,
-        nova_prover: &'a NovaProver<S1, Coproc<S1>>,
-        pp: &'a PublicParams<'_, S1, Coproc<S1>>,
+        nova_prover: &'a NovaProver<'_, S1, Coproc<S1>, MultiFrame<'a, S1, Coproc<S1>>>,
+        pp: &'a PublicParams<S1, MultiFrame<'_, S1, Coproc<S1>>>,
         lang: &Arc<Lang<S1, Coproc<S1>>>,
     ) -> Result<Self, Error> {
         let reduction_count = nova_prover.reduction_count();
@@ -881,7 +881,7 @@ impl<'a> Proof<'a, S1> {
         };
 
         let (proof, _public_input, _public_output, num_steps) = nova_prover
-            .evaluate_and_prove(pp, expr, env, s, limit, lang.clone())
+            .evaluate_and_prove(pp, expr, env, s, limit, lang)
             .expect("Nova proof failed");
 
         let proof = Self {
@@ -922,7 +922,7 @@ impl<'a> Proof<'a, S1> {
 
     pub fn verify(
         &self,
-        pp: &PublicParams<'_, S1, Coproc<S1>>,
+        pp: &PublicParams<S1, MultiFrame<'_, S1, Coproc<S1>>>,
         lang: &Lang<S1, Coproc<S1>>,
     ) -> Result<VerificationResult, Error> {
         let (public_inputs, public_outputs) = self.io_vecs(lang)?;
@@ -1236,7 +1236,10 @@ mod test {
             .expect("function_map set");
 
         for (function_input, _expected_output) in io {
-            let prover = NovaProver::<S1, Coproc<S1>>::new(rc.count(), lang.clone());
+            let prover = NovaProver::<'_, S1, Coproc<S1>, MultiFrame<'_, S1, Coproc<S1>>>::new(
+                rc.count(),
+                lang.clone(),
+            );
 
             let input = s.read(function_input).expect("Read error");
 

--- a/fcomm/tests/proof_tests.rs
+++ b/fcomm/tests/proof_tests.rs
@@ -234,7 +234,7 @@ fn test_function_aux(
         let proof = Proof::<S1>::read_from_json_path(&proof_path).expect("read proof");
         let opening = proof.claim.opening().expect("expected opening claim");
 
-        let mut store = Store::<S1>::default();
+        let store = Store::<S1>::default();
 
         let input = store.read(function_input).expect("store read");
         let canonical_input = input.fmt_to_string(&store, initial_lurk_state());

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -16,11 +16,13 @@ use crate::{
         pointer::{AllocatedContPtr, AllocatedPtr, AsAllocatedHashComponents},
     },
     config::CONFIG,
+    eval::{empty_sym_env, lang::Lang},
     field::LurkField,
     hash::HashConst,
     hash_witness::{
         ConsCircuitWitness, ConsName, ContCircuitWitness, ContName, HashCircuitWitnessCache,
     },
+    proof::CEKState,
     store::NamedConstants,
     tag::Tag,
 };
@@ -39,9 +41,11 @@ use crate::eval::{Frame, Meta, Witness, IO};
 use crate::expr::Thunk;
 use crate::hash_witness::HashWitness;
 use crate::lurk_sym_ptr;
-use crate::proof::{supernova::FoldingConfig, Provable};
-use crate::ptr::Ptr;
-use crate::store::Store;
+use crate::proof::{
+    supernova::FoldingConfig, EvaluationStore, FrameLike, MultiFrameTrait, Provable,
+};
+use crate::ptr::{ContPtr, Ptr};
+use crate::store::{self, Store};
 use crate::tag::{ContTag, ExprTag, Op1, Op2};
 use num_bigint::BigUint;
 use num_integer::Integer;
@@ -67,6 +71,205 @@ pub struct MultiFrame<'a, F: LurkField, C: Coprocessor<F>> {
     pub count: usize,
     pub folding_config: Arc<FoldingConfig<F, C>>,
     pub meta: Meta<F>,
+}
+
+impl<F: LurkField> CEKState<Ptr<F>, ContPtr<F>> for IO<F> {
+    fn expr(&self) -> &Ptr<F> {
+        &self.expr
+    }
+    fn env(&self) -> &Ptr<F> {
+        &self.env
+    }
+    fn cont(&self) -> &ContPtr<F> {
+        &self.cont
+    }
+}
+
+impl<F: LurkField, C: Coprocessor<F>> FrameLike<Ptr<F>, ContPtr<F>>
+    for Frame<IO<F>, Witness<F>, F, C>
+{
+    type FrameIO = IO<F>;
+    fn input(&self) -> &Self::FrameIO {
+        &self.input
+    }
+    fn output(&self) -> &Self::FrameIO {
+        &self.output
+    }
+}
+
+impl<'a, F: LurkField, C: Coprocessor<F>> FrameLike<Ptr<F>, ContPtr<F>> for CircuitFrame<'a, F, C> {
+    // TODO: fix the inability to return an error here
+    // We *could* add an Error type here, but actually, this is a case where a builder pattern
+    // would resolve the initialization of these structures
+    type FrameIO = IO<F>;
+    fn input(&self) -> &Self::FrameIO {
+        self.input.as_ref().unwrap()
+    }
+    fn output(&self) -> &Self::FrameIO {
+        self.output.as_ref().unwrap()
+    }
+}
+
+impl<F: LurkField> EvaluationStore for Store<F> {
+    type Ptr = Ptr<F>;
+    type ContPtr = ContPtr<F>;
+    type Error = store::Error;
+
+    fn read(&mut self, expr: &str) -> Result<Self::Ptr, Self::Error> {
+        Store::read(self, expr).map_err(|e| store::Error(e.to_string()))
+    }
+    fn initial_empty_env(&mut self) -> Self::Ptr {
+        empty_sym_env(self)
+    }
+    fn get_cont_terminal(&self) -> Self::ContPtr {
+        // qualified syntax for the
+        Store::get_cont_terminal(self)
+    }
+
+    fn ptr_eq(&self, left: &Self::Ptr, right: &Self::Ptr) -> Result<bool, Self::Error> {
+        self.ptr_eq(left, right)
+    }
+}
+
+impl<'a, F: LurkField, C: Coprocessor<F> + 'a> MultiFrameTrait<'a, F, C> for MultiFrame<'a, F, C> {
+    type Ptr = Ptr<F>;
+    type ContPtr = ContPtr<F>;
+    type Store = Store<F>;
+    type StoreError = store::Error;
+    type EvalFrame = Frame<IO<F>, Witness<F>, F, C>;
+    type CircuitFrame = CircuitFrame<'a, F, C>;
+    type GlobalAllocation = GlobalAllocations<F>;
+    type AllocatedIO = AllocatedIO<F>;
+
+    fn emitted(store: &Self::Store, eval_frame: &Self::EvalFrame) -> Vec<Ptr<F>> {
+        match eval_frame.output.maybe_emitted_expression(store) {
+            Some(ptr) => vec![ptr],
+            None => Vec::default(),
+        }
+    }
+
+    fn get_evaluation_frames(
+        padding_predicate: impl Fn(usize) -> bool,
+        expr: Ptr<F>,
+        env: Ptr<F>,
+        store: &Self::Store,
+        limit: usize,
+        lang: &Lang<F, C>,
+    ) -> Result<Vec<Frame<IO<F>, Witness<F>, F, C>>, crate::error::ProofError> {
+        let frames = crate::eval::Evaluator::generate_frames(
+            expr,
+            env,
+            store,
+            limit,
+            padding_predicate,
+            lang,
+        )?;
+
+        store.hydrate_scalar_cache();
+
+        Ok(frames)
+    }
+
+    fn io_to_scalar_vector(
+        store: &Self::Store,
+        io: &<Self::EvalFrame as FrameLike<Ptr<F>, ContPtr<F>>>::FrameIO,
+    ) -> Result<Vec<F>, Self::StoreError> {
+        io.to_vector(store)
+    }
+
+    fn compute_witness(&self, s: &Self::Store) -> WitnessCS<F> {
+        let mut wcs = WitnessCS::new();
+
+        let input = self.input.unwrap();
+
+        let expr = s.hash_expr(&input.expr).unwrap();
+        let env = s.hash_expr(&input.env).unwrap();
+        let cont = s.hash_cont(&input.cont).unwrap();
+
+        let z_scalar = vec![
+            expr.tag().to_field(),
+            *expr.value(),
+            env.tag().to_field(),
+            *env.value(),
+            cont.tag().to_field(),
+            *cont.value(),
+        ];
+
+        let mut bogus_cs = WitnessCS::<F>::new();
+        let z: Vec<AllocatedNum<F>> = z_scalar
+            .iter()
+            .map(|x| AllocatedNum::alloc(&mut bogus_cs, || Ok(*x)).unwrap())
+            .collect::<Vec<_>>();
+
+        let _ = nova::traits::circuit::StepCircuit::synthesize(self, &mut wcs, z.as_slice());
+
+        wcs
+    }
+
+    fn cached_witness(&mut self) -> &mut Option<WitnessCS<F>> {
+        &mut self.cached_witness
+    }
+
+    fn output(&self) -> &Option<<Self::EvalFrame as FrameLike<Ptr<F>, ContPtr<F>>>::FrameIO> {
+        &self.output
+    }
+
+    fn frames(&self) -> Option<&Vec<Self::CircuitFrame>> {
+        self.frames.as_ref()
+    }
+
+    fn precedes(&self, maybe_next: &Self) -> bool {
+        self.output == maybe_next.input
+    }
+
+    fn synthesize_frames<CS: ConstraintSystem<F>>(
+        &self,
+        cs: &mut CS,
+        store: &Self::Store,
+        input: Self::AllocatedIO,
+        frames: &[Self::CircuitFrame],
+        g: &GlobalAllocations<F>,
+    ) -> Self::AllocatedIO {
+        let (allocated_expr, allocated_env, allocated_cont) = input;
+        MultiFrame::synthesize_frames(
+            self,
+            cs,
+            store,
+            allocated_expr,
+            allocated_env,
+            allocated_cont,
+            frames,
+            g,
+        )
+    }
+
+    fn blank(folding_config: Arc<FoldingConfig<F, C>>, meta: Meta<F>) -> Self {
+        MultiFrame::blank(folding_config, meta)
+    }
+
+    fn from_frames(
+        count: usize,
+        frames: &[Self::EvalFrame],
+        store: &'a Self::Store,
+        folding_config: Arc<FoldingConfig<F, C>>,
+    ) -> Vec<Self> {
+        MultiFrame::from_frames(count, frames, store, folding_config)
+    }
+
+    /// Make a dummy `MultiFrame`, duplicating `self`'s final `CircuitFrame`.
+    fn make_dummy(
+        count: usize,
+        circuit_frame: Option<CircuitFrame<'a, F, C>>,
+        store: &'a Self::Store,
+        folding_config: Arc<FoldingConfig<F, C>>,
+        meta: Meta<F>,
+    ) -> Self {
+        MultiFrame::make_dummy(count, circuit_frame, store, folding_config, meta)
+    }
+
+    fn significant_frame_count(frames: &[Self::EvalFrame]) -> usize {
+        frames.iter().rev().skip_while(|f| f.is_complete()).count()
+    }
 }
 
 impl<'a, F: LurkField, C: Coprocessor<F>> CircuitFrame<'a, F, C> {

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -115,10 +115,10 @@ impl<F: LurkField> EvaluationStore for Store<F> {
     type ContPtr = ContPtr<F>;
     type Error = store::Error;
 
-    fn read(&mut self, expr: &str) -> Result<Self::Ptr, Self::Error> {
+    fn read(&self, expr: &str) -> Result<Self::Ptr, Self::Error> {
         Store::read(self, expr).map_err(|e| store::Error(e.to_string()))
     }
-    fn initial_empty_env(&mut self) -> Self::Ptr {
+    fn initial_empty_env(&self) -> Self::Ptr {
         empty_sym_env(self)
     }
     fn get_cont_terminal(&self) -> Self::ContPtr {
@@ -5684,13 +5684,16 @@ mod tests {
         let lang = Arc::new(raw_lang.clone());
         let (_, witness, meta) = input.reduce(&store, &lang).unwrap();
 
-        let public_params = Groth16Prover::<Bls12, Coproc<Fr>, Fr>::create_groth_params(
+        let public_params = Groth16Prover::<Bls12, Coproc<Fr>, Fr, MultiFrame<'_, Fr, Coproc<Fr>>>::create_groth_params(
             DEFAULT_REDUCTION_COUNT,
             lang.clone(),
         )
         .unwrap();
         let groth_prover =
-            Groth16Prover::<Bls12, Coproc<Fr>, Fr>::new(DEFAULT_REDUCTION_COUNT, raw_lang);
+            Groth16Prover::<Bls12, Coproc<Fr>, Fr, MultiFrame<'_, Fr, Coproc<Fr>>>::new(
+                DEFAULT_REDUCTION_COUNT,
+                raw_lang,
+            );
         let groth_params = &public_params.0;
 
         let vk = &groth_params.vk;

--- a/src/cli/lurk_proof.rs
+++ b/src/cli/lurk_proof.rs
@@ -1,14 +1,16 @@
 use ::nova::traits::Group;
 use abomonation::Abomonation;
 use anyhow::Result;
-use pasta_curves::pallas::Scalar;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
     coprocessor::Coprocessor,
     eval::lang::{Coproc, Lang},
     field::LurkField,
-    proof::nova::{self, CurveCycleEquipped, G1, G2},
+    proof::{
+        nova::{self, CurveCycleEquipped, G1, G2},
+        MultiFrameTrait,
+    },
     public_parameters::public_params,
     z_ptr::{ZContPtr, ZExprPtr},
     z_store::ZStore,
@@ -46,15 +48,20 @@ impl<F: LurkField> HasFieldModulus for LurkProofMeta<F> {
 }
 
 /// Minimal data structure containing just enough for proof verification
+#[non_exhaustive]
 #[derive(Serialize, Deserialize)]
-pub(crate) enum LurkProof<'a, F: CurveCycleEquipped>
-where
-    Coproc<F>: Coprocessor<F>,
+#[serde(bound(serialize = "F: Serialize", deserialize = "F: DeserializeOwned"))]
+pub(crate) enum LurkProof<
+    'a,
+    F: CurveCycleEquipped,
+    C: Coprocessor<F>,
+    M: MultiFrameTrait<'a, F, C>,
+> where
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     Nova {
-        proof: nova::Proof<'a, F, Coproc<F>>,
+        proof: nova::Proof<'a, F, C, M>,
         public_inputs: Vec<F>,
         public_outputs: Vec<F>,
         num_steps: usize,
@@ -63,9 +70,9 @@ where
     },
 }
 
-impl<'a, F: CurveCycleEquipped> HasFieldModulus for LurkProof<'a, F>
+impl<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a, M: MultiFrameTrait<'a, F, C>>
+    HasFieldModulus for LurkProof<'a, F, C, M>
 where
-    Coproc<F>: Coprocessor<F>,
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
@@ -81,11 +88,13 @@ impl<F: LurkField + Serialize> LurkProofMeta<F> {
     }
 }
 
-impl<'a, F: CurveCycleEquipped + Serialize> LurkProof<'a, F>
+impl<'a, F: CurveCycleEquipped + Serialize, M: MultiFrameTrait<'a, F, Coproc<F>>>
+    LurkProof<'a, F, Coproc<F>, M>
 where
-    Coproc<F>: Coprocessor<F>,
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <F as CurveCycleEquipped>::CK1: Sync + Send,
+    <F as CurveCycleEquipped>::CK2: Sync + Send,
 {
     #[inline]
     pub(crate) fn persist(self, proof_key: &str) -> Result<()> {
@@ -93,7 +102,26 @@ where
     }
 }
 
-impl<'a> LurkProof<'a, Scalar> {
+impl<
+        F: CurveCycleEquipped + DeserializeOwned,
+        M: MultiFrameTrait<'static, F, Coproc<F>> + 'static,
+    > LurkProof<'static, F, Coproc<F>, M>
+where
+    <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <F as CurveCycleEquipped>::CK1: Sync + Send,
+    <F as CurveCycleEquipped>::CK2: Sync + Send,
+{
+    pub(crate) fn verify_proof(proof_key: &str) -> Result<()> {
+        let lurk_proof: LurkProof<'_, F, Coproc<F>, M> = load(proof_path(proof_key))?;
+        if lurk_proof.verify()? {
+            println!("✓ Proof \"{proof_key}\" verified");
+        } else {
+            println!("✗ Proof \"{proof_key}\" failed on verification");
+        }
+        Ok(())
+    }
+
     fn verify(self) -> Result<bool> {
         match self {
             Self::Nova {
@@ -106,18 +134,8 @@ impl<'a> LurkProof<'a, Scalar> {
             } => {
                 tracing::info!("Loading public parameters");
                 let pp = public_params(rc, true, std::sync::Arc::new(lang), &public_params_dir())?;
-                Ok(proof.verify(&pp, num_steps, &public_inputs, &public_outputs)?)
+                Ok(proof.verify(&*pp, num_steps, &public_inputs, &public_outputs)?)
             }
         }
-    }
-
-    pub(crate) fn verify_proof(proof_key: &str) -> Result<()> {
-        let lurk_proof: LurkProof<'_, Scalar> = load(proof_path(proof_key))?;
-        if lurk_proof.verify()? {
-            println!("✓ Proof \"{proof_key}\" verified");
-        } else {
-            println!("✗ Proof \"{proof_key}\" failed on verification");
-        }
-        Ok(())
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -15,6 +15,8 @@ use pasta_curves::pallas;
 use std::{collections::HashMap, fs};
 
 use crate::{
+    circuit::MultiFrame,
+    eval::lang::Coproc,
     field::{LanguageField, LurkField},
     store::Store,
     z_data::{from_z_data, ZData},
@@ -519,7 +521,9 @@ impl Cli {
                     &None,
                     &None,
                 );
-                LurkProof::verify_proof(&verify_args.proof_id)?;
+                LurkProof::<_, _, MultiFrame<'_, _, Coproc<pallas::Scalar>>>::verify_proof(
+                    &verify_args.proof_id,
+                )?;
                 Ok(())
             }
             Command::Circom(circom_args) => {

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -19,6 +19,7 @@ use tracing::info;
 use super::{backend::Backend, commitment::Commitment, field_data::load, paths::commitment_path};
 
 use crate::{
+    circuit::MultiFrame,
     cli::paths::{proof_path, public_params_dir},
     eval::{
         lang::{Coproc, Lang},
@@ -238,11 +239,14 @@ impl Repl<F> {
                         let pp =
                             public_params(self.rc, true, self.lang.clone(), &public_params_dir())?;
 
-                        let prover = NovaProver::new(self.rc, (*self.lang).clone());
+                        let prover = NovaProver::<F, Coproc<F>, MultiFrame<'_, F, Coproc<F>>>::new(
+                            self.rc,
+                            (*self.lang).clone(),
+                        );
 
                         info!("Proving");
                         let (proof, public_inputs, public_outputs, num_steps) =
-                            prover.prove(&pp, frames, &self.store, self.lang.clone())?;
+                            prover.prove(&pp, frames, &self.store, &self.lang)?;
                         info!("Compressing proof");
                         let proof = proof.compress(&pp)?;
                         assert_eq!(self.rc * num_steps, pad(n_frames, self.rc));

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -513,7 +513,7 @@ where
     pub fn generate_frames<Fp: Fn(usize) -> bool>(
         expr: Ptr<F>,
         env: Ptr<F>,
-        store: &'a mut Store<F>,
+        store: &'a Store<F>,
         limit: usize,
         needs_frame_padding: Fp,
         lang: &'a Lang<F, C>,

--- a/src/eval/tests/mod.rs
+++ b/src/eval/tests/mod.rs
@@ -1110,7 +1110,7 @@ fn evaluate_make_tree() {
 #[test]
 fn evaluate_make_tree_minimal_regression() {
     {
-        let mut s = Store::<Fr>::default();
+        let s = Store::<Fr>::default();
         let limit = 100;
         let expr = s
             .read(

--- a/src/lem/circuit.rs
+++ b/src/lem/circuit.rs
@@ -551,9 +551,7 @@ impl Func {
                         let img_tag = g
                             .global_allocator
                             .get_allocated_const_cloned($tag.to_field())?;
-                        let AllocatedVal::Number(img_hash) = preallocated_img_hash else {
-                            bail!("Expected number")
-                        };
+                        let AllocatedVal::Number(img_hash) = preallocated_img_hash else { bail!("Expected number")};
                         let img_ptr = AllocatedPtr::from_parts(img_tag, img_hash.clone());
                         bound_allocations.insert_ptr($img, img_ptr);
                     };
@@ -579,9 +577,7 @@ impl Func {
                         };
 
                         // Add the implication constraint for the image
-                        let AllocatedVal::Number(img_hash) = preallocated_img_hash else {
-                            bail!("Expected number")
-                        };
+                        let AllocatedVal::Number(img_hash) = preallocated_img_hash else { bail!("Expected number")};
                         implies_equal(
                             &mut cs.namespace(|| format!("implies equal {}.hash", $img)),
                             not_dummy,
@@ -806,9 +802,7 @@ impl Func {
                                 &preallocated_preimg[i],
                             );
                         }
-                        let AllocatedVal::Boolean(lt) = lt else {
-                            panic!("Expected boolean")
-                        };
+                        let AllocatedVal::Boolean(lt) = lt else { panic!("Expected boolean") };
                         bound_allocations.insert_bool(tgt.clone(), lt.clone());
                     }
                     Op::Trunc(tgt, a, n) => {
@@ -880,9 +874,7 @@ impl Func {
                             .get_allocated_const(Tag::Expr(Num).to_field())?;
                         let (preallocated_preimg, hash) =
                             &g.preallocated_commitment_slots[next_slot.consume_commitment()];
-                        let AllocatedVal::Number(hash) = hash else {
-                            panic!("Excepted number")
-                        };
+                        let AllocatedVal::Number(hash) = hash else { panic!("Excepted number") };
                         implies_equal(
                             &mut cs.namespace(|| "implies equal secret.tag"),
                             not_dummy,
@@ -920,9 +912,7 @@ impl Func {
                         let comm_tag = g
                             .global_allocator
                             .get_allocated_const(Tag::Expr(Comm).to_field())?;
-                        let AllocatedVal::Number(com_hash) = com_hash else {
-                            panic!("Excepted number")
-                        };
+                        let AllocatedVal::Number(com_hash) = com_hash else { panic!("Excepted number") };
                         implies_equal(
                             &mut cs.namespace(|| "implies equal comm.tag"),
                             not_dummy,

--- a/src/lem/circuit.rs
+++ b/src/lem/circuit.rs
@@ -551,7 +551,9 @@ impl Func {
                         let img_tag = g
                             .global_allocator
                             .get_allocated_const_cloned($tag.to_field())?;
-                        let AllocatedVal::Number(img_hash) = preallocated_img_hash else { bail!("Expected number")};
+                        let AllocatedVal::Number(img_hash) = preallocated_img_hash else {
+                            bail!("Expected number")
+                        };
                         let img_ptr = AllocatedPtr::from_parts(img_tag, img_hash.clone());
                         bound_allocations.insert_ptr($img, img_ptr);
                     };
@@ -577,7 +579,9 @@ impl Func {
                         };
 
                         // Add the implication constraint for the image
-                        let AllocatedVal::Number(img_hash) = preallocated_img_hash else { bail!("Expected number")};
+                        let AllocatedVal::Number(img_hash) = preallocated_img_hash else {
+                            bail!("Expected number")
+                        };
                         implies_equal(
                             &mut cs.namespace(|| format!("implies equal {}.hash", $img)),
                             not_dummy,
@@ -802,7 +806,9 @@ impl Func {
                                 &preallocated_preimg[i],
                             );
                         }
-                        let AllocatedVal::Boolean(lt) = lt else { panic!("Expected boolean") };
+                        let AllocatedVal::Boolean(lt) = lt else {
+                            panic!("Expected boolean")
+                        };
                         bound_allocations.insert_bool(tgt.clone(), lt.clone());
                     }
                     Op::Trunc(tgt, a, n) => {
@@ -874,7 +880,9 @@ impl Func {
                             .get_allocated_const(Tag::Expr(Num).to_field())?;
                         let (preallocated_preimg, hash) =
                             &g.preallocated_commitment_slots[next_slot.consume_commitment()];
-                        let AllocatedVal::Number(hash) = hash else { panic!("Excepted number") };
+                        let AllocatedVal::Number(hash) = hash else {
+                            panic!("Excepted number")
+                        };
                         implies_equal(
                             &mut cs.namespace(|| "implies equal secret.tag"),
                             not_dummy,
@@ -912,7 +920,9 @@ impl Func {
                         let comm_tag = g
                             .global_allocator
                             .get_allocated_const(Tag::Expr(Comm).to_field())?;
-                        let AllocatedVal::Number(com_hash) = com_hash else { panic!("Excepted number") };
+                        let AllocatedVal::Number(com_hash) = com_hash else {
+                            panic!("Excepted number")
+                        };
                         implies_equal(
                             &mut cs.namespace(|| "implies equal comm.tag"),
                             not_dummy,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -35,7 +35,7 @@ pub enum Error {
 }
 
 impl<F: LurkField> Store<F> {
-    pub fn read(&mut self, input: &str) -> Result<Ptr<F>, Error> {
+    pub fn read(&self, input: &str) -> Result<Ptr<F>, Error> {
         let state = State::init_lurk_state().rccell();
         match preceded(
             syntax::parse_space,

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -16,13 +16,153 @@ pub mod supernova;
 use crate::circuit::MultiFrame;
 use crate::coprocessor::Coprocessor;
 use crate::error::ProofError;
+use crate::eval::Meta;
 use crate::eval::{lang::Lang, Evaluator, Frame, Witness, IO};
 use crate::field::LurkField;
 
 use crate::ptr::Ptr;
 use crate::store::Store;
+use ::nova::traits::circuit::StepCircuit;
+use bellpepper::util_cs::witness_cs::WitnessCS;
+use bellpepper_core::ConstraintSystem;
 use bellpepper_core::{test_cs::TestConstraintSystem, Circuit, SynthesisError};
 use std::sync::Arc;
+
+use self::supernova::FoldingConfig;
+
+/// The State of a CEK machine.
+pub trait CEKState<ExprPtr, ContPtr> {
+    /// the expression, or control word (C)
+    fn expr(&self) -> &ExprPtr;
+    /// the environment (E)
+    fn env(&self) -> &ExprPtr;
+    /// the continuation (K)
+    fn cont(&self) -> &ContPtr;
+}
+
+/// A Frame of evaluation in a CEK machine.
+pub trait FrameLike<ExprPtr, ContPtr>: Sized {
+    /// the type for the Frame's IO
+    type FrameIO: CEKState<ExprPtr, ContPtr>;
+    /// the input of the frame
+    fn input(&self) -> &Self::FrameIO;
+    /// the output of the frame
+    fn output(&self) -> &Self::FrameIO;
+}
+
+/// A trait for a store of expressions
+pub trait EvaluationStore {
+    /// the type for the Store's pointers
+    type Ptr;
+    /// the type for the Store's continuation poitners
+    type ContPtr;
+    /// the type for the Store's errors
+    type Error: std::fmt::Debug;
+
+    /// interpreting a string representation of an expression
+    fn read(&mut self, expr: &str) -> Result<Self::Ptr, Self::Error>;
+    /// getting a pointer to the initial, empty environment
+    fn initial_empty_env(&mut self) -> Self::Ptr;
+    /// getting the terminal continuation pointer
+    fn get_cont_terminal(&self) -> Self::ContPtr;
+
+    /// hash-equality of the expressions represented by Ptrs
+    fn ptr_eq(&self, left: &Self::Ptr, right: &Self::Ptr) -> Result<bool, Self::Error>;
+}
+
+/// Trait to support multiple `MultiFrame` implementations.
+pub trait MultiFrameTrait<'a, F: LurkField, C: Coprocessor<F> + 'a>:
+    Provable<F> + Circuit<F> + StepCircuit<F> + 'a
+{
+    /// The associated `Ptr` type
+    type Ptr: std::fmt::Debug + Eq + Copy;
+    /// The associated `ContPtr` type
+    type ContPtr: std::fmt::Debug + Eq + Copy;
+    /// The associated `Store` type
+    type Store: Send + Sync + EvaluationStore<Ptr = Self::Ptr, ContPtr = Self::ContPtr>;
+    /// The error type for the Store type
+    type StoreError: Into<ProofError>;
+
+    /// The associated `Frame` type
+    type EvalFrame: FrameLike<Self::Ptr, Self::ContPtr>;
+    /// The associated `CircuitFrame` type
+    type CircuitFrame: FrameLike<
+        Self::Ptr,
+        Self::ContPtr,
+        FrameIO = <Self::EvalFrame as FrameLike<Self::Ptr, Self::ContPtr>>::FrameIO,
+    >;
+    /// The associated type which manages global allocations
+    type GlobalAllocation;
+    /// The associated type of allocated input and output to the circuit
+    type AllocatedIO;
+
+    /// the emitted frames
+    fn emitted(store: &Self::Store, eval_frame: &Self::EvalFrame) -> Vec<Self::Ptr>;
+
+    /// Counting the number of non-trivial frames in the evaluation
+    fn significant_frame_count(frames: &[Self::EvalFrame]) -> usize;
+
+    /// Evaluates and generates the frames of the computation given the expression, environment, and store
+    fn get_evaluation_frames(
+        padding_predicate: impl Fn(usize) -> bool, // Determines if the prover needs padding for a given total number of frames
+        expr: Self::Ptr,
+        env: Self::Ptr,
+        store: &Self::Store,
+        limit: usize,
+        land: &Lang<F, C>,
+    ) -> Result<Vec<Self::EvalFrame>, ProofError>;
+
+    /// Returns a public IO vector when equipped with the local store, and the Self::Frame's IO
+    fn io_to_scalar_vector(
+        store: &Self::Store,
+        io: &<Self::EvalFrame as FrameLike<Self::Ptr, Self::ContPtr>>::FrameIO,
+    ) -> Result<Vec<F>, Self::StoreError>;
+
+    /// Returns true if the supplied instance directly precedes this one in a sequential computation trace.
+    fn precedes(&self, maybe_next: &Self) -> bool;
+
+    /// Populates a WitnessCS with the witness values for the given store.
+    fn compute_witness(&self, s: &Self::Store) -> WitnessCS<F>;
+
+    /// Returns a reference to the cached witness values
+    fn cached_witness(&mut self) -> &mut Option<WitnessCS<F>>;
+
+    /// The output of the last frame
+    fn output(&self) -> &Option<<Self::EvalFrame as FrameLike<Self::Ptr, Self::ContPtr>>::FrameIO>;
+
+    /// Iterates through the Self::CircuitFrame instances
+    fn frames(&self) -> Option<&Vec<Self::CircuitFrame>>;
+
+    /// Synthesize some frames.
+    fn synthesize_frames<CS: ConstraintSystem<F>>(
+        &self,
+        cs: &mut CS,
+        store: &Self::Store,
+        input: Self::AllocatedIO,
+        frames: &[Self::CircuitFrame],
+        g: &Self::GlobalAllocation,
+    ) -> Self::AllocatedIO;
+
+    /// Synthesize a blank circuit.
+    fn blank(folding_config: Arc<FoldingConfig<F, C>>, meta: Meta<F>) -> Self;
+
+    /// Create an instance from some `Self::Frame`s.
+    fn from_frames(
+        count: usize,
+        frames: &[Self::EvalFrame],
+        store: &'a Self::Store,
+        folding_config: Arc<FoldingConfig<F, C>>,
+    ) -> Vec<Self>;
+
+    /// Make a dummy instance, duplicating `self`'s final `CircuitFrame`.
+    fn make_dummy(
+        count: usize,
+        circuit_frame: Option<Self::CircuitFrame>,
+        store: &'a Self::Store,
+        folding_config: Arc<FoldingConfig<F, C>>,
+        meta: Meta<F>,
+    ) -> Self;
+}
 
 /// Represents a sequential Constraint System for a given proof.
 pub(crate) type SequentialCS<'a, F, C> = Vec<(MultiFrame<'a, F, C>, TestConstraintSystem<F>)>;
@@ -134,7 +274,7 @@ pub trait Prover<'a, F: LurkField, C: Coprocessor<F>> {
         &self,
         expr: Ptr<F>,
         env: Ptr<F>,
-        store: &mut Store<F>,
+        store: &Store<F>,
         limit: usize,
         lang: Arc<Lang<F, C>>,
     ) -> Result<Vec<Frame<IO<F>, Witness<F>, F, C>>, ProofError> {

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -1,5 +1,5 @@
 #![allow(non_snake_case)]
-use std::sync::Mutex;
+use std::{marker::PhantomData, sync::Mutex};
 
 use abomonation::Abomonation;
 use bellpepper::util_cs::witness_cs::WitnessCS;
@@ -33,11 +33,12 @@ use crate::config::CONFIG;
 
 use crate::coprocessor::Coprocessor;
 use crate::error::ProofError;
-use crate::eval::{lang::Lang, Frame, Meta, Witness, IO};
+use crate::eval::{lang::Lang, Meta};
 use crate::field::LurkField;
-use crate::proof::{supernova::FoldingConfig, Prover, PublicParameters};
-use crate::ptr::Ptr;
+use crate::proof::{supernova::FoldingConfig, MultiFrameTrait, Prover, PublicParameters};
 use crate::store::Store;
+
+use super::FrameLike;
 
 /// This trait defines most of the requirements for programming generically over the supported Nova curve cycles
 /// (currently Pallas/Vesta and BN254/Grumpkin). It being pegged on the `LurkField` trait encodes that we do
@@ -123,24 +124,24 @@ pub type C1<'a, F, C> = MultiFrame<'a, F, C>;
 pub type C2<F> = TrivialTestCircuit<<G2<F> as Group>::Scalar>;
 
 /// Type alias for Nova Public Parameters with the curve cycle types defined above.
-pub type NovaPublicParams<'a, F, C> = nova::PublicParams<G1<F>, G2<F>, C1<'a, F, C>, C2<F>>;
+pub type NovaPublicParams<F, C1> = nova::PublicParams<G1<F>, G2<F>, C1, C2<F>>;
 
 /// A struct that contains public parameters for the Nova proving system.
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct PublicParams<'a, F, C: Coprocessor<F>>
+pub struct PublicParams<F, SC: StepCircuit<F>>
 where
     F: CurveCycleEquipped,
     // technical bounds that would disappear once associated_type_bounds stabilizes
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
-    pp: NovaPublicParams<'a, F, C>,
-    pk: ProverKey<G1<F>, G2<F>, C1<'a, F, C>, C2<F>, SS1<F>, SS2<F>>,
-    vk: VerifierKey<G1<F>, G2<F>, C1<'a, F, C>, C2<F>, SS1<F>, SS2<F>>,
+    pp: NovaPublicParams<F, SC>,
+    pk: ProverKey<G1<F>, G2<F>, SC, C2<F>, SS1<F>, SS2<F>>,
+    vk: VerifierKey<G1<F>, G2<F>, SC, C2<F>, SS1<F>, SS2<F>>,
 }
 
-impl<'c, F: CurveCycleEquipped, C: Coprocessor<F>> Abomonation for PublicParams<'c, F, C>
+impl<F: CurveCycleEquipped, SC: StepCircuit<F>> Abomonation for PublicParams<F, SC>
 where
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
@@ -169,27 +170,39 @@ where
 
 /// An enum representing the two types of proofs that can be generated and verified.
 #[derive(Serialize, Deserialize)]
-pub enum Proof<'a, F: CurveCycleEquipped, C: Coprocessor<F>>
+#[serde(bound = "")]
+pub enum Proof<'a, F: CurveCycleEquipped, C: Coprocessor<F>, M: MultiFrameTrait<'a, F, C>>
 where
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     /// A proof for the intermediate steps of a recursive computation
-    Recursive(Box<RecursiveSNARK<G1<F>, G2<F>, C1<'a, F, C>, C2<F>>>),
+    Recursive(
+        Box<RecursiveSNARK<G1<F>, G2<F>, M, C2<F>>>,
+        PhantomData<&'a C>,
+    ),
     /// A proof for the final step of a recursive computation
-    Compressed(Box<CompressedSNARK<G1<F>, G2<F>, C1<'a, F, C>, C2<F>, SS1<F>, SS2<F>>>),
+    Compressed(
+        Box<CompressedSNARK<G1<F>, G2<F>, M, C2<F>, SS1<F>, SS2<F>>>,
+        PhantomData<&'a C>,
+    ),
 }
 
 /// Generates the public parameters for the Nova proving system.
-pub fn public_params<'a, F: CurveCycleEquipped, C: Coprocessor<F>>(
+pub fn public_params<
+    'a,
+    F: CurveCycleEquipped,
+    C: Coprocessor<F> + 'a,
+    M: StepCircuit<F> + MultiFrameTrait<'a, F, C>,
+>(
     num_iters_per_step: usize,
     lang: Arc<Lang<F, C>>,
-) -> PublicParams<'a, F, C>
+) -> PublicParams<F, M>
 where
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
-    let (circuit_primary, circuit_secondary) = C1::circuits(num_iters_per_step, lang);
+    let (circuit_primary, circuit_secondary) = circuits(num_iters_per_step, lang);
 
     let commitment_size_hint1 = <SS1<F> as RelaxedR1CSSNARKTrait<G1<F>>>::commitment_key_floor();
     let commitment_size_hint2 = <SS2<F> as RelaxedR1CSSNARKTrait<G2<F>>>::commitment_key_floor();
@@ -204,41 +217,51 @@ where
     PublicParams { pp, pk, vk }
 }
 
-impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> C1<'a, F, C> {
-    fn circuits(count: usize, lang: Arc<Lang<F, C>>) -> (C1<'a, F, C>, C2<F>) {
-        let folding_config = Arc::new(FoldingConfig::new_ivc(lang, count));
-        (
-            MultiFrame::blank(folding_config, Meta::Lurk),
-            TrivialTestCircuit::default(),
-        )
-    }
+/// Generates the circuits for the Nova proving system.
+pub fn circuits<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a, M: MultiFrameTrait<'a, F, C>>(
+    count: usize,
+    lang: Arc<Lang<F, C>>,
+) -> (M, C2<F>) {
+    let folding_config = Arc::new(FoldingConfig::new_ivc(lang, count));
+    (
+        M::blank(folding_config, Meta::Lurk),
+        TrivialTestCircuit::default(),
+    )
 }
 
 /// A struct for the Nova prover that operates on field elements of type `F`.
 #[derive(Debug)]
-pub struct NovaProver<F: CurveCycleEquipped, C: Coprocessor<F>> {
+pub struct NovaProver<
+    'a,
+    F: CurveCycleEquipped,
+    C: Coprocessor<F> + 'a,
+    M: MultiFrameTrait<'a, F, C>,
+> {
     // `reduction_count` specifies the number of small-step reductions are performed in each recursive step.
     reduction_count: usize,
     lang: Lang<F, C>,
+    _phantom: PhantomData<&'a M>,
 }
 
-impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> PublicParameters for PublicParams<'a, F, C>
+impl<F: CurveCycleEquipped, C1: StepCircuit<F>> PublicParameters for PublicParams<F, C1>
 where
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
 }
 
-impl<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a> Prover<'a, F, C> for NovaProver<F, C>
+impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>, M: MultiFrameTrait<'a, F, C>> Prover<'a, F, C, M>
+    for NovaProver<'a, F, C, M>
 where
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
-    type PublicParams = PublicParams<'a, F, C>;
+    type PublicParams = PublicParams<F, M>;
     fn new(reduction_count: usize, lang: Lang<F, C>) -> Self {
-        NovaProver::<F, C> {
+        NovaProver::<F, C, M> {
             reduction_count,
             lang,
+            _phantom: PhantomData,
         }
     }
     fn reduction_count(&self) -> usize {
@@ -250,47 +273,63 @@ where
     }
 }
 
-impl<F: CurveCycleEquipped, C: Coprocessor<F>> NovaProver<F, C>
+impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>, M: MultiFrameTrait<'a, F, C>>
+    NovaProver<'a, F, C, M>
 where
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     /// Proves the computation given the public parameters, frames, and store.
-    pub fn prove<'a>(
-        &'a self,
-        pp: &'a PublicParams<'_, F, C>,
-        frames: &[Frame<IO<F>, Witness<F>, F, C>],
-        store: &'a Store<F>,
-        lang: Arc<Lang<F, C>>,
-    ) -> Result<(Proof<'a, F, C>, Vec<F>, Vec<F>, usize), ProofError> {
-        let z0 = frames[0].input.to_vector(store)?;
-        let zi = frames.last().unwrap().output.to_vector(store)?;
+    pub fn prove(
+        &self,
+        pp: &PublicParams<F, M>,
+        frames: &[M::EvalFrame],
+        store: &'a M::Store,
+        lang: &Arc<Lang<F, C>>,
+    ) -> Result<(Proof<'a, F, C, M>, Vec<F>, Vec<F>, usize), ProofError> {
+        let z0 = M::io_to_scalar_vector(store, frames[0].input()).map_err(|e| e.into())?;
+        let zi =
+            M::io_to_scalar_vector(store, frames.last().unwrap().output()).map_err(|e| e.into())?;
         let folding_config = Arc::new(FoldingConfig::new_ivc(lang.clone(), self.reduction_count()));
-        let circuits = MultiFrame::from_frames(self.reduction_count, frames, store, folding_config);
+        let circuits = M::from_frames(self.reduction_count(), frames, store, folding_config);
 
         let num_steps = circuits.len();
-        let proof =
-            Proof::prove_recursively(pp, store, &circuits, self.reduction_count, z0.clone(), lang)?;
+        let proof = Proof::prove_recursively(
+            pp,
+            store,
+            &circuits,
+            self.reduction_count,
+            z0.clone(),
+            lang.clone(),
+        )?;
 
         Ok((proof, z0, zi, num_steps))
     }
 
     /// Evaluates and proves the computation given the public parameters, expression, environment, and store.
-    pub fn evaluate_and_prove<'a>(
-        &'a self,
-        pp: &'a PublicParams<'_, F, C>,
-        expr: Ptr<F>,
-        env: Ptr<F>,
-        store: &'a mut Store<F>,
+    pub fn evaluate_and_prove(
+        &self,
+        pp: &PublicParams<F, M>,
+        expr: M::Ptr,
+        env: M::Ptr,
+        store: &'a mut M::Store,
         limit: usize,
-        lang: Arc<Lang<F, C>>,
-    ) -> Result<(Proof<'_, F, C>, Vec<F>, Vec<F>, usize), ProofError> {
-        let frames = self.get_evaluation_frames(expr, env, store, limit, lang.clone())?;
+        lang: &Arc<Lang<F, C>>,
+    ) -> Result<(Proof<'a, F, C, M>, Vec<F>, Vec<F>, usize), ProofError> {
+        let frames = M::get_evaluation_frames(
+            |count| self.needs_frame_padding(count),
+            expr,
+            env,
+            store,
+            limit,
+            lang,
+        )?;
         self.prove(pp, &frames, store, lang)
     }
 }
 
 impl<'a, F: LurkField, C: Coprocessor<F>> MultiFrame<'a, F, C> {
+    #[allow(dead_code)] // TODO(huitseeker): is this used?
     fn compute_witness(&self, s: &Store<F>) -> WitnessCS<F> {
         let mut wcs = WitnessCS::new();
 
@@ -441,7 +480,7 @@ impl<'a, F: LurkField, C: Coprocessor<F>> StepCircuit<F> for MultiFrame<'a, F, C
     }
 }
 
-impl<'a: 'b, 'b, F: CurveCycleEquipped, C: Coprocessor<F>> Proof<'a, F, C>
+impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>, M: MultiFrameTrait<'a, F, C>> Proof<'a, F, C, M>
 where
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
@@ -449,9 +488,9 @@ where
     /// Proves the computation recursively, generating a recursive SNARK proof.
     #[tracing::instrument(skip_all, name = "Proof::prove_recursively")]
     pub fn prove_recursively(
-        pp: &'a PublicParams<'_, F, C>,
-        store: &'a Store<F>,
-        circuits: &[C1<'a, F, C>],
+        pp: &PublicParams<F, M>,
+        store: &M::Store,
+        circuits: &[M],
         num_iters_per_step: usize,
         z0: Vec<F>,
         lang: Arc<Lang<F, C>>,
@@ -462,19 +501,16 @@ where
         let z0_primary = z0;
         let z0_secondary = Self::z0_secondary();
 
-        assert_eq!(
-            circuits[0].frames.as_ref().unwrap().len(),
-            num_iters_per_step
-        );
+        assert_eq!(circuits[0].frames().unwrap().len(), num_iters_per_step);
         let (_circuit_primary, circuit_secondary): (
             MultiFrame<'_, F, C>,
             TrivialTestCircuit<<G2<F> as Group>::Scalar>,
-        ) = C1::<'a>::circuits(num_iters_per_step, lang);
+        ) = crate::proof::nova::circuits(num_iters_per_step, lang);
 
         tracing::debug!("circuits.len: {}", circuits.len());
 
         // produce a recursive SNARK
-        let mut recursive_snark: Option<RecursiveSNARK<G1<F>, G2<F>, C1<'a, F, C>, C2<F>>> = None;
+        let mut recursive_snark: Option<RecursiveSNARK<G1<F>, G2<F>, M, C2<F>>> = None;
 
         // the shadowing here is voluntary
         let recursive_snark = if CONFIG.parallelism.recursive_steps.is_parallel() {
@@ -494,7 +530,7 @@ where
                         };
                         let mut mf2 = mf.lock().unwrap();
 
-                        mf2.cached_witness = Some(witness);
+                        *mf2.cached_witness() = Some(witness);
                     });
                 });
 
@@ -502,7 +538,7 @@ where
                     let circuit_primary = circuit_primary.lock().unwrap();
                     assert_eq!(
                         num_iters_per_step,
-                        circuit_primary.frames.as_ref().unwrap().len()
+                        circuit_primary.frames().unwrap().iter().len()
                     );
 
                     let mut r_snark = recursive_snark.unwrap_or_else(|| {
@@ -530,19 +566,16 @@ where
             .unwrap()
         } else {
             for circuit_primary in circuits.iter() {
-                assert_eq!(
-                    num_iters_per_step,
-                    circuit_primary.frames.as_ref().unwrap().len()
-                );
+                assert_eq!(num_iters_per_step, circuit_primary.frames().unwrap().len());
                 if debug {
                     // For debugging purposes, synthesize the circuit and check that the constraint system is satisfied.
                     use bellpepper_core::test_cs::TestConstraintSystem;
                     let mut cs = TestConstraintSystem::<<G1<F> as Group>::Scalar>::new();
 
-                    let zi = circuit_primary.frames.as_ref().unwrap()[0]
-                        .input
-                        .unwrap()
-                        .to_vector(store)?;
+                    // This is a CircuitFrame, not an EvalFrame
+                    let first_frame = circuit_primary.frames().unwrap().iter().next().unwrap();
+                    let zi =
+                        M::io_to_scalar_vector(store, first_frame.input()).map_err(|e| e.into())?;
                     let zi_allocated: Vec<_> = zi
                         .iter()
                         .enumerate()
@@ -579,32 +612,31 @@ where
             recursive_snark
         };
 
-        Ok(Self::Recursive(Box::new(recursive_snark.unwrap())))
+        Ok(Self::Recursive(
+            Box::new(recursive_snark.unwrap()),
+            PhantomData,
+        ))
     }
 
     /// Compresses the proof using a (Spartan) Snark (finishing step)
-    pub fn compress(self, pp: &'a PublicParams<'_, F, C>) -> Result<Self, ProofError> {
+    pub fn compress(self, pp: &PublicParams<F, M>) -> Result<Self, ProofError> {
         match &self {
-            Self::Recursive(recursive_snark) => Ok(Self::Compressed(Box::new(CompressedSNARK::<
-                _,
-                _,
-                _,
-                _,
-                SS1<F>,
-                SS2<F>,
-            >::prove(
-                &pp.pp,
-                &pp.pk,
-                recursive_snark,
-            )?))),
-            Self::Compressed(_) => Ok(self),
+            Self::Recursive(recursive_snark, _) => Ok(Self::Compressed(
+                Box::new(CompressedSNARK::<_, _, _, _, SS1<F>, SS2<F>>::prove(
+                    &pp.pp,
+                    &pp.pk,
+                    recursive_snark,
+                )?),
+                PhantomData,
+            )),
+            Self::Compressed(_, _) => Ok(self),
         }
     }
 
     /// Verifies the proof given the public parameters, the number of steps, and the input and output values.
     pub fn verify(
         &self,
-        pp: &PublicParams<'_, F, C>,
+        pp: &PublicParams<F, M>,
         num_steps: usize,
         z0: &[F],
         zi: &[F],
@@ -614,8 +646,10 @@ where
         let zi_secondary = z0_secondary.clone();
 
         let (zi_primary_verified, zi_secondary_verified) = match self {
-            Self::Recursive(p) => p.verify(&pp.pp, num_steps, z0_primary, &z0_secondary),
-            Self::Compressed(p) => p.verify(&pp.vk, num_steps, z0_primary.to_vec(), z0_secondary),
+            Self::Recursive(p, _) => p.verify(&pp.pp, num_steps, z0_primary, &z0_secondary),
+            Self::Compressed(p, _) => {
+                p.verify(&pp.vk, num_steps, z0_primary.to_vec(), z0_secondary)
+            }
         }?;
 
         Ok(zi_primary == zi_primary_verified && zi_secondary == zi_secondary_verified)
@@ -637,16 +671,15 @@ pub mod tests {
     use crate::state::{user_sym, State};
 
     use super::*;
-    use crate::eval::empty_sym_env;
+
     use crate::eval::lang::Coproc;
-    use crate::proof::Provable;
-    use crate::ptr::ContPtr;
+    use crate::proof::{CEKState, EvaluationStore};
     use crate::tag::{Op, Op1, Op2};
 
     use bellpepper::util_cs::witness_cs::WitnessCS;
     use bellpepper::util_cs::{metric_cs::MetricCS, Comparable};
     use bellpepper_core::test_cs::TestConstraintSystem;
-    use bellpepper_core::{Circuit, Delta};
+    use bellpepper_core::Delta;
     use pallas::Scalar as Fr;
 
     const DEFAULT_REDUCTION_COUNT: usize = 5;
@@ -667,24 +700,29 @@ pub mod tests {
         }
     }
 
-    pub fn test_aux<C: Coprocessor<Fr>>(
-        s: &mut Store<Fr>,
+    pub fn test_aux<'a, F: CurveCycleEquipped, C: Coprocessor<F>, M: MultiFrameTrait<'a, F, C>>(
+        s: &'a M::Store,
         expr: &str,
-        expected_result: Option<Ptr<Fr>>,
-        expected_env: Option<Ptr<Fr>>,
-        expected_cont: Option<ContPtr<Fr>>,
-        expected_emitted: Option<Vec<Ptr<Fr>>>,
+        expected_result: Option<M::Ptr>,
+        expected_env: Option<M::Ptr>,
+        expected_cont: Option<M::ContPtr>,
+        expected_emitted: Option<&[M::Ptr]>,
         expected_iterations: usize,
-        lang: Option<Arc<Lang<Fr, C>>>,
-    ) {
+        lang: Option<Arc<Lang<F, C>>>,
+    )
+    // technical bounds that would disappear once associated_type_bounds stabilizes
+    where
+        <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+        <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    {
         for chunk_size in REDUCTION_COUNTS_TO_TEST {
-            nova_test_full_aux(
+            nova_test_full_aux::<F, C, M>(
                 s,
                 expr,
                 expected_result,
                 expected_env,
                 expected_cont,
-                expected_emitted.as_ref(),
+                expected_emitted,
                 expected_iterations,
                 chunk_size,
                 false,
@@ -694,23 +732,33 @@ pub mod tests {
         }
     }
 
-    fn nova_test_full_aux<C: Coprocessor<Fr>>(
-        s: &mut Store<Fr>,
+    fn nova_test_full_aux<
+        'a,
+        F: CurveCycleEquipped,
+        C: Coprocessor<F>,
+        M: MultiFrameTrait<'a, F, C>,
+    >(
+        s: &'a M::Store,
         expr: &str,
-        expected_result: Option<Ptr<Fr>>,
-        expected_env: Option<Ptr<Fr>>,
-        expected_cont: Option<ContPtr<Fr>>,
-        expected_emitted: Option<&Vec<Ptr<Fr>>>,
+        expected_result: Option<M::Ptr>,
+        expected_env: Option<M::Ptr>,
+        expected_cont: Option<M::ContPtr>,
+        expected_emitted: Option<&[M::Ptr]>,
         expected_iterations: usize,
         reduction_count: usize,
         check_nova: bool,
         limit: Option<usize>,
-        lang: Option<Arc<Lang<Fr, C>>>,
-    ) {
+        lang: Option<Arc<Lang<F, C>>>,
+    )
+    // technical bounds that would disappear once associated_type_bounds stabilizes
+    where
+        <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+        <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    {
         let expr = s.read(expr).unwrap();
 
-        let mut f = |l| {
-            nova_test_full_aux2(
+        let f = |l| {
+            nova_test_full_aux2::<F, C, M>(
                 s,
                 expr,
                 expected_result,
@@ -733,30 +781,47 @@ pub mod tests {
         };
     }
 
-    fn nova_test_full_aux2<C: Coprocessor<Fr>>(
-        s: &mut Store<Fr>,
-        expr: Ptr<Fr>,
-        expected_result: Option<Ptr<Fr>>,
-        expected_env: Option<Ptr<Fr>>,
-        expected_cont: Option<ContPtr<Fr>>,
-        expected_emitted: Option<&Vec<Ptr<Fr>>>,
+    fn nova_test_full_aux2<
+        'a,
+        F: CurveCycleEquipped,
+        C: Coprocessor<F>,
+        M: MultiFrameTrait<'a, F, C>,
+    >(
+        s: &'a M::Store,
+        expr: M::Ptr,
+        expected_result: Option<M::Ptr>,
+        expected_env: Option<M::Ptr>,
+        expected_cont: Option<M::ContPtr>,
+        expected_emitted: Option<&[M::Ptr]>,
         expected_iterations: usize,
         reduction_count: usize,
         check_nova: bool,
         limit: Option<usize>,
-        lang: Arc<Lang<Fr, C>>,
-    ) {
+        lang: Arc<Lang<F, C>>,
+    )
+    // technical bounds that would disappear once associated_type_bounds stabilizes
+    where
+        <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+        <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    {
         let limit = limit.unwrap_or(10000);
 
-        let e = empty_sym_env(s);
+        let e = s.initial_empty_env();
 
-        let nova_prover = NovaProver::<Fr, C>::new(reduction_count, (*lang).clone());
+        let nova_prover = NovaProver::<'a, F, C, M>::new(reduction_count, (*lang).clone());
+        let frames = M::get_evaluation_frames(
+            |frame_count| nova_prover.needs_frame_padding(frame_count),
+            expr,
+            e,
+            s,
+            limit,
+            &lang,
+        )
+        .unwrap();
 
         if check_nova {
-            let pp = public_params(reduction_count, lang.clone());
-            let (proof, z0, zi, num_steps) = nova_prover
-                .evaluate_and_prove(&pp, expr, empty_sym_env(s), s, limit, lang.clone())
-                .unwrap();
+            let pp = public_params::<_, _, M>(reduction_count, lang.clone());
+            let (proof, z0, zi, num_steps) = nova_prover.prove(&pp, &frames, s, &lang).unwrap();
 
             let res = proof.verify(&pp, num_steps, &z0, &zi);
             if res.is_err() {
@@ -770,12 +835,9 @@ pub mod tests {
             assert!(res2.unwrap());
         }
 
-        let frames = nova_prover
-            .get_evaluation_frames(expr, e, s, limit, lang.clone())
-            .unwrap();
         let folding_config = Arc::new(FoldingConfig::new_ivc(lang, nova_prover.reduction_count()));
 
-        let multiframes = MultiFrame::from_frames(
+        let multiframes = M::from_frames(
             nova_prover.reduction_count(),
             &frames,
             s,
@@ -784,11 +846,11 @@ pub mod tests {
         let len = multiframes.len();
 
         let adjusted_iterations = nova_prover.expected_total_iterations(expected_iterations);
-        let mut previous_frame: Option<MultiFrame<'_, Fr, C>> = None;
+        let mut previous_frame: Option<&M> = None;
 
-        let mut cs_blank = MetricCS::<Fr>::new();
+        let mut cs_blank = MetricCS::<F>::new();
 
-        let blank = MultiFrame::<Fr, C>::blank(folding_config, Meta::Lurk);
+        let blank = M::blank(folding_config, Meta::Lurk);
         blank
             .synthesize(&mut cs_blank)
             .expect("failed to synthesize blank");
@@ -824,35 +886,35 @@ pub mod tests {
             assert_eq!(None, mismatch(&cs_inputs, &wcs_inputs));
             assert_eq!(None, mismatch(&cs_aux, &wcs_aux));
 
-            previous_frame = Some(multiframe.clone());
+            previous_frame = Some(multiframe);
 
             let delta = cs.delta(&cs_blank, true);
 
             assert!(delta == Delta::Equal);
         }
-        let output = previous_frame.unwrap().output.unwrap();
+        let output = previous_frame.unwrap().output().as_ref().unwrap();
 
         if let Some(expected_emitted) = expected_emitted {
-            let emitted_vec: Vec<_> = frames
-                .iter()
-                .filter_map(|frame| frame.output.maybe_emitted_expression(s))
-                .collect();
+            let mut emitted_vec = Vec::default();
+            for frame in frames.iter() {
+                emitted_vec.extend(M::emitted(s, frame));
+            }
             assert_eq!(expected_emitted, &emitted_vec);
         }
 
         if let Some(expected_result) = expected_result {
-            assert!(s.ptr_eq(&expected_result, &output.expr).unwrap());
+            assert!(s.ptr_eq(&expected_result, output.expr()).unwrap());
         }
         if let Some(expected_env) = expected_env {
-            assert!(s.ptr_eq(&expected_env, &output.env).unwrap());
+            assert!(s.ptr_eq(&expected_env, output.env()).unwrap());
         }
         if let Some(expected_cont) = expected_cont {
-            assert_eq!(expected_cont, output.cont);
+            assert_eq!(&expected_cont, output.cont());
         } else {
-            assert_eq!(s.get_cont_terminal(), output.cont);
+            assert_eq!(&s.get_cont_terminal(), output.cont());
         }
 
-        assert_eq!(expected_iterations, Frame::significant_frame_count(&frames));
+        assert_eq!(expected_iterations, M::significant_frame_count(&frames));
         assert_eq!(adjusted_iterations, len);
     }
 
@@ -866,7 +928,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(3);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(+ 1 2)",
             Some(expected),
@@ -886,7 +948,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(2);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(+ 1 2)",
             Some(expected),
@@ -904,7 +966,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(3);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(let ((a 5)
                       (b 1)
@@ -925,7 +987,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = lurk_sym_ptr!(s, t);
         let terminal = s.get_cont_terminal();
-        nova_test_full_aux::<Coproc<Fr>>(
+        nova_test_full_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(eq 5 5)",
             Some(expected),
@@ -946,7 +1008,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = lurk_sym_ptr!(s, t);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(= 5 5)",
             Some(expected),
@@ -959,7 +1021,7 @@ pub mod tests {
 
         let expected = lurk_sym_ptr!(s, nil);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(= 5 6)",
             Some(expected),
@@ -976,7 +1038,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = lurk_sym_ptr!(s, nil);
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(= 5 nil)",
             Some(expected),
@@ -988,7 +1050,7 @@ pub mod tests {
         );
 
         let expected = s.num(5);
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(= nil 5)",
             Some(expected),
@@ -1007,7 +1069,7 @@ pub mod tests {
         let t = lurk_sym_ptr!(s, t);
         let terminal = s.get_cont_terminal();
 
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(eq 5 nil)",
             Some(nil),
@@ -1017,7 +1079,7 @@ pub mod tests {
             3,
             None,
         );
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(eq nil 5)",
             Some(nil),
@@ -1027,7 +1089,7 @@ pub mod tests {
             3,
             None,
         );
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(eq nil nil)",
             Some(t),
@@ -1037,14 +1099,32 @@ pub mod tests {
             3,
             None,
         );
-        test_aux::<Coproc<Fr>>(s, "(eq 5 5)", Some(t), None, Some(terminal), None, 3, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            "(eq 5 5)",
+            Some(t),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
     }
 
     #[test]
     fn test_prove_quote_end_is_nil_error() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(s, "(quote (1) (2))", None, None, Some(error), None, 1, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            "(quote (1) (2))",
+            None,
+            None,
+            Some(error),
+            None,
+            1,
+            None,
+        );
     }
 
     #[test]
@@ -1052,7 +1132,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(5);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(if t 5 6)",
             Some(expected),
@@ -1065,7 +1145,7 @@ pub mod tests {
 
         let expected = s.num(6);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(if nil 5 6)",
             Some(expected),
@@ -1082,7 +1162,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(5);
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(if nil 5 6 7)",
             Some(expected),
@@ -1100,7 +1180,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(10);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(if t (+ 5 5) 6)",
             Some(expected),
@@ -1118,7 +1198,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(25);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(letrec ((exp (lambda (base)
                                (lambda (exponent)
@@ -1141,7 +1221,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(25);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(letrec ((exp (lambda (base)
                                   (lambda (exponent)
@@ -1163,7 +1243,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = lurk_sym_ptr!(s, t);
         let terminal = s.get_cont_terminal();
-        nova_test_full_aux::<Coproc<Fr>>(
+        nova_test_full_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(atom 123)",
             Some(expected),
@@ -1178,7 +1258,7 @@ pub mod tests {
         );
 
         let expected = s.num(1);
-        nova_test_full_aux::<Coproc<Fr>>(
+        nova_test_full_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(car '(1 . 2))",
             Some(expected),
@@ -1193,7 +1273,7 @@ pub mod tests {
         );
 
         let expected = s.num(2);
-        nova_test_full_aux::<Coproc<Fr>>(
+        nova_test_full_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(cdr '(1 . 2))",
             Some(expected),
@@ -1208,7 +1288,7 @@ pub mod tests {
         );
 
         let expected = s.num(123);
-        nova_test_full_aux::<Coproc<Fr>>(
+        nova_test_full_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(emit 123)",
             Some(expected),
@@ -1239,7 +1319,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(123);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(emit 123)",
             Some(expected),
@@ -1257,7 +1337,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(99);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "((lambda (x) x) 99)",
             Some(expected),
@@ -1275,7 +1355,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(99);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "((lambda (y)
                     ((lambda (x) y) 888))
@@ -1295,7 +1375,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(999);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "((lambda (y)
                      ((lambda (x)
@@ -1318,7 +1398,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(888);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "((lambda (y)
                      ((lambda (x)
@@ -1342,7 +1422,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(999);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(((lambda (fn)
                       (lambda (x) (fn x)))
@@ -1363,7 +1443,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(9);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(+ 2 (+ 3 4))",
             Some(expected),
@@ -1380,7 +1460,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(9);
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(- 9 8 7)",
             Some(expected),
@@ -1390,7 +1470,7 @@ pub mod tests {
             2,
             None,
         );
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(= 9 8 7)",
             Some(expected),
@@ -1405,30 +1485,66 @@ pub mod tests {
     fn op_syntax_error<T: Op + Copy>() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
-        let mut test = |op: T| {
+        let test = |op: T| {
             let name = op.symbol_name();
 
             if !op.supports_arity(0) {
                 let expr = format!("({name})");
                 tracing::debug!("{:?}", &expr);
-                test_aux::<Coproc<Fr>>(s, &expr, None, None, Some(error), None, 1, None);
+                test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+                    s,
+                    &expr,
+                    None,
+                    None,
+                    Some(error),
+                    None,
+                    1,
+                    None,
+                );
             }
             if !op.supports_arity(1) {
                 let expr = format!("({name} 123)");
                 tracing::debug!("{:?}", &expr);
-                test_aux::<Coproc<Fr>>(s, &expr, None, None, Some(error), None, 1, None);
+                test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+                    s,
+                    &expr,
+                    None,
+                    None,
+                    Some(error),
+                    None,
+                    1,
+                    None,
+                );
             }
             if !op.supports_arity(2) {
                 let expr = format!("({name} 123 456)");
                 tracing::debug!("{:?}", &expr);
-                test_aux::<Coproc<Fr>>(s, &expr, None, None, Some(error), None, 1, None);
+                test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+                    s,
+                    &expr,
+                    None,
+                    None,
+                    Some(error),
+                    None,
+                    1,
+                    None,
+                );
             }
 
             if !op.supports_arity(3) {
                 let expr = format!("({name} 123 456 789)");
                 tracing::debug!("{:?}", &expr);
                 let iterations = if op.supports_arity(2) { 2 } else { 1 };
-                test_aux::<Coproc<Fr>>(s, &expr, None, None, Some(error), None, iterations, None);
+                test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+                    s,
+                    &expr,
+                    None,
+                    None,
+                    Some(error),
+                    None,
+                    iterations,
+                    None,
+                );
             }
         };
 
@@ -1454,7 +1570,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(4);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(- 9 5)",
             Some(expected),
@@ -1472,7 +1588,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(45);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(* 9 5)",
             Some(expected),
@@ -1490,7 +1606,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(7);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(/ 21 3)",
             Some(expected),
@@ -1507,7 +1623,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(0);
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(/ 21 0)",
             Some(expected),
@@ -1524,7 +1640,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = lurk_sym_ptr!(s, nil);
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(/ 21 nil)",
             Some(expected),
@@ -1542,7 +1658,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(5);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(((lambda (x)
                     (lambda (y)
@@ -1563,7 +1679,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = lurk_sym_ptr!(s, nil);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(current-env)",
             Some(expected),
@@ -1580,7 +1696,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.read("(current-env a)").unwrap();
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(current-env a)",
             Some(expected),
@@ -1598,7 +1714,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(1);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(let ((a 1))
                   a)",
@@ -1615,7 +1731,7 @@ pub mod tests {
     fn test_prove_let_end_is_nil_error() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(let ((a 1 2)) a)",
             None,
@@ -1631,7 +1747,7 @@ pub mod tests {
     fn test_prove_letrec_end_is_nil_error() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(letrec ((a 1 2)) a)",
             None,
@@ -1647,7 +1763,7 @@ pub mod tests {
     fn test_prove_lambda_empty_error() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "((lambda (x)) 0)",
             None,
@@ -1663,28 +1779,46 @@ pub mod tests {
     fn test_prove_let_empty_error() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(s, "(let)", None, None, Some(error), None, 1, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, "(let)", None, None, Some(error), None, 1, None);
     }
 
     #[test]
     fn test_prove_let_empty_body_error() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(s, "(let ((a 1)))", None, None, Some(error), None, 1, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            "(let ((a 1)))",
+            None,
+            None,
+            Some(error),
+            None,
+            1,
+            None,
+        );
     }
 
     #[test]
     fn test_prove_letrec_empty_error() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(s, "(letrec)", None, None, Some(error), None, 1, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            "(letrec)",
+            None,
+            None,
+            Some(error),
+            None,
+            1,
+            None,
+        );
     }
 
     #[test]
     fn test_prove_letrec_empty_body_error() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(letrec ((a 1)))",
             None,
@@ -1701,7 +1835,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = lurk_sym_ptr!(s, t);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(eq nil (let () nil))",
             Some(expected),
@@ -1717,7 +1851,7 @@ pub mod tests {
     fn test_prove_let_rest_body_is_nil_error() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(let ((a 1)) a 1)",
             None,
@@ -1733,7 +1867,7 @@ pub mod tests {
     fn test_prove_letrec_rest_body_is_nil_error() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(letrec ((a 1)) a 1)",
             None,
@@ -1751,7 +1885,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(3);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(let () (+ 1 2))",
             Some(expected),
@@ -1768,7 +1902,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(3);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(letrec () (+ 1 2))",
             Some(expected),
@@ -1786,7 +1920,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(6);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(let ((a 1)
                        (b 2)
@@ -1807,7 +1941,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(20);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "((((lambda (x)
                       (lambda (y)
@@ -1832,7 +1966,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = lurk_sym_ptr!(s, t);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(let ((x 2)
                        (y 3)
@@ -1854,7 +1988,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(5);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(let ((true (lambda (a)
                                (lambda (b)
@@ -1883,7 +2017,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(6);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(let ((true (lambda (a)
                                (lambda (b)
@@ -1912,7 +2046,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(5);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(let ((true (lambda (a)
                                (lambda (b)
@@ -1938,7 +2072,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(10);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(if t (+ 5 5) 6)",
             Some(expected),
@@ -1956,7 +2090,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(25);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(letrec ((exp (lambda (base)
                                    (lambda (exponent)
@@ -1979,7 +2113,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(25);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(letrec ((exp (lambda (base exponent)
                                    (if (= 0 exponent)
@@ -2001,7 +2135,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(25);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(let ((exp (lambda (base)
                                 (letrec ((base-inner
@@ -2026,7 +2160,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(25);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(letrec ((exp (lambda (base)
                                    (lambda (exponent-remaining)
@@ -2049,7 +2183,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(25);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(letrec ((exp (lambda (base)
                                    (letrec ((base-inner
@@ -2074,7 +2208,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = lurk_sym_ptr!(s, t);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(letrec ((even (lambda (n)
                                   (if (= 0 n)
@@ -2099,7 +2233,7 @@ pub mod tests {
     fn test_prove_no_mutual_recursion_error() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(letrec ((even (lambda (n)
                                   (if (= 0 n)
@@ -2125,7 +2259,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(1);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(car (cons 1 2))",
             Some(expected),
@@ -2141,28 +2275,64 @@ pub mod tests {
     fn test_prove_car_end_is_nil_error() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(s, "(car (1 2) 3)", None, None, Some(error), None, 1, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            "(car (1 2) 3)",
+            None,
+            None,
+            Some(error),
+            None,
+            1,
+            None,
+        );
     }
 
     #[test]
     fn test_prove_cdr_end_is_nil_error() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(s, "(cdr (1 2) 3)", None, None, Some(error), None, 1, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            "(cdr (1 2) 3)",
+            None,
+            None,
+            Some(error),
+            None,
+            1,
+            None,
+        );
     }
 
     #[test]
     fn test_prove_atom_end_is_nil_error() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(s, "(atom 123 4)", None, None, Some(error), None, 1, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            "(atom 123 4)",
+            None,
+            None,
+            Some(error),
+            None,
+            1,
+            None,
+        );
     }
 
     #[test]
     fn test_prove_emit_end_is_nil_error() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(s, "(emit 123 4)", None, None, Some(error), None, 1, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            "(emit 123 4)",
+            None,
+            None,
+            Some(error),
+            None,
+            1,
+            None,
+        );
     }
 
     #[test]
@@ -2170,7 +2340,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(2);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(cdr (cons 1 2))",
             Some(expected),
@@ -2187,7 +2357,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(123);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "((lambda () 123))",
             Some(expected),
@@ -2204,7 +2374,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(10);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(let ((x 9) (f (lambda () (+ x 1)))) (f))",
             Some(expected),
@@ -2227,7 +2397,7 @@ pub mod tests {
             s.intern_fun(arg, body, env)
         };
         let terminal = s.get_cont_terminal();
-        nova_test_full_aux::<Coproc<Fr>>(
+        nova_test_full_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "((lambda (x) 123))",
             Some(expected),
@@ -2246,7 +2416,7 @@ pub mod tests {
     fn test_prove_zero_arg_lambda4() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "((lambda () 123) 1)",
             None,
@@ -2263,7 +2433,16 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.read("(123)").unwrap();
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(s, "(123)", Some(expected), None, Some(error), None, 1, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            "(123)",
+            Some(expected),
+            None,
+            Some(error),
+            None,
+            1,
+            None,
+        );
     }
 
     #[test]
@@ -2271,7 +2450,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(123);
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "((emit 123))",
             Some(expected),
@@ -2292,7 +2471,7 @@ pub mod tests {
                           (x 6)
                           (data (data-function)))
                       x)";
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             expr,
             Some(expected),
@@ -2310,7 +2489,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(123);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(letrec
                    ((f (lambda (x)
@@ -2333,7 +2512,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(2);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(((lambda (a)
                     (lambda (b)
@@ -2355,7 +2534,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(3);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(((lambda (a)
                     (lambda (b)
@@ -2377,7 +2556,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(2);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(car (cdr '(1 2 3 4)))",
             Some(expected),
@@ -2395,7 +2574,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(123);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(letrec
                    ((x 888)
@@ -2419,7 +2598,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(123);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(letrec
                    ((f (lambda (x)
@@ -2443,7 +2622,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(13);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(letrec ((double (lambda (x) (* 2 x)))
                            (square (lambda (x) (* x x))))
@@ -2463,7 +2642,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(11);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(letrec ((double (lambda (x) (* 2 x)))
                            (double-inc (lambda (x) (+ 1 (double x)))))
@@ -2483,7 +2662,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(33);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(letrec ((exp (lambda (base exponent)
                                   (if (= 0 exponent)
@@ -2514,7 +2693,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(18);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(let ((z 9))
                    (letrec ((a 1)
@@ -2536,7 +2715,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(1);
         let terminal = s.get_cont_terminal();
-        nova_test_full_aux::<Coproc<Fr>>(
+        nova_test_full_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(letrec ((next (lambda (a b n target)
                      (if (eq n target)
@@ -2590,7 +2769,7 @@ pub mod tests {
     fn test_prove_terminal_continuation_regression() {
         let s = &mut Store::<Fr>::default();
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(letrec ((a (lambda (x) (cons 2 2))))
                (a 1))",
@@ -2608,7 +2787,7 @@ pub mod tests {
     fn test_prove_chained_functional_commitment() {
         let s = &mut Store::<Fr>::default();
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(letrec ((secret 12345)
                       (a (lambda (acc x)
@@ -2629,7 +2808,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = lurk_sym_ptr!(s, nil);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(begin)",
             Some(expected),
@@ -2647,13 +2826,13 @@ pub mod tests {
         let expr = "(begin (emit 1) (emit 2) (emit 3))";
         let expected_expr = s.num(3);
         let expected_emitted = vec![s.num(1), s.num(2), s.num(3)];
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             expr,
             Some(expected_expr),
             None,
             None,
-            Some(expected_emitted),
+            Some(&expected_emitted),
             13,
             None,
         );
@@ -2664,7 +2843,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected_a = s.read(r"#\a").unwrap();
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             r#"(car "apple")"#,
             Some(expected_a),
@@ -2681,7 +2860,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected_pple = s.read(r#" "pple" "#).unwrap();
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             r#"(cdr "apple")"#,
             Some(expected_pple),
@@ -2698,7 +2877,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected_nil = lurk_sym_ptr!(s, nil);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             r#"(car "")"#,
             Some(expected_nil),
@@ -2715,7 +2894,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected_empty_str = s.intern_string("");
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             r#"(cdr "")"#,
             Some(expected_empty_str),
@@ -2732,7 +2911,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected_apple = s.read(r#" "apple" "#).unwrap();
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             r#"(strcons #\a "pple")"#,
             Some(expected_apple),
@@ -2748,7 +2927,7 @@ pub mod tests {
     fn test_prove_str_cons_error() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             r"(strcons #\a 123)",
             None,
@@ -2764,7 +2943,16 @@ pub mod tests {
     fn test_prove_one_arg_cons_error() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(s, r#"(cons "")"#, None, None, Some(error), None, 1, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            r#"(cons "")"#,
+            None,
+            None,
+            Some(error),
+            None,
+            1,
+            None,
+        );
     }
 
     #[test]
@@ -2772,7 +2960,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = lurk_sym_ptr!(s, nil);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             r#"(car nil)"#,
             Some(expected),
@@ -2789,7 +2977,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = lurk_sym_ptr!(s, nil);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             r#"(cdr nil)"#,
             Some(expected),
@@ -2805,24 +2993,78 @@ pub mod tests {
     fn test_prove_car_cdr_invalid_tag_error_sym() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(s, r#"(car car)"#, None, None, Some(error), None, 2, None);
-        test_aux::<Coproc<Fr>>(s, r#"(cdr car)"#, None, None, Some(error), None, 2, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            r#"(car car)"#,
+            None,
+            None,
+            Some(error),
+            None,
+            2,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            r#"(cdr car)"#,
+            None,
+            None,
+            Some(error),
+            None,
+            2,
+            None,
+        );
     }
 
     #[test]
     fn test_prove_car_cdr_invalid_tag_error_char() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(s, r"(car #\a)", None, None, Some(error), None, 2, None);
-        test_aux::<Coproc<Fr>>(s, r"(cdr #\a)", None, None, Some(error), None, 2, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            r"(car #\a)",
+            None,
+            None,
+            Some(error),
+            None,
+            2,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            r"(cdr #\a)",
+            None,
+            None,
+            Some(error),
+            None,
+            2,
+            None,
+        );
     }
 
     #[test]
     fn test_prove_car_cdr_invalid_tag_error_num() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(s, r#"(car 42)"#, None, None, Some(error), None, 2, None);
-        test_aux::<Coproc<Fr>>(s, r#"(cdr 42)"#, None, None, Some(error), None, 2, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            r#"(car 42)"#,
+            None,
+            None,
+            Some(error),
+            None,
+            2,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            r#"(cdr 42)"#,
+            None,
+            None,
+            Some(error),
+            None,
+            2,
+            None,
+        );
     }
 
     #[test]
@@ -2831,7 +3073,7 @@ pub mod tests {
         let res1 = s.num(1);
         let res2 = s.num(2);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             r#"(car (cons 1 2))"#,
             Some(res1),
@@ -2841,7 +3083,7 @@ pub mod tests {
             5,
             None,
         );
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             r#"(cdr (cons 1 2))"#,
             Some(res2),
@@ -2857,7 +3099,7 @@ pub mod tests {
     fn test_prove_car_cdr_invalid_tag_error_lambda() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             r#"(car (lambda (x) x))"#,
             None,
@@ -2867,7 +3109,7 @@ pub mod tests {
             2,
             None,
         );
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             r#"(cdr (lambda (x) x))"#,
             None,
@@ -2885,7 +3127,16 @@ pub mod tests {
         let expr = "(open (hide 123 456))";
         let expected = s.num(456);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(s, expr, Some(expected), None, Some(terminal), None, 5, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(expected),
+            None,
+            Some(terminal),
+            None,
+            5,
+            None,
+        );
     }
 
     #[test]
@@ -2893,7 +3144,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expr = "(hide 'x 456)";
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 3, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr, None, None, Some(error), None, 3, None);
     }
 
     #[test]
@@ -2902,7 +3153,16 @@ pub mod tests {
         let expr = "(secret (hide 123 456))";
         let expected = s.num(123);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(s, expr, Some(expected), None, Some(terminal), None, 5, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(expected),
+            None,
+            Some(terminal),
+            None,
+            5,
+            None,
+        );
     }
 
     #[test]
@@ -2911,7 +3171,16 @@ pub mod tests {
         let expr = "(open (hide 123 'x))";
         let x = s.user_sym("x");
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(s, expr, Some(x), None, Some(terminal), None, 5, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(x),
+            None,
+            Some(terminal),
+            None,
+            5,
+            None,
+        );
     }
 
     #[test]
@@ -2920,7 +3189,16 @@ pub mod tests {
         let expr = "(open (commit 'x))";
         let x = s.user_sym("x");
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(s, expr, Some(x), None, Some(terminal), None, 4, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(x),
+            None,
+            Some(terminal),
+            None,
+            4,
+            None,
+        );
     }
 
     #[test]
@@ -2929,7 +3207,16 @@ pub mod tests {
         let expr = "(open (commit 123))";
         let expected = s.num(123);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(s, expr, Some(expected), None, Some(terminal), None, 4, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(expected),
+            None,
+            Some(terminal),
+            None,
+            4,
+            None,
+        );
     }
 
     #[test]
@@ -2937,7 +3224,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expr = "(commit 123 456)";
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 1, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr, None, None, Some(error), None, 1, None);
     }
 
     #[test]
@@ -2945,7 +3232,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expr = "(open 123 456)";
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 1, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr, None, None, Some(error), None, 1, None);
     }
 
     #[test]
@@ -2953,7 +3240,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expr = "(open 'asdf)";
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 2, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr, None, None, Some(error), None, 2, None);
     }
 
     #[test]
@@ -2961,7 +3248,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expr = "(secret 'asdf)";
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 2, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr, None, None, Some(error), None, 2, None);
     }
 
     #[test]
@@ -2970,7 +3257,16 @@ pub mod tests {
         let expr = "(secret (commit 123))";
         let expected = s.num(0);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(s, expr, Some(expected), None, Some(terminal), None, 4, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(expected),
+            None,
+            Some(terminal),
+            None,
+            4,
+            None,
+        );
     }
 
     #[test]
@@ -2979,7 +3275,16 @@ pub mod tests {
         let expr = "(num 123)";
         let expected = s.num(123);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(s, expr, Some(expected), None, Some(terminal), None, 2, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(expected),
+            None,
+            Some(terminal),
+            None,
+            2,
+            None,
+        );
     }
 
     #[test]
@@ -2988,7 +3293,16 @@ pub mod tests {
         let expr = r"(num #\a)";
         let expected = s.num(97);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(s, expr, Some(expected), None, Some(terminal), None, 2, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(expected),
+            None,
+            Some(terminal),
+            None,
+            2,
+            None,
+        );
     }
 
     #[test]
@@ -2997,7 +3311,7 @@ pub mod tests {
         let expr = r#"(char 97)"#;
         let expected_a = s.read(r"#\a").unwrap();
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             expr,
             Some(expected_a),
@@ -3017,7 +3331,7 @@ pub mod tests {
         let expected_a = s.read(r"#\a").unwrap();
         let expected_b = s.read(r"#\b").unwrap();
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             expr,
             Some(expected_a),
@@ -3027,7 +3341,7 @@ pub mod tests {
             5,
             None,
         );
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             expr2,
             Some(expected_b),
@@ -3044,7 +3358,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expr = "(num (commit 123))";
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(s, expr, None, None, Some(terminal), None, 4, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr, None, None, Some(terminal), None, 4, None);
     }
 
     #[test]
@@ -3053,7 +3367,16 @@ pub mod tests {
         let expr = "(open (comm (num (hide 123 456))))";
         let expected = s.num(456);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(s, expr, Some(expected), None, Some(terminal), None, 9, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(expected),
+            None,
+            Some(terminal),
+            None,
+            9,
+            None,
+        );
     }
 
     #[test]
@@ -3062,7 +3385,16 @@ pub mod tests {
         let expr = "(secret (comm (num (hide 123 456))))";
         let expected = s.num(123);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(s, expr, Some(expected), None, Some(terminal), None, 9, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(expected),
+            None,
+            Some(terminal),
+            None,
+            9,
+            None,
+        );
     }
 
     #[test]
@@ -3071,7 +3403,16 @@ pub mod tests {
         let expr = "(open (comm (num (commit 123))))";
         let expected = s.num(123);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(s, expr, Some(expected), None, Some(terminal), None, 8, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(expected),
+            None,
+            Some(terminal),
+            None,
+            8,
+            None,
+        );
     }
 
     #[test]
@@ -3080,7 +3421,16 @@ pub mod tests {
         let expr = "(secret (comm (num (commit 123))))";
         let expected = s.num(0);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(s, expr, Some(expected), None, Some(terminal), None, 8, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(expected),
+            None,
+            Some(terminal),
+            None,
+            8,
+            None,
+        );
     }
 
     #[test]
@@ -3089,7 +3439,16 @@ pub mod tests {
         let expr = "(open (num (commit 123)))";
         let expected = s.num(123);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(s, expr, Some(expected), None, Some(terminal), None, 6, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(expected),
+            None,
+            Some(terminal),
+            None,
+            6,
+            None,
+        );
     }
 
     #[test]
@@ -3099,9 +3458,9 @@ pub mod tests {
         let expr1 = "(num \"asdf\")";
         let expr2 = "(num '(1))";
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 2, None);
-        test_aux::<Coproc<Fr>>(s, expr1, None, None, Some(error), None, 2, None);
-        test_aux::<Coproc<Fr>>(s, expr2, None, None, Some(error), None, 2, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr, None, None, Some(error), None, 2, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr1, None, None, Some(error), None, 2, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr2, None, None, Some(error), None, 2, None);
     }
 
     #[test]
@@ -3111,9 +3470,9 @@ pub mod tests {
         let expr1 = "(comm \"asdf\")";
         let expr2 = "(comm '(1))";
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 2, None);
-        test_aux::<Coproc<Fr>>(s, expr1, None, None, Some(error), None, 2, None);
-        test_aux::<Coproc<Fr>>(s, expr2, None, None, Some(error), None, 2, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr, None, None, Some(error), None, 2, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr1, None, None, Some(error), None, 2, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr2, None, None, Some(error), None, 2, None);
     }
 
     #[test]
@@ -3123,9 +3482,9 @@ pub mod tests {
         let expr1 = "(char \"asdf\")";
         let expr2 = "(char '(1))";
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 2, None);
-        test_aux::<Coproc<Fr>>(s, expr1, None, None, Some(error), None, 2, None);
-        test_aux::<Coproc<Fr>>(s, expr2, None, None, Some(error), None, 2, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr, None, None, Some(error), None, 2, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr1, None, None, Some(error), None, 2, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr2, None, None, Some(error), None, 2, None);
     }
 
     #[test]
@@ -3134,7 +3493,16 @@ pub mod tests {
         let expr = "(quote x)";
         let x = s.user_sym("x");
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(s, expr, Some(x), None, Some(terminal), None, 1, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(x),
+            None,
+            Some(terminal),
+            None,
+            1,
+            None,
+        );
     }
 
     #[test]
@@ -3142,7 +3510,7 @@ pub mod tests {
     fn test_prove_open_opaque_commit() {
         let s = &mut Store::<Fr>::default();
         let expr = "(open 123)";
-        test_aux::<Coproc<Fr>>(s, expr, None, None, None, None, 2, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr, None, None, None, None, 2, None);
     }
 
     #[test]
@@ -3150,7 +3518,7 @@ pub mod tests {
     fn test_prove_secret_invalid_tag() {
         let s = &mut Store::<Fr>::default();
         let expr = "(secret 123)";
-        test_aux::<Coproc<Fr>>(s, expr, None, None, None, None, 2, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr, None, None, None, None, 2, None);
     }
 
     #[test]
@@ -3158,7 +3526,7 @@ pub mod tests {
     fn test_prove_secret_opaque_commit() {
         let s = &mut Store::<Fr>::default();
         let expr = "(secret (comm 123))";
-        test_aux::<Coproc<Fr>>(s, expr, None, None, None, None, 2, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr, None, None, None, None, 2, None);
     }
 
     #[test]
@@ -3173,7 +3541,7 @@ pub mod tests {
         let terminal = s.get_cont_terminal();
         let error = s.get_cont_error();
 
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             r#"(car "apple")"#,
             Some(a),
@@ -3183,7 +3551,7 @@ pub mod tests {
             2,
             None,
         );
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             r#"(cdr "apple")"#,
             Some(pple),
@@ -3193,7 +3561,7 @@ pub mod tests {
             2,
             None,
         );
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             r#"(car "")"#,
             Some(nil),
@@ -3203,7 +3571,7 @@ pub mod tests {
             2,
             None,
         );
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             r#"(cdr "")"#,
             Some(empty),
@@ -3213,7 +3581,7 @@ pub mod tests {
             2,
             None,
         );
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             r#"(cons #\a "pple")"#,
             Some(a_pple),
@@ -3224,7 +3592,7 @@ pub mod tests {
             None,
         );
 
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             r#"(strcons #\a "pple")"#,
             Some(apple),
@@ -3235,7 +3603,7 @@ pub mod tests {
             None,
         );
 
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             r"(strcons #\a #\b)",
             None,
@@ -3246,7 +3614,7 @@ pub mod tests {
             None,
         );
 
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             r#"(strcons "a" "b")"#,
             None,
@@ -3257,7 +3625,7 @@ pub mod tests {
             None,
         );
 
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             r#"(strcons 1 2)"#,
             None,
@@ -3278,7 +3646,16 @@ pub mod tests {
         };
         let terminal = s.get_cont_terminal();
 
-        test_aux::<Coproc<Fr>>(s, expr, Some(expected), None, Some(terminal), None, 3, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(expected),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
     }
 
     #[ignore]
@@ -3406,7 +3783,16 @@ pub mod tests {
         let t = lurk_sym_ptr!(s, t);
         let terminal = s.get_cont_terminal();
 
-        test_aux::<Coproc<Fr>>(s, expr, Some(t), None, Some(terminal), None, 19, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(t),
+            None,
+            Some(terminal),
+            None,
+            19,
+            None,
+        );
     }
 
     #[test]
@@ -3418,8 +3804,26 @@ pub mod tests {
         let res2 = s.num(20);
         let terminal = s.get_cont_terminal();
 
-        test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 17, None);
-        test_aux::<Coproc<Fr>>(s, expr2, Some(res2), None, Some(terminal), None, 9, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(res),
+            None,
+            Some(terminal),
+            None,
+            17,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr2,
+            Some(res2),
+            None,
+            Some(terminal),
+            None,
+            9,
+            None,
+        );
     }
 
     #[test]
@@ -3435,9 +3839,36 @@ pub mod tests {
 
         let terminal = s.get_cont_terminal();
 
-        test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 1, None);
-        test_aux::<Coproc<Fr>>(s, expr2, Some(res2), None, Some(terminal), None, 3, None);
-        test_aux::<Coproc<Fr>>(s, expr3, Some(res3), None, Some(terminal), None, 3, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(res),
+            None,
+            Some(terminal),
+            None,
+            1,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr2,
+            Some(res2),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr3,
+            Some(res3),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
     }
 
     // The following functional commitment tests were discovered to fail. They are commented out (as tests) for now so
@@ -3453,7 +3884,16 @@ pub mod tests {
         let res = s.num(10);
         let terminal = s.get_cont_terminal();
 
-        test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 25, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(res),
+            None,
+            Some(terminal),
+            None,
+            25,
+            None,
+        );
     }
 
     #[test]
@@ -3474,7 +3914,16 @@ pub mod tests {
         let res = s.num(6);
         let terminal = s.get_cont_terminal();
 
-        test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 108, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(res),
+            None,
+            Some(terminal),
+            None,
+            108,
+            None,
+        );
     }
 
     #[test]
@@ -3488,7 +3937,16 @@ pub mod tests {
         let res = s.num(6);
         let terminal = s.get_cont_terminal();
 
-        test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 152, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(res),
+            None,
+            Some(terminal),
+            None,
+            152,
+            None,
+        );
     }
 
     #[test]
@@ -3498,7 +3956,7 @@ pub mod tests {
         let expr = "(cons (lambda (x y) nil) nil)";
         let terminal = s.get_cont_terminal();
 
-        test_aux::<Coproc<Fr>>(s, expr, None, None, Some(terminal), None, 3, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr, None, None, Some(terminal), None, 3, None);
     }
 
     #[test]
@@ -3508,7 +3966,7 @@ pub mod tests {
         let expr = "(eval 'a '(nil))";
         let error = s.get_cont_error();
 
-        test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 4, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr, None, None, Some(error), None, 4, None);
     }
 
     #[test]
@@ -3523,7 +3981,7 @@ pub mod tests {
         let expr = "(let ((a 1)) t)";
 
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(s, expr, None, None, Some(terminal), None, 3, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr, None, None, Some(terminal), None, 3, None);
     }
 
     #[test]
@@ -3534,7 +3992,7 @@ pub mod tests {
         let expr = "nil";
 
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(s, expr, None, None, Some(terminal), None, 1, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr, None, None, Some(terminal), None, 1, None);
     }
 
     #[test]
@@ -3544,7 +4002,7 @@ pub mod tests {
         let expr = "(let ((a 1) (b 2)) c)";
 
         let error = s.get_cont_error();
-        test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 7, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr, None, None, Some(error), None, 7, None);
     }
 
     #[test]
@@ -3553,7 +4011,7 @@ pub mod tests {
         let expr = "(* 5 (eval '(+ 1 a) '((0 . 3))))"; // two-arg eval, optional second arg is env. This tests for error on malformed env.
         let error = s.get_cont_error();
 
-        test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 8, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr, None, None, Some(error), None, 8, None);
     }
 
     #[test]
@@ -3564,7 +4022,16 @@ pub mod tests {
         let res = s.uint64(123);
         let terminal = s.get_cont_terminal();
 
-        test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 1, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(res),
+            None,
+            Some(terminal),
+            None,
+            1,
+            None,
+        );
     }
 
     #[test]
@@ -3579,10 +4046,46 @@ pub mod tests {
         let res2 = s.uint64(1);
         let terminal = s.get_cont_terminal();
 
-        test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 7, None);
-        test_aux::<Coproc<Fr>>(s, expr2, Some(res), None, Some(terminal), None, 3, None);
-        test_aux::<Coproc<Fr>>(s, expr3, Some(res), None, Some(terminal), None, 6, None);
-        test_aux::<Coproc<Fr>>(s, expr4, Some(res2), None, Some(terminal), None, 2, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(res),
+            None,
+            Some(terminal),
+            None,
+            7,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr2,
+            Some(res),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr3,
+            Some(res),
+            None,
+            Some(terminal),
+            None,
+            6,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr4,
+            Some(res2),
+            None,
+            Some(terminal),
+            None,
+            2,
+            None,
+        );
     }
 
     #[test]
@@ -3594,8 +4097,26 @@ pub mod tests {
         let res = s.uint64(1);
         let terminal = s.get_cont_terminal();
 
-        test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 3, None);
-        test_aux::<Coproc<Fr>>(s, expr2, Some(res), None, Some(terminal), None, 6, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(res),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr2,
+            Some(res),
+            None,
+            Some(terminal),
+            None,
+            6,
+            None,
+        );
     }
 
     #[test]
@@ -3610,9 +4131,36 @@ pub mod tests {
         let res3 = s.uint64(0);
         let terminal = s.get_cont_terminal();
 
-        test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 3, None);
-        test_aux::<Coproc<Fr>>(s, expr2, Some(res2), None, Some(terminal), None, 3, None);
-        test_aux::<Coproc<Fr>>(s, expr3, Some(res3), None, Some(terminal), None, 6, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(res),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr2,
+            Some(res2),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr3,
+            Some(res3),
+            None,
+            Some(terminal),
+            None,
+            6,
+            None,
+        );
     }
 
     #[test]
@@ -3630,9 +4178,27 @@ pub mod tests {
         let terminal = s.get_cont_terminal();
         let error = s.get_cont_error();
 
-        test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 3, None);
-        test_aux::<Coproc<Fr>>(s, expr2, Some(res2), None, Some(terminal), None, 3, None);
-        test_aux::<Coproc<Fr>>(s, expr3, None, None, Some(error), None, 3, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(res),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr2,
+            Some(res2),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr3, None, None, Some(error), None, 3, None);
     }
 
     #[test]
@@ -3650,9 +4216,27 @@ pub mod tests {
         let terminal = s.get_cont_terminal();
         let error = s.get_cont_error();
 
-        test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 3, None);
-        test_aux::<Coproc<Fr>>(s, expr2, Some(res2), None, Some(terminal), None, 3, None);
-        test_aux::<Coproc<Fr>>(s, expr3, None, None, Some(error), None, 3, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(res),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr2,
+            Some(res2),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr3, None, None, Some(error), None, 3, None);
     }
 
     #[test]
@@ -3665,9 +4249,9 @@ pub mod tests {
 
         let error = s.get_cont_error();
 
-        test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 3, None);
-        test_aux::<Coproc<Fr>>(s, expr2, None, None, Some(error), None, 3, None);
-        test_aux::<Coproc<Fr>>(s, expr3, None, None, Some(error), None, 3, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr, None, None, Some(error), None, 3, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr2, None, None, Some(error), None, 3, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr3, None, None, Some(error), None, 3, None);
     }
 
     #[test]
@@ -3691,18 +4275,108 @@ pub mod tests {
         let nil = lurk_sym_ptr!(s, nil);
         let terminal = s.get_cont_terminal();
 
-        test_aux::<Coproc<Fr>>(s, expr, Some(t), None, Some(terminal), None, 3, None);
-        test_aux::<Coproc<Fr>>(s, expr2, Some(nil), None, Some(terminal), None, 3, None);
-        test_aux::<Coproc<Fr>>(s, expr3, Some(t), None, Some(terminal), None, 3, None);
-        test_aux::<Coproc<Fr>>(s, expr4, Some(nil), None, Some(terminal), None, 3, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(t),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr2,
+            Some(nil),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr3,
+            Some(t),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr4,
+            Some(nil),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
 
-        test_aux::<Coproc<Fr>>(s, expr5, Some(nil), None, Some(terminal), None, 3, None);
-        test_aux::<Coproc<Fr>>(s, expr6, Some(t), None, Some(terminal), None, 3, None);
-        test_aux::<Coproc<Fr>>(s, expr7, Some(nil), None, Some(terminal), None, 3, None);
-        test_aux::<Coproc<Fr>>(s, expr8, Some(t), None, Some(terminal), None, 3, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr5,
+            Some(nil),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr6,
+            Some(t),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr7,
+            Some(nil),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr8,
+            Some(t),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
 
-        test_aux::<Coproc<Fr>>(s, expr9, Some(t), None, Some(terminal), None, 3, None);
-        test_aux::<Coproc<Fr>>(s, expr10, Some(t), None, Some(terminal), None, 3, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr9,
+            Some(t),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr10,
+            Some(t),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
     }
 
     #[test]
@@ -3718,10 +4392,46 @@ pub mod tests {
         let res3 = s.intern_u64(2);
         let terminal = s.get_cont_terminal();
 
-        test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 3, None);
-        test_aux::<Coproc<Fr>>(s, expr2, Some(res), None, Some(terminal), None, 2, None);
-        test_aux::<Coproc<Fr>>(s, expr3, Some(res2), None, Some(terminal), None, 3, None);
-        test_aux::<Coproc<Fr>>(s, expr4, Some(res3), None, Some(terminal), None, 5, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(res),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr2,
+            Some(res),
+            None,
+            Some(terminal),
+            None,
+            2,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr3,
+            Some(res2),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr4,
+            Some(res3),
+            None,
+            Some(terminal),
+            None,
+            5,
+            None,
+        );
     }
 
     #[test]
@@ -3734,8 +4444,26 @@ pub mod tests {
         let nil = lurk_sym_ptr!(s, nil);
         let terminal = s.get_cont_terminal();
 
-        test_aux::<Coproc<Fr>>(s, expr, Some(t), None, Some(terminal), None, 3, None);
-        test_aux::<Coproc<Fr>>(s, expr2, Some(nil), None, Some(terminal), None, 3, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(t),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr2,
+            Some(nil),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
     }
 
     #[test]
@@ -3748,8 +4476,26 @@ pub mod tests {
         let res2 = s.read("(1u64 . 1)").unwrap();
         let terminal = s.get_cont_terminal();
 
-        test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 3, None);
-        test_aux::<Coproc<Fr>>(s, expr2, Some(res2), None, Some(terminal), None, 3, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr,
+            Some(res),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            expr2,
+            Some(res2),
+            None,
+            Some(terminal),
+            None,
+            3,
+            None,
+        );
     }
 
     #[test]
@@ -3759,7 +4505,7 @@ pub mod tests {
         let expr = "(hide 0u64 123)";
         let error = s.get_cont_error();
 
-        test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 3, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr, None, None, Some(error), None, 3, None);
     }
 
     #[test]
@@ -3769,7 +4515,7 @@ pub mod tests {
         let expr = "(% 0 0)";
         let error = s.get_cont_error();
 
-        test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 3, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr, None, None, Some(error), None, 3, None);
     }
 
     #[test]
@@ -3778,7 +4524,7 @@ pub mod tests {
         let expr = "(let ((a (lambda (x) (+ x 1)))) (a . 1))";
         let error = s.get_cont_error();
 
-        test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 3, None);
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(s, expr, None, None, Some(error), None, 3, None);
     }
 
     #[test]
@@ -3794,7 +4540,7 @@ pub mod tests {
         let terminal = s.get_cont_terminal();
         let lang: Arc<Lang<Fr, Coproc<Fr>>> = Arc::new(Lang::new());
 
-        nova_test_full_aux2(
+        nova_test_full_aux2::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             expr,
             Some(res),
@@ -3814,8 +4560,17 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
 
-        test_aux::<Coproc<Fr>>(s, "((lambda ()))", None, None, Some(error), None, 2, None);
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+            s,
+            "((lambda ()))",
+            None,
+            None,
+            Some(error),
+            None,
+            2,
+            None,
+        );
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "((lambda () 1 2))",
             None,
@@ -3825,7 +4580,7 @@ pub mod tests {
             2,
             None,
         );
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "((lambda (x)) 1)",
             None,
@@ -3835,7 +4590,7 @@ pub mod tests {
             3,
             None,
         );
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "((lambda (x) 1 2) 1)",
             None,
@@ -3853,14 +4608,41 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
 
-        let mut test = |x| {
+        let test = |x| {
             let expr = format!("(let (({x} 123)) {x})");
             let expr2 = format!("(letrec (({x} 123)) {x})");
             let expr3 = format!("(lambda ({x}) {x})");
 
-            test_aux::<Coproc<Fr>>(s, &expr, None, None, Some(error), None, 1, None);
-            test_aux::<Coproc<Fr>>(s, &expr2, None, None, Some(error), None, 1, None);
-            test_aux::<Coproc<Fr>>(s, &expr3, None, None, Some(error), None, 1, None);
+            test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+                s,
+                &expr,
+                None,
+                None,
+                Some(error),
+                None,
+                1,
+                None,
+            );
+            test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+                s,
+                &expr2,
+                None,
+                None,
+                Some(error),
+                None,
+                1,
+                None,
+            );
+            test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+                s,
+                &expr3,
+                None,
+                None,
+                Some(error),
+                None,
+                1,
+                None,
+            );
         };
 
         test(":a");
@@ -3886,37 +4668,100 @@ pub mod tests {
         {
             // binop
             let expr = format!("({} 1 1)", hash_num(s, state.clone(), "+"));
-            test_aux::<Coproc<Fr>>(s, &expr, None, None, Some(error), None, 1, None);
+            test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+                s,
+                &expr,
+                None,
+                None,
+                Some(error),
+                None,
+                1,
+                None,
+            );
         }
         {
             // unop
             let expr = format!("({} '(1 . 2))", hash_num(s, state.clone(), "car"));
-            test_aux::<Coproc<Fr>>(s, &expr, None, None, Some(error), None, 1, None);
+            test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+                s,
+                &expr,
+                None,
+                None,
+                Some(error),
+                None,
+                1,
+                None,
+            );
         }
         {
             // let_or_letrec
             let expr = format!("({} ((a 1)) a)", hash_num(s, state.clone(), "let"));
-            test_aux::<Coproc<Fr>>(s, &expr, None, None, Some(error), None, 1, None);
+            test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+                s,
+                &expr,
+                None,
+                None,
+                Some(error),
+                None,
+                1,
+                None,
+            );
         }
         {
             // current-env
             let expr = format!("({})", hash_num(s, state.clone(), "current-env"));
-            test_aux::<Coproc<Fr>>(s, &expr, None, None, Some(error), None, 1, None);
+            test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+                s,
+                &expr,
+                None,
+                None,
+                Some(error),
+                None,
+                1,
+                None,
+            );
         }
         {
             // lambda
             let expr = format!("({} (x) 123)", hash_num(s, state.clone(), "lambda"));
-            test_aux::<Coproc<Fr>>(s, &expr, None, None, Some(error), None, 1, None);
+            test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+                s,
+                &expr,
+                None,
+                None,
+                Some(error),
+                None,
+                1,
+                None,
+            );
         }
         {
             // quote
             let expr = format!("({} asdf)", hash_num(s, state.clone(), "quote"));
-            test_aux::<Coproc<Fr>>(s, &expr, None, None, Some(error), None, 1, None);
+            test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+                s,
+                &expr,
+                None,
+                None,
+                Some(error),
+                None,
+                1,
+                None,
+            );
         }
         {
             // if
             let expr = format!("({} t 123 456)", hash_num(s, state, "if"));
-            test_aux::<Coproc<Fr>>(s, &expr, None, None, Some(error), None, 1, None);
+            test_aux::<_, _, C1<'_, _, Coproc<_>>>(
+                s,
+                &expr,
+                None,
+                None,
+                Some(error),
+                None,
+                1,
+                None,
+            );
         }
     }
 
@@ -3949,9 +4794,27 @@ pub mod tests {
         let error = s.get_cont_error();
         let lang = Arc::new(lang);
 
-        test_aux(s, expr, Some(res), None, None, None, 2, Some(lang.clone()));
-        test_aux(s, expr2, Some(res), None, None, None, 4, Some(lang.clone()));
-        test_aux(
+        test_aux::<_, _, C1<'_, _, DumbCoproc<_>>>(
+            s,
+            expr,
+            Some(res),
+            None,
+            None,
+            None,
+            2,
+            Some(lang.clone()),
+        );
+        test_aux::<_, _, C1<'_, _, DumbCoproc<_>>>(
+            s,
+            expr2,
+            Some(res),
+            None,
+            None,
+            None,
+            4,
+            Some(lang.clone()),
+        );
+        test_aux::<_, _, C1<'_, _, DumbCoproc<_>>>(
             s,
             expr3,
             None,
@@ -3961,7 +4824,16 @@ pub mod tests {
             1,
             Some(lang.clone()),
         );
-        test_aux(s, expr4, None, None, Some(error), None, 1, Some(lang));
+        test_aux::<_, _, C1<'_, _, DumbCoproc<_>>>(
+            s,
+            expr4,
+            None,
+            None,
+            Some(error),
+            None,
+            1,
+            Some(lang),
+        );
     }
 
     // This is related to issue #426
@@ -3970,7 +4842,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = lurk_sym_ptr!(s, nil);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "((lambda (x) nil) 0)",
             Some(expected),
@@ -3988,7 +4860,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(2);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(letrec ((x (let ((z 0)) 1))) 2)",
             Some(expected),
@@ -4004,7 +4876,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(1);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(let ((x 0) (y x)) 1)",
             Some(expected),
@@ -4020,7 +4892,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(3);
         let terminal = s.get_cont_terminal();
-        test_aux::<Coproc<Fr>>(
+        test_aux::<_, _, C1<'_, _, Coproc<_>>>(
             s,
             "(letrec ((x 0) (y (letrec ((inner 1)) 2))) 3)",
             Some(expected),

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -247,7 +247,8 @@ where
 {
 }
 
-impl<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a> Prover<'a, F, C> for SuperNovaProver<F, C>
+impl<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a> Prover<'a, F, C, MultiFrame<'a, F, C>>
+    for SuperNovaProver<F, C>
 where
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,

--- a/src/public_parameters/disk_cache.rs
+++ b/src/public_parameters/disk_cache.rs
@@ -8,18 +8,21 @@ use nova::traits::Group;
 
 use crate::coprocessor::Coprocessor;
 use crate::proof::nova::{CurveCycleEquipped, PublicParams, G1, G2};
+use crate::proof::MultiFrameTrait;
 use crate::public_parameters::error::Error;
 
-pub(crate) struct PublicParamDiskCache<F, C>
+pub(crate) struct PublicParamDiskCache<'a, F, C, M>
 where
     F: CurveCycleEquipped,
-    C: Coprocessor<F>,
+    C: Coprocessor<F> + 'a,
+    M: MultiFrameTrait<'a, F, C>,
 {
     dir: Utf8PathBuf,
-    _t: PhantomData<(F, C)>,
+    _t: PhantomData<(&'a (), F, C, M)>,
 }
 
-impl<F: CurveCycleEquipped, C: Coprocessor<F>> PublicParamDiskCache<F, C>
+impl<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a, M: MultiFrameTrait<'a, F, C>>
+    PublicParamDiskCache<'a, F, C, M>
 where
     // technical bounds that would disappear once associated_type_bounds stabilizes
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
@@ -38,7 +41,7 @@ where
         self.dir.join(Utf8PathBuf::from(key))
     }
 
-    pub(crate) fn get(&self, key: &str) -> Result<PublicParams<'static, F, C>, Error> {
+    pub(crate) fn get(&self, key: &str) -> Result<PublicParams<F, M>, Error> {
         let file = File::open(self.key_path(key))?;
         let reader = BufReader::new(file);
         bincode::deserialize_from(reader).map_err(|e| {
@@ -54,7 +57,7 @@ where
         Ok(bytes)
     }
 
-    pub(crate) fn set(&self, key: &str, data: &PublicParams<'static, F, C>) -> Result<(), Error> {
+    pub(crate) fn set(&self, key: &str, data: &PublicParams<F, M>) -> Result<(), Error> {
         let file = File::create(self.key_path(key)).expect("failed to create file");
         let writer = BufWriter::new(&file);
         bincode::serialize_into(writer, &data).map_err(|e| {

--- a/src/public_parameters/mem_cache.rs
+++ b/src/public_parameters/mem_cache.rs
@@ -10,6 +10,7 @@ use once_cell::sync::Lazy;
 use tap::TapFallible;
 use tracing::{info, warn};
 
+use crate::proof::MultiFrameTrait;
 use crate::{
     coprocessor::Coprocessor,
     eval::lang::Lang,
@@ -20,7 +21,7 @@ use crate::{proof::nova::CurveCycleEquipped, public_parameters::error::Error};
 use super::disk_cache::PublicParamDiskCache;
 
 type AnyMap = anymap::Map<dyn core::any::Any + Send + Sync>;
-type PublicParamMap<F, C> = HashMap<(usize, bool), Arc<PublicParams<'static, F, C>>>;
+type PublicParamMap<F, M> = HashMap<(usize, bool), Arc<PublicParams<F, M>>>;
 
 /// This is a global registry for Coproc-specific parameters.
 /// It is used to cache parameters for each Coproc, so that they are not
@@ -39,9 +40,11 @@ pub(crate) static PUBLIC_PARAM_MEM_CACHE: Lazy<PublicParamMemCache> =
 
 impl PublicParamMemCache {
     fn get_from_disk_cache_or_update_with<
+        'a,
         F: CurveCycleEquipped,
-        C: Coprocessor<F>,
-        Fn: FnOnce(Arc<Lang<F, C>>) -> Arc<PublicParams<'static, F, C>>,
+        C: Coprocessor<F> + 'a,
+        M: MultiFrameTrait<'a, F, C>,
+        Fn: FnOnce(Arc<Lang<F, C>>) -> Arc<PublicParams<F, M>>,
     >(
         &'static self,
         rc: usize,
@@ -49,7 +52,7 @@ impl PublicParamMemCache {
         default: Fn,
         lang: Arc<Lang<F, C>>,
         disk_cache_path: &Utf8Path,
-    ) -> Result<Arc<PublicParams<'static, F, C>>, Error>
+    ) -> Result<Arc<PublicParams<F, M>>, Error>
     where
         <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
         <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
@@ -67,8 +70,7 @@ impl PublicParamMemCache {
             match disk_cache.get_raw_bytes(&key) {
                 Ok(mut bytes) => {
                     info!("loading abomonated {lang_key}");
-                    let (pp, rest) =
-                        unsafe { decode::<PublicParams<'_, F, C>>(&mut bytes).unwrap() };
+                    let (pp, rest) = unsafe { decode::<PublicParams<F, M>>(&mut bytes).unwrap() };
                     assert!(rest.is_empty());
                     Ok(Arc::new(pp.clone())) // this clone is VERY expensive
                 }
@@ -106,7 +108,8 @@ impl PublicParamMemCache {
     pub(crate) fn get_from_mem_cache_or_update_with<
         F: CurveCycleEquipped,
         C: Coprocessor<F> + 'static,
-        Fn: FnOnce(Arc<Lang<F, C>>) -> Arc<PublicParams<'static, F, C>>,
+        M: MultiFrameTrait<'static, F, C> + 'static,
+        Fn: FnOnce(Arc<Lang<F, C>>) -> Arc<PublicParams<F, M>>,
     >(
         &'static self,
         rc: usize,
@@ -114,7 +117,7 @@ impl PublicParamMemCache {
         default: Fn,
         lang: Arc<Lang<F, C>>,
         disk_cache_path: &Utf8Path,
-    ) -> Result<Arc<PublicParams<'static, F, C>>, Error>
+    ) -> Result<Arc<PublicParams<F, M>>, Error>
     where
         F::CK1: Sync + Send,
         F::CK2: Sync + Send,
@@ -124,7 +127,7 @@ impl PublicParamMemCache {
         // re-grab the lock
         let mut mem_cache = self.mem_cache.lock().unwrap();
         // retrieve the per-Coproc public param table
-        let entry = mem_cache.entry::<PublicParamMap<F, C>>();
+        let entry = mem_cache.entry::<PublicParamMap<F, M>>();
         // deduce the map and populate it if needed
         let param_entry = entry.or_default();
         match param_entry.entry((rc, abomonated)) {

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -107,7 +107,7 @@ impl<F: LurkField> fmt::Display for Syntax<F> {
 }
 
 impl<F: LurkField> Store<F> {
-    pub fn intern_syntax(&mut self, syn: Syntax<F>) -> Ptr<F> {
+    pub fn intern_syntax(&self, syn: Syntax<F>) -> Ptr<F> {
         match syn {
             Syntax::Num(_, x) => self.intern_num(x),
             Syntax::UInt(_, x) => self.intern_uint(x),
@@ -252,7 +252,7 @@ mod test {
 
     #[test]
     fn syntax_rootkey_roundtrip() {
-        let mut store1 = Store::<Fr>::default();
+        let store1 = Store::<Fr>::default();
         let ptr1 = store1.intern_syntax(Syntax::Symbol(Pos::No, Symbol::root_key().into()));
         let (z_store, z_ptr) = store1.to_z_store_with_ptr(&ptr1).unwrap();
         let (store2, ptr2) = z_store.to_store_with_z_ptr(&z_ptr).unwrap();
@@ -263,7 +263,7 @@ mod test {
 
     #[test]
     fn syntax_empty_keyword_roundtrip() {
-        let mut store1 = Store::<Fr>::default();
+        let store1 = Store::<Fr>::default();
         let ptr1 = store1.intern_syntax(Syntax::Symbol(Pos::No, Symbol::key(&[""]).into()));
         let (z_store, z_ptr) = store1.to_z_store_with_ptr(&ptr1).unwrap();
         let (store2, ptr2) = z_store.to_store_with_z_ptr(&z_ptr).unwrap();
@@ -276,7 +276,7 @@ mod test {
         // TODO: Proptest the Store/ZStore roundtrip with two distinct syntaxes
         #[test]
         fn syntax_full_roundtrip(x in any::<Syntax<Fr>>()) {
-            let mut store1 = Store::<Fr>::default();
+            let store1 = Store::<Fr>::default();
             let ptr1 = store1.intern_syntax(x);
             let (z_store, z_ptr) = store1.to_z_store_with_ptr(&ptr1).unwrap();
             let (store2, ptr2) = z_store.to_store_with_z_ptr(&z_ptr).unwrap();

--- a/src/z_data/z_expr.rs
+++ b/src/z_data/z_expr.rs
@@ -216,7 +216,7 @@ mod tests {
         #[test]
         // TODO: Overflows stack in non-release mode
         fn prop_expr_z_expr_roundtrip(x in any::<Syntax<Scalar>>()) {
-            let mut store = Store::<Scalar>::default();
+            let store = Store::<Scalar>::default();
             let ptr = store.intern_syntax(x);
             let expr = store.fetch(&ptr).unwrap();
 
@@ -230,7 +230,7 @@ mod tests {
 
     #[test]
     fn unit_expr_z_expr() {
-        let mut store = Store::<Scalar>::default();
+        let store = Store::<Scalar>::default();
         let x = "(+ 1 1)";
         let ptr = store.read(x).unwrap();
         let expr = store.fetch(&ptr).unwrap();

--- a/src/z_data/z_ptr.rs
+++ b/src/z_data/z_ptr.rs
@@ -131,7 +131,7 @@ pub type ZExprPtr<F> = ZPtr<ExprTag, F>;
 impl<F: LurkField> ZExprPtr<F> {
     /// Parses and hashes a Lurk source string into a ZExprPtr
     pub fn from_lurk_str(value: &str) -> Result<Self, store::Error> {
-        let mut store = Store::<F>::default();
+        let store = Store::<F>::default();
         let ptr = store
             .read(value)
             .map_err(|e| store::Error(format!("Parse error: {}", e)))?;


### PR DESCRIPTION
- introduces a Multiframe trait generalizing over the circuit machinery produced by LEM & Lurk,
- implements it for the Lurk Circuit,
- converts the nova proof file to work with this MultiFrame trait, making proving generic.

## Nest steps :
- implementing the MultiFrame trait for LEM (see #629 #677)
- refactoring the test suite in `src/proof/nova.rs` so that it tests each expression with LEM and Lurk,
- extending the same logic to SuperNova