### PR TITLE
chore: fix GitHub nbightly action with submodule handling

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,6 +33,8 @@ jobs:
       RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Install dependencies
         run: sudo apt-get install -y pkg-config libssl-dev
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
- Implemented the inclusion of submodules in the GitHub workflow checkout step.
- FIxes #708