### PR TITLE
refactor: Finish refactoring codebase to use immutable Store references

### DIFF
--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -25,7 +25,7 @@ use lurk::{
 
 const PUBLIC_PARAMS_PATH: &str = "/var/tmp/lurk_benches/public_params";
 
-fn fib<F: LurkField>(store: &mut Store<F>, state: Rc<RefCell<State>>, _a: u64) -> Ptr<F> {
+fn fib<F: LurkField>(store: &Store<F>, state: Rc<RefCell<State>>, _a: u64) -> Ptr<F> {
     let program = r#"
 (letrec ((next (lambda (a b) (next b (+ a b))))
            (fib (next 0 1)))
@@ -88,11 +88,11 @@ fn fibo_prove<M: measurement::Measurement>(
         BenchmarkId::new(prove_params.name(), fib_n),
         &prove_params,
         |b, prove_params| {
-            let mut store = Store::default();
+            let store = Store::default();
 
             let env = empty_sym_env(&store);
             let ptr = fib::<pasta_curves::Fq>(
-                &mut store,
+                &store,
                 state.clone(),
                 black_box(prove_params.fib_n as u64),
             );

--- a/benches/sha256_ivc.rs
+++ b/benches/sha256_ivc.rs
@@ -43,7 +43,7 @@ use sha2::{Digest, Sha256};
 const PUBLIC_PARAMS_PATH: &str = "/var/tmp/lurk_benches/public_params";
 
 fn sha256_ivc<F: LurkField>(
-    store: &mut Store<F>,
+    store: &Store<F>,
     state: Rc<RefCell<State>>,
     arity: usize,
     n: usize,

--- a/benches/synthesis.rs
+++ b/benches/synthesis.rs
@@ -22,7 +22,7 @@ use lurk::{
     store::Store,
 };
 
-fn fib<F: LurkField>(store: &mut Store<F>, state: Rc<RefCell<State>>, a: u64) -> Ptr<F> {
+fn fib<F: LurkField>(store: &Store<F>, state: Rc<RefCell<State>>, a: u64) -> Ptr<F> {
     let program = format!(
         r#"
 (let ((fib (lambda (target)
@@ -54,10 +54,10 @@ fn synthesize<M: measurement::Measurement>(
         BenchmarkId::new(name.to_string(), reduction_count),
         &reduction_count,
         |b, reduction_count| {
-            let mut store = Store::default();
+            let store = Store::default();
             let env = empty_sym_env(&store);
             let fib_n = (reduction_count / 3) as u64; // Heuristic, since one fib is 35 iterations.
-            let ptr = fib::<pasta_curves::Fq>(&mut store, state.clone(), black_box(fib_n));
+            let ptr = fib::<pasta_curves::Fq>(&store, state.clone(), black_box(fib_n));
             let prover = NovaProver::<_, _, MultiFrame<'_, _, _>>::new(
                 *reduction_count,
                 lang_pallas.clone(),

--- a/examples/fibonacci.rs
+++ b/examples/fibonacci.rs
@@ -12,7 +12,7 @@ use lurk::{
 };
 use pasta_curves::pallas::Scalar;
 
-fn fib_expr<F: LurkField>(store: &mut Store<F>) -> Ptr<F> {
+fn fib_expr<F: LurkField>(store: &Store<F>) -> Ptr<F> {
     let program = r#"
 (letrec ((next (lambda (a b) (next b (+ a b))))
            (fib (next 0 1)))
@@ -35,7 +35,7 @@ fn fib_limit(n: usize, rc: usize) -> usize {
     rc * (frame / rc + usize::from(frame % rc != 0))
 }
 
-fn lurk_fib(store: &mut Store<Scalar>, n: usize, _rc: usize) -> Ptr<Scalar> {
+fn lurk_fib(store: &Store<Scalar>, n: usize, _rc: usize) -> Ptr<Scalar> {
     let lang = Lang::<Scalar, Coproc<Scalar>>::new();
     let frame_idx = fib_frame(n);
     // let limit = fib_limit(n, rc);

--- a/examples/sha256_ivc.rs
+++ b/examples/sha256_ivc.rs
@@ -30,7 +30,7 @@ use tracing_texray::TeXRayLayer;
 
 const REDUCTION_COUNT: usize = 10;
 
-fn sha256_ivc<F: LurkField>(store: &mut Store<F>, n: usize, input: Vec<usize>) -> Ptr<F> {
+fn sha256_ivc<F: LurkField>(store: &Store<F>, n: usize, input: Vec<usize>) -> Ptr<F> {
     assert_eq!(n, input.len());
     let input = input
         .iter()

--- a/examples/sha256_nivc.rs
+++ b/examples/sha256_nivc.rs
@@ -29,7 +29,7 @@ use tracing_texray::TeXRayLayer;
 
 const REDUCTION_COUNT: usize = 10;
 
-fn sha256_encode<F: LurkField>(store: &mut Store<F>) -> Ptr<F> {
+fn sha256_encode<F: LurkField>(store: &Store<F>) -> Ptr<F> {
     let program = r#"
 (letrec ((encode-1 (lambda (term)
             (let ((type (car term))

--- a/fcomm/src/bin/fcomm.rs
+++ b/fcomm/src/bin/fcomm.rs
@@ -412,7 +412,7 @@ impl Verify {
 }
 
 fn read_from_path<P: AsRef<Path>, F: LurkField + Serialize>(
-    store: &mut Store<F>,
+    store: &Store<F>,
     path: P,
 ) -> Result<Ptr<F>, Error> {
     let path = env::current_dir().unwrap().join(path);
@@ -423,7 +423,7 @@ fn read_from_path<P: AsRef<Path>, F: LurkField + Serialize>(
 }
 
 fn read_eval_from_path<P: AsRef<Path>, F: LurkField + Serialize>(
-    store: &mut Store<F>,
+    store: &Store<F>,
     path: P,
     limit: usize,
     lang: &Lang<F, Coproc<F>>,
@@ -442,7 +442,7 @@ fn read_eval_from_path<P: AsRef<Path>, F: LurkField + Serialize>(
 }
 
 fn read_no_eval_from_path<P: AsRef<Path>, F: LurkField + Serialize>(
-    store: &mut Store<F>,
+    store: &Store<F>,
     path: P,
 ) -> Result<(Ptr<F>, Ptr<F>), Error> {
     let src = read_from_path(store, path)?;
@@ -453,7 +453,7 @@ fn read_no_eval_from_path<P: AsRef<Path>, F: LurkField + Serialize>(
 }
 
 fn _lurk_function<P: AsRef<Path>, F: LurkField + Serialize>(
-    store: &mut Store<F>,
+    store: &Store<F>,
     function_path: P,
     limit: usize,
     lang: &Lang<F, Coproc<F>>,
@@ -466,7 +466,7 @@ fn _lurk_function<P: AsRef<Path>, F: LurkField + Serialize>(
 }
 
 fn input<P: AsRef<Path>, F: LurkField + Serialize>(
-    store: &mut Store<F>,
+    store: &Store<F>,
     input_path: P,
     eval_input: bool,
     limit: usize,
@@ -489,7 +489,7 @@ fn input<P: AsRef<Path>, F: LurkField + Serialize>(
 }
 
 fn expression<P: AsRef<Path>, F: LurkField + Serialize + DeserializeOwned>(
-    store: &mut Store<F>,
+    store: &Store<F>,
     expression_path: P,
     lurk: bool,
     limit: usize,

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -5671,7 +5671,7 @@ mod tests {
 
     #[test]
     fn num_self_evaluating() {
-        let mut store = Store::default();
+        let store = Store::default();
         let env = empty_sym_env(&store);
         let num = store.num(123);
 
@@ -5816,7 +5816,7 @@ mod tests {
 
     #[test]
     fn nil_self_evaluating() {
-        let mut store = Store::default();
+        let store = Store::default();
         let env = empty_sym_env(&store);
         let nil = lurk_sym_ptr!(store, nil);
 
@@ -5900,7 +5900,7 @@ mod tests {
 
     #[test]
     fn t_self_evaluating() {
-        let mut store = Store::default();
+        let store = Store::default();
         let env = empty_sym_env(&store);
         let t = lurk_sym_ptr!(store, t);
 
@@ -5984,7 +5984,7 @@ mod tests {
 
     #[test]
     fn fun_self_evaluating() {
-        let mut store = Store::default();
+        let store = Store::default();
         let env = empty_sym_env(&store);
         let var = store.sym("a");
         let body = store.intern_list(&[var]);
@@ -6073,7 +6073,7 @@ mod tests {
 
     #[test]
     fn non_self_evaluating() {
-        let mut store = Store::default();
+        let store = Store::default();
         let env = empty_sym_env(&store);
 
         // Input is not self-evaluating.
@@ -6089,7 +6089,7 @@ mod tests {
 
         store.hydrate_scalar_cache();
 
-        let test_with_output = |output, expect_success, store: &mut Store<Fr>| {
+        let test_with_output = |output, expect_success, store: &Store<Fr>| {
             let mut cs = TestConstraintSystem::<Fr>::new();
 
             let frame = Frame {
@@ -6132,7 +6132,7 @@ mod tests {
                     cont: store.intern_cont_terminal(),
                 };
 
-                test_with_output(output, false, &mut store);
+                test_with_output(output, false, &store);
             }
         }
     }
@@ -6140,7 +6140,7 @@ mod tests {
     #[test]
     fn test_enforce_comparison() {
         let mut cs = TestConstraintSystem::<Fr>::new();
-        let s = &mut Store::<Fr>::default();
+        let s = &Store::<Fr>::default();
         s.hydrate_scalar_cache();
 
         let g = GlobalAllocations::new(&mut cs.namespace(|| "global_allocations"), s).unwrap();
@@ -6167,7 +6167,7 @@ mod tests {
     #[test]
     fn test_u64_op() {
         let mut cs = TestConstraintSystem::<Fr>::new();
-        let s = &mut Store::<Fr>::default();
+        let s = &Store::<Fr>::default();
 
         let g = GlobalAllocations::new(&mut cs.namespace(|| "global_allocations"), s).unwrap();
 

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -157,7 +157,7 @@ impl Repl<F> {
 
     #[allow(dead_code)]
     fn proof_claim(
-        store: &mut Store<F>,
+        store: &Store<F>,
         exprs: (Ptr<F>, Ptr<F>),
         envs: (Ptr<F>, Ptr<F>),
         conts: ((F, F), (F, F)),
@@ -218,7 +218,7 @@ impl Repl<F> {
                     let cont_out = self.store.get_z_cont(&output.cont, &mut zstore)?.0;
 
                     let claim = Self::proof_claim(
-                        &mut self.store,
+                        &self.store,
                         (input.expr, output.expr),
                         (input.env, output.env),
                         (cont.parts(), cont_out.parts()),

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -549,7 +549,7 @@ pub fn empty_sym_env<F: LurkField>(store: &Store<F>) -> Ptr<F> {
 // Convenience functions, mostly for use in tests.
 
 pub fn eval_to_ptr<F: LurkField, C: Coprocessor<F>>(
-    s: &mut Store<F>,
+    s: &Store<F>,
     src: &str,
 ) -> Result<Ptr<F>, ReductionError> {
     let expr = s.read(src).unwrap();

--- a/src/eval/tests/mod.rs
+++ b/src/eval/tests/mod.rs
@@ -17,7 +17,7 @@ use crate as lurk;
 mod trie;
 
 fn test_aux_with_state<C: Coprocessor<Fr>>(
-    s: &mut Store<Fr>,
+    s: &Store<Fr>,
     state: Rc<RefCell<State>>,
     expr: &str,
     expected_result: Option<Ptr<Fr>>,
@@ -56,7 +56,7 @@ fn test_aux_with_state<C: Coprocessor<Fr>>(
 }
 
 fn test_aux<C: Coprocessor<Fr>>(
-    s: &mut Store<Fr>,
+    s: &Store<Fr>,
     expr: &str,
     expected_result: Option<Ptr<Fr>>,
     expected_env: Option<Ptr<Fr>>,
@@ -94,7 +94,7 @@ fn test_aux<C: Coprocessor<Fr>>(
 }
 
 fn test_aux2<C: Coprocessor<Fr>>(
-    s: &mut Store<Fr>,
+    s: &Store<Fr>,
     expr: &Ptr<Fr>,
     expected_result: Option<Ptr<Fr>>,
     expected_env: Option<Ptr<Fr>>,
@@ -139,7 +139,7 @@ fn test_aux2<C: Coprocessor<Fr>>(
 
 #[test]
 fn test_lookup() {
-    let mut store = Store::<Fr>::default();
+    let store = Store::<Fr>::default();
     let env = empty_sym_env(&store);
     let var = store.sym("variable");
     let val = store.num(123);
@@ -152,7 +152,7 @@ fn test_lookup() {
 
 #[test]
 fn test_reduce_simple() {
-    let mut store = Store::<Fr>::default();
+    let store = Store::<Fr>::default();
     let lang = Lang::<Fr, Coproc<Fr>>::new();
     {
         let num = store.num(123);
@@ -192,7 +192,7 @@ fn evaluate_simple() {
 
 #[test]
 fn evaluate_lookup() {
-    let mut store = Store::<Fr>::default();
+    let store = Store::<Fr>::default();
 
     let limit = 20;
     let val = store.num(999);
@@ -1856,7 +1856,7 @@ fn secret_opaque_commit() {
     test_aux::<Coproc<Fr>>(s, expr, None, None, None, None, 2, None);
 }
 
-fn relational_aux(s: &mut Store<Fr>, op: &str, a: &str, b: &str, res: bool) {
+fn relational_aux(s: &Store<Fr>, op: &str, a: &str, b: &str, res: bool) {
     let expr = &format!("({op} {a} {b})");
     let expected = if res {
         lurk_sym_ptr!(s, t)
@@ -2296,7 +2296,7 @@ fn test_numeric_type_error() {
     let s = &mut Store::<Fr>::default();
     let error = s.get_cont_error();
 
-    let mut test = |op| {
+    let test = |op| {
         let expr = &format!("({op} 0 'a)");
         let expr2 = &format!("({op} 0u64 'a)");
 
@@ -2510,7 +2510,7 @@ fn test_eval_dotted_syntax_error() {
 fn op_syntax_error<T: Op + Copy>() {
     let s = &mut Store::<Fr>::default();
     let error = s.get_cont_error();
-    let mut test = |op: T| {
+    let test = |op: T| {
         let name = op.symbol_name();
 
         {
@@ -2601,7 +2601,7 @@ fn test_eval_non_symbol_binding_error() {
     let s = &mut Store::<Fr>::default();
     let error = s.get_cont_error();
 
-    let mut test = |x| {
+    let test = |x| {
         let expr = format!("(let (({x} 123)) {x})");
         let expr2 = format!("(letrec (({x} 123)) {x})");
         let expr3 = format!("(lambda ({x}) {x})");

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -48,11 +48,7 @@ impl<F: LurkField> Store<F> {
         }
     }
 
-    pub fn read_with_state(
-        &mut self,
-        state: Rc<RefCell<State>>,
-        input: &str,
-    ) -> Result<Ptr<F>, Error> {
+    pub fn read_with_state(&self, state: Rc<RefCell<State>>, input: &str) -> Result<Ptr<F>, Error> {
         match preceded(
             syntax::parse_space,
             syntax::parse_syntax(state, false, false),
@@ -65,7 +61,7 @@ impl<F: LurkField> Store<F> {
     }
 
     pub fn read_maybe_meta_with_state<'a>(
-        &mut self,
+        &self,
         state: Rc<RefCell<State>>,
         input: Span<'a>,
     ) -> Result<(Span<'a>, Ptr<F>, bool), Error> {

--- a/src/proof/groth16.rs
+++ b/src/proof/groth16.rs
@@ -139,7 +139,7 @@ impl<'a, C: Coprocessor<Scalar> + 'a, M: MultiFrameTrait<'a, Scalar, C>>
         srs: &GenericSRS<Bls12>,
         expr: Ptr<Scalar>,
         env: Ptr<Scalar>,
-        store: &mut Store<Scalar>,
+        store: &Store<Scalar>,
         limit: usize,
         mut rng: R,
         lang: Arc<Lang<Scalar, C>>,
@@ -344,7 +344,7 @@ mod tests {
     const DEFAULT_CHECK_GROTH16: bool = false;
     const DEFAULT_REDUCTION_COUNT: usize = 5;
 
-    fn outer_prove_aux<Fo: Fn(&'_ mut Store<Fr>) -> Ptr<Fr>>(
+    fn outer_prove_aux<Fo: Fn(&'_ Store<Fr>) -> Ptr<Fr>>(
         source: &str,
         expected_result: Fo,
         expected_iterations: usize,
@@ -353,14 +353,14 @@ mod tests {
         limit: usize,
         debug: bool,
     ) {
-        let mut s = Store::default();
-        let expected_result = expected_result(&mut s);
+        let s = Store::default();
+        let expected_result = expected_result(&s);
 
         let expr = s.read(source).unwrap();
         let lang = Lang::<Fr, Coproc<Fr>>::new();
 
         outer_prove_aux0(
-            &mut s,
+            &s,
             expr,
             expected_result,
             expected_iterations,
@@ -373,7 +373,7 @@ mod tests {
     }
 
     fn outer_prove_aux0<C: Coprocessor<Fr>>(
-        s: &mut Store<Fr>,
+        s: &Store<Fr>,
         expr: Ptr<Fr>,
         expected_result: Ptr<Fr>,
         expected_iterations: usize,
@@ -635,7 +635,7 @@ mod tests {
     #[test]
     #[ignore]
     fn outer_prove_chained_functional_commitment() {
-        let mut s = Store::<Fr>::default();
+        let s = Store::<Fr>::default();
 
         let fun_src = s
             .read(
@@ -672,16 +672,6 @@ mod tests {
 
         let result_expr = output.expr;
 
-        outer_prove_aux0(
-            &mut s,
-            input,
-            result_expr,
-            32,
-            true,
-            true,
-            limit,
-            false,
-            &lang,
-        );
+        outer_prove_aux0(&s, input, result_expr, 32, true, true, limit, false, &lang);
     }
 }

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -312,7 +312,7 @@ where
         pp: &PublicParams<F, M>,
         expr: M::Ptr,
         env: M::Ptr,
-        store: &'a mut M::Store,
+        store: &'a M::Store,
         limit: usize,
         lang: &Arc<Lang<F, C>>,
     ) -> Result<(Proof<'a, F, C, M>, Vec<F>, Vec<F>, usize), ProofError> {
@@ -3948,7 +3948,7 @@ pub mod tests {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
 
-        let hash_num = |s: &mut Store<Fr>, state: Rc<RefCell<State>>, name| {
+        let hash_num = |s: &Store<Fr>, state: Rc<RefCell<State>>, name| {
             let sym = s.read_with_state(state, name).unwrap();
             let z_ptr = s.hash_expr(&sym).unwrap();
             let hash = *z_ptr.value();

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -60,7 +60,7 @@ pub struct Repl<F: LurkField, T: ReplTrait<F, C>, C: Coprocessor<F>> {
 }
 
 pub trait ReplTrait<F: LurkField, C: Coprocessor<F>> {
-    fn new(s: &mut Store<F>, limit: usize, command: Option<Command>, lang: Lang<F, C>) -> Self;
+    fn new(s: &Store<F>, limit: usize, command: Option<Command>, lang: Lang<F, C>) -> Self;
 
     fn name() -> String;
 
@@ -72,7 +72,7 @@ pub trait ReplTrait<F: LurkField, C: Coprocessor<F>> {
 
     fn handle_form<'a, P: AsRef<Path> + Copy>(
         &mut self,
-        store: &mut Store<F>,
+        store: &Store<F>,
         state: Rc<RefCell<State>>,
         input: parser::Span<'a>,
         pwd: P,
@@ -92,7 +92,7 @@ pub trait ReplTrait<F: LurkField, C: Coprocessor<F>> {
 
     fn handle_load<P: AsRef<Path>>(
         &mut self,
-        store: &mut Store<F>,
+        store: &Store<F>,
         state: Rc<RefCell<State>>,
         file_path: P,
     ) -> Result<()> {
@@ -102,7 +102,7 @@ pub trait ReplTrait<F: LurkField, C: Coprocessor<F>> {
 
     fn handle_file<P: AsRef<Path> + Copy>(
         &mut self,
-        store: &mut Store<F>,
+        store: &Store<F>,
         state: Rc<RefCell<State>>,
         file_path: P,
     ) -> Result<()> {
@@ -137,7 +137,7 @@ pub trait ReplTrait<F: LurkField, C: Coprocessor<F>> {
 
     fn handle_meta<P: AsRef<Path> + Copy>(
         &mut self,
-        store: &mut Store<F>,
+        store: &Store<F>,
         state: Rc<RefCell<State>>,
         expr_ptr: Ptr<F>,
         p: P,
@@ -145,7 +145,7 @@ pub trait ReplTrait<F: LurkField, C: Coprocessor<F>> {
 
     fn handle_non_meta(
         &mut self,
-        store: &mut Store<F>,
+        store: &Store<F>,
         state: &State,
         expr_ptr: Ptr<F>,
     ) -> Result<(IO<F>, IO<F>, usize)>;
@@ -153,7 +153,7 @@ pub trait ReplTrait<F: LurkField, C: Coprocessor<F>> {
 
 impl<F: LurkField, T: ReplTrait<F, C>, C: Coprocessor<F>> Repl<F, T, C> {
     pub fn new(
-        s: &mut Store<F>,
+        s: &Store<F>,
         limit: usize,
         command: Option<Command>,
         lang: Lang<F, C>,
@@ -254,7 +254,7 @@ fn repl_aux<
 
 // For the moment, input must be on a single line.
 pub fn run_repl<P: AsRef<Path>, F: LurkField, T: ReplTrait<F, C>, C: Coprocessor<F>>(
-    s: &mut Store<F>,
+    s: &Store<F>,
     mut repl: Repl<F, T, C>,
     lurk_file: Option<P>,
 ) -> Result<()> {
@@ -353,7 +353,7 @@ impl<F: LurkField, C: Coprocessor<F>> ReplState<F, C> {
 }
 
 impl<F: LurkField, C: Coprocessor<F>> ReplTrait<F, C> for ReplState<F, C> {
-    fn new(s: &mut Store<F>, limit: usize, command: Option<Command>, lang: Lang<F, C>) -> Self {
+    fn new(s: &Store<F>, limit: usize, command: Option<Command>, lang: Lang<F, C>) -> Self {
         Self {
             env: empty_sym_env(s),
             limit,
@@ -396,7 +396,7 @@ impl<F: LurkField, C: Coprocessor<F>> ReplTrait<F, C> for ReplState<F, C> {
 
     fn handle_meta<P: AsRef<Path> + Copy>(
         &mut self,
-        store: &mut Store<F>,
+        store: &Store<F>,
         state: Rc<RefCell<State>>,
         expr_ptr: Ptr<F>,
         p: P,
@@ -588,7 +588,7 @@ impl<F: LurkField, C: Coprocessor<F>> ReplTrait<F, C> for ReplState<F, C> {
 
     fn handle_non_meta(
         &mut self,
-        store: &mut Store<F>,
+        store: &Store<F>,
         state: &State,
         expr_ptr: Ptr<F>,
     ) -> Result<(IO<F>, IO<F>, usize)> {

--- a/src/store.rs
+++ b/src/store.rs
@@ -251,7 +251,7 @@ impl<F: LurkField> Store<F> {
         self.intern_list(elts)
     }
 
-    pub fn num<T: Into<Num<F>>>(&mut self, num: T) -> Ptr<F> {
+    pub fn num<T: Into<Num<F>>>(&self, num: T) -> Ptr<F> {
         self.intern_num(num)
     }
 
@@ -1933,7 +1933,7 @@ pub mod test {
 
     #[test]
     fn store() {
-        let mut store = Store::<Fr>::default();
+        let store = Store::<Fr>::default();
 
         let num_ptr = store.num(123);
         let num = store.fetch(&num_ptr).unwrap();
@@ -1944,7 +1944,7 @@ pub mod test {
 
     #[test]
     fn equality() {
-        let mut store = Store::<Fr>::default();
+        let store = Store::<Fr>::default();
 
         let (a, b) = (store.num(123), store.sym("pumpkin"));
         let cons1 = store.intern_cons(a, b);
@@ -1962,7 +1962,7 @@ pub mod test {
 
     #[test]
     fn opaque_fun() {
-        let mut store = Store::<Fr>::default();
+        let store = Store::<Fr>::default();
 
         let arg = store.sym("A");
         let body_form = store.num(123);
@@ -2022,7 +2022,7 @@ pub mod test {
 
     #[test]
     fn opaque_sym() {
-        let mut store = Store::<Fr>::default();
+        let store = Store::<Fr>::default();
 
         let empty_env = empty_sym_env(&store);
         let sym = store.sym("sym");
@@ -2123,7 +2123,7 @@ pub mod test {
 
     #[test]
     fn opaque_cons() {
-        let mut store = Store::<Fr>::default();
+        let store = Store::<Fr>::default();
 
         let num1 = store.num(123);
         let num2 = store.num(987);
@@ -2208,7 +2208,7 @@ pub mod test {
         }
     }
 
-    fn make_maybe_opaque_cons(store: &mut Store<Fr>, car: u64, cdr: u64) -> Ptr<Fr> {
+    fn make_maybe_opaque_cons(store: &Store<Fr>, car: u64, cdr: u64) -> Ptr<Fr> {
         let num1 = store.num(Num::<Fr>::from(car));
         let num2 = store.num(Num::<Fr>::from(cdr));
         let cons = store.intern_cons(num1, num2);
@@ -2217,39 +2217,39 @@ pub mod test {
         store.intern_maybe_opaque_cons(*cons_hash.value())
     }
 
-    fn make_opaque_cons(store: &mut Store<Fr>) -> Ptr<Fr> {
+    fn make_opaque_cons(store: &Store<Fr>) -> Ptr<Fr> {
         store.intern_opaque_cons(12345.into())
     }
 
     #[test]
     #[should_panic]
     fn opaque_cons_car() {
-        let mut store = Store::<Fr>::default();
+        let store = Store::<Fr>::default();
 
-        let opaque_cons = make_opaque_cons(&mut store);
+        let opaque_cons = make_opaque_cons(&store);
         store.car(&opaque_cons).unwrap();
     }
     #[test]
     #[should_panic]
     fn opaque_cons_cdr() {
-        let mut store = Store::<Fr>::default();
+        let store = Store::<Fr>::default();
 
-        let opaque_cons = make_opaque_cons(&mut store);
+        let opaque_cons = make_opaque_cons(&store);
         store.cdr(&opaque_cons).unwrap();
     }
 
     #[test]
     fn maybe_opaque_cons_car() {
-        let mut store = Store::<Fr>::default();
+        let store = Store::<Fr>::default();
 
-        let opaque_cons = make_maybe_opaque_cons(&mut store, 123, 987);
+        let opaque_cons = make_maybe_opaque_cons(&store, 123, 987);
         store.car(&opaque_cons).unwrap();
     }
     #[test]
     fn maybe_opaque_cons_cdr() {
-        let mut store = Store::<Fr>::default();
+        let store = Store::<Fr>::default();
 
-        let opaque_cons = make_maybe_opaque_cons(&mut store, 123, 987);
+        let opaque_cons = make_maybe_opaque_cons(&store, 123, 987);
         store.cdr(&opaque_cons).unwrap();
     }
 
@@ -2414,7 +2414,7 @@ pub mod test {
         );
     }
 
-    fn commit_and_open(store: &mut Store<S1>, expr: Ptr<S1>) -> Ptr<S1> {
+    fn commit_and_open(store: &Store<S1>, expr: Ptr<S1>) -> Ptr<S1> {
         let secret = <S1>::random(OsRng);
         let comm = store.hide(secret, expr);
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -356,7 +356,7 @@ pub mod test {
 
     #[test]
     fn print_expr() {
-        let mut s = Store::<Fr>::default();
+        let s = Store::<Fr>::default();
         let state = &mut State::init_lurk_state();
         let nil = lurk_sym_ptr!(s, nil);
         let x = s.user_sym("x");
@@ -376,7 +376,7 @@ pub mod test {
 
     #[test]
     fn test_print_num() {
-        let mut store = Store::<Fr>::default();
+        let store = Store::<Fr>::default();
         let num = store.num(5);
         let res = num.fmt_to_string(&store, initial_lurk_state());
         assert_eq!(&res, &"5");


### PR DESCRIPTION
- Modifications to change mutable `Store` references to immutable across multiple files,
- Removal of  unused mutable `Store` instances in several test functions.
- Adjustments to several test functions to align with the change from mutable to immutable `Store` references.