### PR TITLE
refactor: Refactor AllocatedNum allocation to infallible method

### DIFF
--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -198,7 +198,7 @@ impl<'a, F: LurkField, C: Coprocessor<F> + 'a> MultiFrameTrait<'a, F, C> for Mul
         let mut bogus_cs = WitnessCS::<F>::new();
         let z: Vec<AllocatedNum<F>> = z_scalar
             .iter()
-            .map(|x| AllocatedNum::alloc(&mut bogus_cs, || Ok(*x)).unwrap())
+            .map(|x| AllocatedNum::alloc_infallible(&mut bogus_cs, || *x))
             .collect::<Vec<_>>();
 
         let _ = nova::traits::circuit::StepCircuit::synthesize(self, &mut wcs, z.as_slice());
@@ -6218,9 +6218,9 @@ mod tests {
     fn test_enforce_less_than_bound() {
         let mut cs = TestConstraintSystem::<Fr>::new();
         let alloc_num =
-            AllocatedNum::alloc(&mut cs.namespace(|| "num"), || Ok(Fr::from_u64(42))).unwrap();
+            AllocatedNum::alloc_infallible(&mut cs.namespace(|| "num"), || Fr::from_u64(42));
         let alloc_bound =
-            AllocatedNum::alloc(&mut cs.namespace(|| "bound"), || Ok(Fr::from_u64(43))).unwrap();
+            AllocatedNum::alloc_infallible(&mut cs.namespace(|| "bound"), || Fr::from_u64(43));
         let cond = Boolean::Constant(true);
 
         let res = enforce_less_than_bound(
@@ -6237,9 +6237,9 @@ mod tests {
     fn test_enforce_less_than_bound_negative() {
         let mut cs = TestConstraintSystem::<Fr>::new();
         let alloc_num =
-            AllocatedNum::alloc(&mut cs.namespace(|| "num"), || Ok(Fr::from_u64(43))).unwrap();
+            AllocatedNum::alloc_infallible(&mut cs.namespace(|| "num"), || Fr::from_u64(43));
         let alloc_bound =
-            AllocatedNum::alloc(&mut cs.namespace(|| "bound"), || Ok(Fr::from_u64(42))).unwrap();
+            AllocatedNum::alloc_infallible(&mut cs.namespace(|| "bound"), || Fr::from_u64(42));
         let cond = Boolean::Constant(true);
 
         let res = enforce_less_than_bound(
@@ -6338,7 +6338,7 @@ mod tests {
         let field_bn = BigUint::from_bytes_le(v.to_repr().as_ref());
 
         let a_plus_power2_32_num =
-            AllocatedNum::alloc(&mut cs.namespace(|| "pow(2, 32) + 2"), || Ok(v)).unwrap();
+            AllocatedNum::alloc_infallible(&mut cs.namespace(|| "pow(2, 32) + 2"), || v);
 
         let bits = a_plus_power2_32_num
             .to_bits_le(&mut cs.namespace(|| "bits"))
@@ -6368,7 +6368,7 @@ mod tests {
         let field_bn = BigUint::from_bytes_le(v.to_repr().as_ref());
 
         let a_plus_power2_64_num =
-            AllocatedNum::alloc(&mut cs.namespace(|| "pow(2, 64) + 2"), || Ok(v)).unwrap();
+            AllocatedNum::alloc_infallible(&mut cs.namespace(|| "pow(2, 64) + 2"), || v);
 
         let bits = a_plus_power2_64_num
             .to_bits_le(&mut cs.namespace(|| "bits"))
@@ -6391,7 +6391,7 @@ mod tests {
     fn test_enforce_pack() {
         let mut cs = TestConstraintSystem::<Fr>::new();
         let a_num =
-            AllocatedNum::alloc(&mut cs.namespace(|| "a num"), || Ok(Fr::from_u64(42))).unwrap();
+            AllocatedNum::alloc_infallible(&mut cs.namespace(|| "a num"), || Fr::from_u64(42));
         let bits = a_num.to_bits_le(&mut cs.namespace(|| "bits")).unwrap();
         enforce_pack(&mut cs, &bits, &a_num);
         assert!(cs.is_satisfied());

--- a/src/circuit/gadgets/case.rs
+++ b/src/circuit/gadgets/case.rs
@@ -374,11 +374,11 @@ mod tests {
 
         let x = Fr::from(123);
         let y = Fr::from(124);
-        let selected = AllocatedNum::alloc(cs.namespace(|| "selected"), || Ok(x)).unwrap();
-        let val0 = AllocatedNum::alloc(cs.namespace(|| "val0"), || Ok(Fr::from(666))).unwrap();
-        let val1 = AllocatedNum::alloc(cs.namespace(|| "val1"), || Ok(Fr::from(777))).unwrap();
+        let selected = AllocatedNum::alloc_infallible(cs.namespace(|| "selected"), || x);
+        let val0 = AllocatedNum::alloc_infallible(cs.namespace(|| "val0"), || Fr::from(666));
+        let val1 = AllocatedNum::alloc_infallible(cs.namespace(|| "val1"), || Fr::from(777));
         let default =
-            AllocatedNum::alloc(cs.namespace(|| "default_v"), || Ok(Fr::from(999))).unwrap();
+            AllocatedNum::alloc_infallible(cs.namespace(|| "default_v"), || Fr::from(999));
 
         {
             let clauses = [CaseClause::new(x, &val0), CaseClause::new(y, &val1)];
@@ -425,15 +425,15 @@ mod tests {
         let x = Fr::from(123);
         let y = Fr::from(124);
         let z = Fr::from(125);
-        let selected0 = AllocatedNum::alloc(cs.namespace(|| "selected0"), || Ok(x)).unwrap();
-        let selected1 = AllocatedNum::alloc(cs.namespace(|| "selected1"), || Ok(z)).unwrap();
-        let val0 = AllocatedNum::alloc(cs.namespace(|| "val0"), || Ok(Fr::from(666))).unwrap();
-        let val1 = AllocatedNum::alloc(cs.namespace(|| "val1"), || Ok(Fr::from(777))).unwrap();
-        let val2 = AllocatedNum::alloc(cs.namespace(|| "val2"), || Ok(Fr::from(700))).unwrap();
+        let selected0 = AllocatedNum::alloc_infallible(cs.namespace(|| "selected0"), || x);
+        let selected1 = AllocatedNum::alloc_infallible(cs.namespace(|| "selected1"), || z);
+        let val0 = AllocatedNum::alloc_infallible(cs.namespace(|| "val0"), || Fr::from(666));
+        let val1 = AllocatedNum::alloc_infallible(cs.namespace(|| "val1"), || Fr::from(777));
+        let val2 = AllocatedNum::alloc_infallible(cs.namespace(|| "val2"), || Fr::from(700));
         let default_vec = [
-            &AllocatedNum::alloc(cs.namespace(|| "default0"), || Ok(Fr::from(999))).unwrap(),
-            &AllocatedNum::alloc(cs.namespace(|| "default1"), || Ok(Fr::from(998))).unwrap(),
-            &AllocatedNum::alloc(cs.namespace(|| "default2"), || Ok(Fr::from(997))).unwrap(),
+            &AllocatedNum::alloc_infallible(cs.namespace(|| "default0"), || Fr::from(999)),
+            &AllocatedNum::alloc_infallible(cs.namespace(|| "default1"), || Fr::from(998)),
+            &AllocatedNum::alloc_infallible(cs.namespace(|| "default2"), || Fr::from(997)),
         ];
 
         {
@@ -496,14 +496,14 @@ mod tests {
 
         let x = Fr::from(123);
         let z = Fr::from(125);
-        let selected = AllocatedNum::alloc(cs.namespace(|| "selected"), || Ok(z)).unwrap();
-        let val0 = AllocatedNum::alloc(cs.namespace(|| "val0"), || Ok(Fr::from(666))).unwrap();
-        let val1 = AllocatedNum::alloc(cs.namespace(|| "val1"), || Ok(Fr::from(777))).unwrap();
-        let val2 = AllocatedNum::alloc(cs.namespace(|| "val2"), || Ok(Fr::from(700))).unwrap();
+        let selected = AllocatedNum::alloc_infallible(cs.namespace(|| "selected"), || z);
+        let val0 = AllocatedNum::alloc_infallible(cs.namespace(|| "val0"), || Fr::from(666));
+        let val1 = AllocatedNum::alloc_infallible(cs.namespace(|| "val1"), || Fr::from(777));
+        let val2 = AllocatedNum::alloc_infallible(cs.namespace(|| "val2"), || Fr::from(700));
 
         let default_vec = [
-            &AllocatedNum::alloc(cs.namespace(|| "default0"), || Ok(Fr::from(999))).unwrap(),
-            &AllocatedNum::alloc(cs.namespace(|| "default1"), || Ok(Fr::from(998))).unwrap(),
+            &AllocatedNum::alloc_infallible(cs.namespace(|| "default0"), || Fr::from(999)),
+            &AllocatedNum::alloc_infallible(cs.namespace(|| "default1"), || Fr::from(998)),
         ];
 
         let clauses0 = [CaseClause::new(x, &val0), CaseClause::new(x, &val1)];
@@ -534,15 +534,15 @@ mod tests {
         let x = Fr::from(123);
         let y = Fr::from(124);
         let z = Fr::from(125);
-        let selected = AllocatedNum::alloc(cs.namespace(|| "selected"), || Ok(z)).unwrap();
-        let val0 = AllocatedNum::alloc(cs.namespace(|| "val0"), || Ok(Fr::from(666))).unwrap();
-        let val1 = AllocatedNum::alloc(cs.namespace(|| "val1"), || Ok(Fr::from(777))).unwrap();
-        let val2 = AllocatedNum::alloc(cs.namespace(|| "val2"), || Ok(Fr::from(700))).unwrap();
+        let selected = AllocatedNum::alloc_infallible(cs.namespace(|| "selected"), || z);
+        let val0 = AllocatedNum::alloc_infallible(cs.namespace(|| "val0"), || Fr::from(666));
+        let val1 = AllocatedNum::alloc_infallible(cs.namespace(|| "val1"), || Fr::from(777));
+        let val2 = AllocatedNum::alloc_infallible(cs.namespace(|| "val2"), || Fr::from(700));
 
         let default_vec = [
-            &AllocatedNum::alloc(cs.namespace(|| "default0"), || Ok(Fr::from(999))).unwrap(),
-            &AllocatedNum::alloc(cs.namespace(|| "default1"), || Ok(Fr::from(998))).unwrap(),
-            &AllocatedNum::alloc(cs.namespace(|| "default2"), || Ok(Fr::from(997))).unwrap(),
+            &AllocatedNum::alloc_infallible(cs.namespace(|| "default0"), || Fr::from(999)),
+            &AllocatedNum::alloc_infallible(cs.namespace(|| "default1"), || Fr::from(998)),
+            &AllocatedNum::alloc_infallible(cs.namespace(|| "default2"), || Fr::from(997)),
         ];
 
         let clauses0 = [CaseClause::new(x, &val0), CaseClause::new(y, &val1)];
@@ -572,14 +572,14 @@ mod tests {
         let x = Fr::from(123);
         let y = Fr::from(124);
         let z = Fr::from(125);
-        let selected = AllocatedNum::alloc(cs.namespace(|| "selected"), || Ok(z)).unwrap();
-        let val0 = AllocatedNum::alloc(cs.namespace(|| "val0"), || Ok(Fr::from(666))).unwrap();
-        let val1 = AllocatedNum::alloc(cs.namespace(|| "val1"), || Ok(Fr::from(777))).unwrap();
-        let val2 = AllocatedNum::alloc(cs.namespace(|| "val2"), || Ok(Fr::from(700))).unwrap();
+        let selected = AllocatedNum::alloc_infallible(cs.namespace(|| "selected"), || z);
+        let val0 = AllocatedNum::alloc_infallible(cs.namespace(|| "val0"), || Fr::from(666));
+        let val1 = AllocatedNum::alloc_infallible(cs.namespace(|| "val1"), || Fr::from(777));
+        let val2 = AllocatedNum::alloc_infallible(cs.namespace(|| "val2"), || Fr::from(700));
 
         let default_vec = [
-            &AllocatedNum::alloc(cs.namespace(|| "default0"), || Ok(Fr::from(999))).unwrap(),
-            &AllocatedNum::alloc(cs.namespace(|| "default1"), || Ok(Fr::from(998))).unwrap(),
+            &AllocatedNum::alloc_infallible(cs.namespace(|| "default0"), || Fr::from(999)),
+            &AllocatedNum::alloc_infallible(cs.namespace(|| "default1"), || Fr::from(998)),
         ];
 
         let clauses0 = [CaseClause::new(x, &val0), CaseClause::new(y, &val1)];
@@ -611,10 +611,10 @@ mod tests {
         let g = GlobalAllocations::new(&mut cs, s).unwrap();
 
         let x = Fr::from(123);
-        let selected = AllocatedNum::alloc(cs.namespace(|| "selected"), || Ok(x)).unwrap();
+        let selected = AllocatedNum::alloc_infallible(cs.namespace(|| "selected"), || x);
         let default_vec = [
-            &AllocatedNum::alloc(cs.namespace(|| "default0"), || Ok(Fr::from(999))).unwrap(),
-            &AllocatedNum::alloc(cs.namespace(|| "default1"), || Ok(Fr::from(998))).unwrap(),
+            &AllocatedNum::alloc_infallible(cs.namespace(|| "default0"), || Fr::from(999)),
+            &AllocatedNum::alloc_infallible(cs.namespace(|| "default1"), || Fr::from(998)),
         ];
 
         let _ = multi_case(
@@ -637,10 +637,10 @@ mod tests {
 
         let x = Fr::from(123);
         let y = Fr::from(124);
-        let selected = AllocatedNum::alloc(cs.namespace(|| "selected"), || Ok(x)).unwrap();
-        let val0 = AllocatedNum::alloc(cs.namespace(|| "val0"), || Ok(Fr::from(666))).unwrap();
-        let val1 = AllocatedNum::alloc(cs.namespace(|| "val1"), || Ok(Fr::from(777))).unwrap();
-        let val2 = AllocatedNum::alloc(cs.namespace(|| "val2"), || Ok(Fr::from(700))).unwrap();
+        let selected = AllocatedNum::alloc_infallible(cs.namespace(|| "selected"), || x);
+        let val0 = AllocatedNum::alloc_infallible(cs.namespace(|| "val0"), || Fr::from(666));
+        let val1 = AllocatedNum::alloc_infallible(cs.namespace(|| "val1"), || Fr::from(777));
+        let val2 = AllocatedNum::alloc_infallible(cs.namespace(|| "val2"), || Fr::from(700));
         let clauses0 = [CaseClause::new(x, &val0), CaseClause::new(y, &val1)];
         let clauses1 = [
             CaseClause::new(x, &val2),
@@ -670,12 +670,12 @@ mod tests {
 
         let x = Fr::from(123);
         let y = Fr::from(124);
-        let selected = AllocatedNum::alloc(cs.namespace(|| "selected"), || Ok(x)).unwrap();
-        let val0 = AllocatedNum::alloc(cs.namespace(|| "val0"), || Ok(Fr::from(666))).unwrap();
-        let val1 = AllocatedNum::alloc(cs.namespace(|| "val1"), || Ok(Fr::from(777))).unwrap();
+        let selected = AllocatedNum::alloc_infallible(cs.namespace(|| "selected"), || x);
+        let val0 = AllocatedNum::alloc_infallible(cs.namespace(|| "val0"), || Fr::from(666));
+        let val1 = AllocatedNum::alloc_infallible(cs.namespace(|| "val1"), || Fr::from(777));
         let default_vec = [
-            &AllocatedNum::alloc(cs.namespace(|| "default0"), || Ok(Fr::from(999))).unwrap(),
-            &AllocatedNum::alloc(cs.namespace(|| "default1"), || Ok(Fr::from(998))).unwrap(),
+            &AllocatedNum::alloc_infallible(cs.namespace(|| "default0"), || Fr::from(999)),
+            &AllocatedNum::alloc_infallible(cs.namespace(|| "default1"), || Fr::from(998)),
         ];
         let clauses0 = [CaseClause::new(x, &val0), CaseClause::new(y, &val1)];
         let clauses1 = [];
@@ -701,23 +701,23 @@ mod tests {
 
         let x = Fr::from(123);
         let y = Fr::from(124);
-        let selected = AllocatedNum::alloc(cs.namespace(|| "selected"), || Ok(x)).unwrap();
+        let selected = AllocatedNum::alloc_infallible(cs.namespace(|| "selected"), || x);
         let _selected_blank = AllocatedNum::alloc(cs_blank.namespace(|| "selected"), || {
             Err(SynthesisError::AssignmentMissing)
         })
         .unwrap();
-        let val0 = AllocatedNum::alloc(cs.namespace(|| "val0"), || Ok(Fr::from(666))).unwrap();
+        let val0 = AllocatedNum::alloc_infallible(cs.namespace(|| "val0"), || Fr::from(666));
         let val0_blank = AllocatedNum::alloc(cs_blank.namespace(|| "val0"), || {
             Err(SynthesisError::AssignmentMissing)
         })
         .unwrap();
-        let val1 = AllocatedNum::alloc(cs.namespace(|| "val1"), || Ok(Fr::from(777))).unwrap();
+        let val1 = AllocatedNum::alloc_infallible(cs.namespace(|| "val1"), || Fr::from(777));
         let val1_blank = AllocatedNum::alloc(cs_blank.namespace(|| "val1"), || {
             Err(SynthesisError::AssignmentMissing)
         })
         .unwrap();
         let default =
-            AllocatedNum::alloc(cs.namespace(|| "default_v"), || Ok(Fr::from(999))).unwrap();
+            AllocatedNum::alloc_infallible(cs.namespace(|| "default_v"), || Fr::from(999));
         let default_blank = AllocatedNum::alloc(cs_blank.namespace(|| "default_v"), || {
             Err(SynthesisError::AssignmentMissing)
         })

--- a/src/circuit/gadgets/constraints.rs
+++ b/src/circuit/gadgets/constraints.rs
@@ -963,8 +963,8 @@ mod tests {
 
             let test_a_b = |a, b| {
                 let mut cs = TestConstraintSystem::<Fr>::new();
-                let a_num = AllocatedNum::alloc(cs.namespace(|| "a_num"), || Ok(a)).unwrap();
-                let b_num = AllocatedNum::alloc(cs.namespace(|| "b_num"), || Ok(b)).unwrap();
+                let a_num = AllocatedNum::alloc_infallible(cs.namespace(|| "a_num"), || a);
+                let b_num = AllocatedNum::alloc_infallible(cs.namespace(|| "b_num"), || b);
                 enforce_equal(&mut cs, || "enforce equal", &a_num, &b_num);
                 assert_eq!(cs.is_satisfied(), a==b);
             };
@@ -981,7 +981,7 @@ mod tests {
 
             let test_num = |n: u64| {
                 let mut cs = TestConstraintSystem::<Fr>::new();
-                let num = AllocatedNum::alloc(cs.namespace(|| "zero"), || Ok(Fr::from(n))).unwrap();
+                let num = AllocatedNum::alloc_infallible(cs.namespace(|| "zero"), || Fr::from(n));
                 enforce_equal_zero(&mut cs, || "enforce equal zero", &num);
                 assert_eq!(cs.is_satisfied(), n==0);
 
@@ -1005,7 +1005,7 @@ mod tests {
 
             let test_premise_num = |premise: bool, n| -> bool  {
                 let mut cs = TestConstraintSystem::<Fr>::new();
-                let num = AllocatedNum::alloc(cs.namespace(|| "num"), || Ok(Fr::from(n))).unwrap();
+                let num = AllocatedNum::alloc_infallible(cs.namespace(|| "num"), || Fr::from(n));
                 let pb = Boolean::constant(premise);
                 implies_equal_zero(&mut cs.namespace(|| "implies equal zero"), &pb, &num);
                 cs.is_satisfied()
@@ -1021,8 +1021,8 @@ mod tests {
         ]) {
             let test_a_b = |premise: bool, a, b| -> bool {
                 let mut cs = TestConstraintSystem::<Fr>::new();
-                let a_num = AllocatedNum::alloc(cs.namespace(|| "a_num"), || Ok(a)).unwrap();
-                let b_num = AllocatedNum::alloc(cs.namespace(|| "b_num"), || Ok(b)).unwrap();
+                let a_num = AllocatedNum::alloc_infallible(cs.namespace(|| "a_num"), || a);
+                let b_num = AllocatedNum::alloc_infallible(cs.namespace(|| "b_num"), || b);
                 let pb = Boolean::constant(premise);
                 implies_equal(&mut cs.namespace(|| "implies equal"), &pb, &a_num, &b_num);
                 cs.is_satisfied()
@@ -1038,8 +1038,8 @@ mod tests {
         ]) {
             let test_a_b = |premise: bool, a, b| -> bool{
                 let mut cs = TestConstraintSystem::<Fr>::new();
-                let a_num = AllocatedNum::alloc(cs.namespace(|| "a_num"), || Ok(a)).unwrap();
-                let b_num = AllocatedNum::alloc(cs.namespace(|| "b_num"), || Ok(b)).unwrap();
+                let a_num = AllocatedNum::alloc_infallible(cs.namespace(|| "a_num"), || a);
+                let b_num = AllocatedNum::alloc_infallible(cs.namespace(|| "b_num"), || b);
                 let pb = Boolean::constant(premise);
                 let _ = implies_unequal(&mut cs.namespace(|| "implies equal"), &pb, &a_num, &b_num);
                 cs.is_satisfied()
@@ -1057,7 +1057,7 @@ mod tests {
 
             let test_premise_unequal = |premise: bool, n, t| -> bool  {
                 let mut cs = TestConstraintSystem::<Fr>::new();
-                let num = AllocatedNum::alloc(cs.namespace(|| "num"), || Ok(n)).unwrap();
+                let num = AllocatedNum::alloc_infallible(cs.namespace(|| "num"), || n);
                 let pb = Boolean::constant(premise);
                 let _ = implies_unequal_const(&mut cs.namespace(|| "implies equal zero"), &pb, &num, t);
                 cs.is_satisfied()
@@ -1076,7 +1076,7 @@ mod tests {
 
             let test_premise_equal = |premise: bool, n, t| -> bool  {
                 let mut cs = TestConstraintSystem::<Fr>::new();
-                let num = AllocatedNum::alloc(cs.namespace(|| "num"), || Ok(n)).unwrap();
+                let num = AllocatedNum::alloc_infallible(cs.namespace(|| "num"), || n);
                 let pb = Boolean::constant(premise);
                 implies_equal_const(&mut cs.namespace(|| "implies equal zero"), &pb, &num, t);
                 cs.is_satisfied()
@@ -1209,7 +1209,7 @@ mod tests {
         fn prop_alloc_equal_const((x, y) in any::<(FWrap<Fr>, FWrap<Fr>)>()) {
             let mut cs = TestConstraintSystem::<Fr>::new();
 
-            let a = AllocatedNum::alloc(&mut cs.namespace(|| "a"), || Ok(x.0)).unwrap();
+            let a = AllocatedNum::alloc_infallible(&mut cs.namespace(|| "a"), || x.0);
 
             let equal =
                 alloc_equal_const(&mut cs.namespace(|| "alloc_equal_const"), &a, x.0).unwrap();
@@ -1473,7 +1473,7 @@ mod tests {
         fn test_implies_u64(f in any::<FWrap<Fr>>()) {
             let mut cs = TestConstraintSystem::<Fr>::new();
 
-            let num = AllocatedNum::alloc(cs.namespace(|| "num"), || Ok(f.0)).unwrap();
+            let num = AllocatedNum::alloc_infallible(cs.namespace(|| "num"), || f.0);
 
             let t = Boolean::Constant(true);
             implies_u64(&mut cs.namespace(|| "enforce u64"), &t, &num).unwrap();

--- a/src/circuit/gadgets/pointer.rs
+++ b/src/circuit/gadgets/pointer.rs
@@ -288,8 +288,8 @@ impl<F: LurkField> AllocatedPtr<F> {
     ) -> Result<Self, SynthesisError> {
         let [tag, hash] = t.into_hash_components();
 
-        let tag = AllocatedNum::alloc(&mut cs.namespace(|| "tag"), || Ok(tag))?;
-        let hash = AllocatedNum::alloc(&mut cs.namespace(|| "hash"), || Ok(hash))?;
+        let tag = AllocatedNum::alloc_infallible(&mut cs.namespace(|| "tag"), || tag);
+        let hash = AllocatedNum::alloc_infallible(&mut cs.namespace(|| "hash"), || hash);
 
         Ok(Self { tag, hash })
     }

--- a/src/lem/circuit.rs
+++ b/src/lem/circuit.rs
@@ -839,10 +839,12 @@ impl Func {
                                 }
                             })
                         });
-                        let div =
-                            AllocatedNum::alloc(cs.namespace(|| "div"), || Ok(div_rem.unwrap().0))?;
-                        let rem =
-                            AllocatedNum::alloc(cs.namespace(|| "rem"), || Ok(div_rem.unwrap().1))?;
+                        let div = AllocatedNum::alloc_infallible(cs.namespace(|| "div"), || {
+                            div_rem.unwrap().0
+                        });
+                        let rem = AllocatedNum::alloc_infallible(cs.namespace(|| "rem"), || {
+                            div_rem.unwrap().1
+                        });
 
                         let diff = sub(cs.namespace(|| "diff for slot {slot}"), b, &rem)?;
                         implies_u64(cs.namespace(|| "div_u64"), not_dummy, &div)?;

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -352,7 +352,7 @@ impl<'a, F: LurkField, C: Coprocessor<F>> MultiFrame<'a, F, C> {
         let mut bogus_cs = WitnessCS::<F>::new();
         let z: Vec<AllocatedNum<F>> = z_scalar
             .iter()
-            .map(|x| AllocatedNum::alloc(&mut bogus_cs, || Ok(*x)).unwrap())
+            .map(|x| AllocatedNum::alloc_infallible(&mut bogus_cs, || *x))
             .collect::<Vec<_>>();
 
         let _ = self.clone().synthesize(&mut wcs, z.as_slice());
@@ -393,7 +393,7 @@ impl<'a, F: LurkField, C: Coprocessor<F>> StepCircuit<F> for MultiFrame<'a, F, C
 
                     scalars
                         .iter()
-                        .map(|scalar| AllocatedNum::alloc(&mut bogus_cs, || Ok(*scalar)).unwrap())
+                        .map(|scalar| AllocatedNum::alloc_infallible(&mut bogus_cs, || *scalar))
                         .collect::<Vec<_>>()
                 };
 


### PR DESCRIPTION
- Replaced `AllocatedNum::alloc` with `AllocatedNum::alloc_infallible` throughout multiple files to simplify error handling and make code less verbose.