### PR TITLE
NIVC implementation for LEM

### DIFF
--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -6,42 +6,28 @@
 //! Note: The example [example/sha256_ivc.rs] is this same benchmark but as an example
 //! that's easier to play with and run.
 
-use lurk::circuit::circuit_frame::MultiFrame;
-use lurk::circuit::gadgets::data::GlobalAllocations;
-use lurk::proof::supernova::SuperNovaProver;
-use lurk::public_parameters::instance::{Instance, Kind};
-use lurk::public_parameters::supernova_public_params;
-use lurk::state::user_sym;
-use lurk::{circuit::gadgets::pointer::AllocatedContPtr, tag::Tag};
-use std::{cell::RefCell, marker::PhantomData, rc::Rc, sync::Arc, time::Duration};
-
-use bellpepper::gadgets::{multipack::pack_bits, sha256::sha256};
-use bellpepper_core::{boolean::Boolean, ConstraintSystem, SynthesisError};
 use camino::Utf8Path;
 use criterion::{
     black_box, criterion_group, criterion_main, measurement, BatchSize, BenchmarkGroup,
     BenchmarkId, Criterion, SamplingMode,
 };
-
-use lurk_macros::Coproc;
 use pasta_curves::pallas::Scalar as Fr;
+use std::{cell::RefCell, rc::Rc, sync::Arc, time::Duration};
 
 use lurk::{
-    circuit::gadgets::pointer::AllocatedPtr,
-    coprocessor::{CoCircuit, Coprocessor},
+    circuit::circuit_frame::MultiFrame,
+    coprocessor::sha256::{Sha256Coproc, Sha256Coprocessor},
     eval::{empty_sym_env, lang::Lang},
     field::LurkField,
-    proof::nova::NovaProver,
-    proof::Prover,
+    proof::{nova::NovaProver, supernova::SuperNovaProver, Prover},
     ptr::Ptr,
-    public_parameters::public_params,
-    state::State,
+    public_parameters::{
+        instance::{Instance, Kind},
+        public_params, supernova_public_params,
+    },
+    state::{user_sym, State},
     store::Store,
-    tag::ExprTag,
-    Num,
 };
-use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 
 const PUBLIC_PARAMS_PATH: &str = "/var/tmp/lurk_benches/public_params";
 
@@ -80,114 +66,6 @@ fn sha256_ivc<F: LurkField>(
     );
 
     store.read_with_state(state, &program).unwrap()
-}
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct Sha256Coprocessor<F: LurkField> {
-    arity: usize,
-    pub(crate) _p: PhantomData<F>,
-}
-
-impl<F: LurkField> CoCircuit<F> for Sha256Coprocessor<F> {
-    fn arity(&self) -> usize {
-        self.arity
-    }
-
-    fn synthesize<CS: ConstraintSystem<F>>(
-        &self,
-        cs: &mut CS,
-        _g: &GlobalAllocations<F>,
-        _store: &Store<F>,
-        input_exprs: &[AllocatedPtr<F>],
-        input_env: &AllocatedPtr<F>,
-        input_cont: &AllocatedContPtr<F>,
-    ) -> Result<(AllocatedPtr<F>, AllocatedPtr<F>, AllocatedContPtr<F>), SynthesisError> {
-        let zero = Boolean::constant(false);
-
-        let mut bits = vec![];
-
-        // println!("{:?}", input_exprs);
-
-        for input_ptr in input_exprs {
-            let tag_bits = input_ptr
-                .tag()
-                .to_bits_le_strict(&mut cs.namespace(|| "preimage_tag_bits"))?;
-            let hash_bits = input_ptr
-                .hash()
-                .to_bits_le_strict(&mut cs.namespace(|| "preimage_hash_bits"))?;
-
-            bits.extend(tag_bits);
-            bits.push(zero.clone()); // need 256 bits (or some multiple of 8).
-            bits.extend(hash_bits);
-            bits.push(zero.clone()); // need 256 bits (or some multiple of 8).
-        }
-
-        bits.reverse();
-
-        let mut digest_bits = sha256(cs.namespace(|| "digest_bits"), &bits)?;
-
-        digest_bits.reverse();
-
-        // Fine to lose the last <1 bit of precision.
-        let digest_scalar = pack_bits(cs.namespace(|| "digest_scalar"), &digest_bits)?;
-        let output_expr = AllocatedPtr::alloc_tag(
-            &mut cs.namespace(|| "output_expr"),
-            ExprTag::Num.to_field(),
-            digest_scalar,
-        )?;
-        Ok((output_expr, input_env.clone(), input_cont.clone()))
-    }
-}
-
-impl<F: LurkField> Coprocessor<F> for Sha256Coprocessor<F> {
-    fn eval_arity(&self) -> usize {
-        self.arity
-    }
-
-    fn simple_evaluate(&self, s: &Store<F>, args: &[Ptr<F>]) -> Ptr<F> {
-        let mut hasher = <Sha256 as sha2::Digest>::new();
-
-        let mut input = vec![0u8; 64 * self.arity];
-
-        for (i, input_ptr) in args.iter().enumerate() {
-            let input_zptr = s.hash_expr(input_ptr).unwrap();
-            let tag_zptr: F = input_zptr.tag().to_field();
-            let hash_zptr = input_zptr.value();
-            input[(64 * i)..(64 * i + 32)].copy_from_slice(&tag_zptr.to_bytes());
-            input[(64 * i + 32)..(64 * (i + 1))].copy_from_slice(&hash_zptr.to_bytes());
-        }
-
-        input.reverse();
-
-        hasher.update(input);
-        let mut bytes = hasher.finalize();
-        bytes.reverse();
-        let l = bytes.len();
-        // Discard the two most significant bits.
-        bytes[l - 1] &= 0b00111111;
-
-        let scalar = F::from_bytes(&bytes).unwrap();
-        let result = Num::from_scalar(scalar);
-
-        s.intern_num(result)
-    }
-
-    fn has_circuit(&self) -> bool {
-        true
-    }
-}
-
-impl<F: LurkField> Sha256Coprocessor<F> {
-    pub(crate) fn new(arity: usize) -> Self {
-        Self {
-            arity,
-            _p: Default::default(),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Coproc, Serialize, Deserialize)]
-enum Sha256Coproc<F: LurkField> {
-    SC(Sha256Coprocessor<F>),
 }
 
 struct ProveParams {

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -109,7 +109,12 @@ fn sha256_ivc_prove<M: measurement::Measurement>(
 
     // use cached public params
 
-    let instance: Instance<pasta_curves::Fq, Sha256Coproc<pasta_curves::Fq>> = Instance::new(
+    let instance: Instance<
+        '_,
+        pasta_curves::Fq,
+        Sha256Coproc<pasta_curves::Fq>,
+        MultiFrame<'_, _, _>,
+    > = Instance::new(
         reduction_count,
         lang_rc.clone(),
         true,

--- a/examples/sha256_ivc.rs
+++ b/examples/sha256_ivc.rs
@@ -1,33 +1,22 @@
-use std::marker::PhantomData;
-use std::sync::Arc;
-use std::time::Instant;
-
-use lurk::circuit::circuit_frame::MultiFrame;
-use lurk::circuit::gadgets::data::GlobalAllocations;
-use lurk::circuit::gadgets::pointer::{AllocatedContPtr, AllocatedPtr};
-use lurk::coprocessor::{CoCircuit, Coprocessor};
-use lurk::eval::{empty_sym_env, lang::Lang};
-use lurk::field::LurkField;
-use lurk::proof::{nova::NovaProver, Prover};
-use lurk::ptr::Ptr;
-use lurk::public_parameters::instance::{Instance, Kind};
-use lurk::public_parameters::{public_params, public_params_default_dir};
-use lurk::state::user_sym;
-use lurk::store::Store;
-use lurk::tag::{ExprTag, Tag};
-use lurk::Num;
-use lurk_macros::Coproc;
-
-use bellpepper::gadgets::multipack::pack_bits;
-use bellpepper::gadgets::sha256::sha256;
-use bellpepper_core::boolean::Boolean;
-use bellpepper_core::{ConstraintSystem, SynthesisError};
-
 use pasta_curves::pallas::Scalar as Fr;
-use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
+use std::{sync::Arc, time::Instant};
 use tracing_subscriber::{fmt, prelude::*, EnvFilter, Registry};
 use tracing_texray::TeXRayLayer;
+
+use lurk::{
+    circuit::circuit_frame::MultiFrame,
+    coprocessor::sha256::{Sha256Coproc, Sha256Coprocessor},
+    eval::{empty_sym_env, lang::Lang},
+    field::LurkField,
+    proof::{nova::NovaProver, Prover},
+    ptr::Ptr,
+    public_parameters::{
+        instance::{Instance, Kind},
+        public_params, public_params_default_dir,
+    },
+    state::user_sym,
+    store::Store,
+};
 
 const REDUCTION_COUNT: usize = 10;
 
@@ -60,115 +49,6 @@ fn sha256_ivc<F: LurkField>(store: &Store<F>, n: usize, input: Vec<usize>) -> Pt
     );
 
     store.read(&program).unwrap()
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct Sha256Coprocessor<F: LurkField> {
-    n: usize,
-    pub(crate) _p: PhantomData<F>,
-}
-
-impl<F: LurkField> CoCircuit<F> for Sha256Coprocessor<F> {
-    fn arity(&self) -> usize {
-        self.n
-    }
-
-    fn synthesize<CS: ConstraintSystem<F>>(
-        &self,
-        cs: &mut CS,
-        _g: &GlobalAllocations<F>,
-        _store: &Store<F>,
-        input_exprs: &[AllocatedPtr<F>],
-        input_env: &AllocatedPtr<F>,
-        input_cont: &AllocatedContPtr<F>,
-    ) -> Result<(AllocatedPtr<F>, AllocatedPtr<F>, AllocatedContPtr<F>), SynthesisError> {
-        let zero = Boolean::constant(false);
-
-        let mut bits = vec![];
-
-        // println!("{:?}", input_exprs);
-
-        for input_ptr in input_exprs {
-            let tag_bits = input_ptr
-                .tag()
-                .to_bits_le_strict(&mut cs.namespace(|| "preimage_tag_bits"))?;
-            let hash_bits = input_ptr
-                .hash()
-                .to_bits_le_strict(&mut cs.namespace(|| "preimage_hash_bits"))?;
-
-            bits.extend(tag_bits);
-            bits.push(zero.clone()); // need 256 bits (or some multiple of 8).
-            bits.extend(hash_bits);
-            bits.push(zero.clone()); // need 256 bits (or some multiple of 8).
-        }
-
-        bits.reverse();
-
-        let mut digest_bits = sha256(cs.namespace(|| "digest_bits"), &bits)?;
-
-        digest_bits.reverse();
-
-        // Fine to lose the last <1 bit of precision.
-        let digest_scalar = pack_bits(cs.namespace(|| "digest_scalar"), &digest_bits)?;
-        let output_expr = AllocatedPtr::alloc_tag(
-            &mut cs.namespace(|| "output_expr"),
-            ExprTag::Num.to_field(),
-            digest_scalar,
-        )?;
-        Ok((output_expr, input_env.clone(), input_cont.clone()))
-    }
-}
-
-impl<F: LurkField> Coprocessor<F> for Sha256Coprocessor<F> {
-    fn eval_arity(&self) -> usize {
-        self.n
-    }
-
-    fn simple_evaluate(&self, s: &Store<F>, args: &[Ptr<F>]) -> Ptr<F> {
-        let mut hasher = Sha256::new();
-
-        let mut input = vec![0u8; 64 * self.n];
-
-        for (i, input_ptr) in args.iter().enumerate() {
-            let input_zptr = s.hash_expr(input_ptr).unwrap();
-            let tag_zptr: F = input_zptr.tag().to_field();
-            let hash_zptr = input_zptr.value();
-            input[(64 * i)..(64 * i + 32)].copy_from_slice(&tag_zptr.to_bytes());
-            input[(64 * i + 32)..(64 * (i + 1))].copy_from_slice(&hash_zptr.to_bytes());
-        }
-
-        input.reverse();
-
-        hasher.update(input);
-        let mut bytes = hasher.finalize();
-        bytes.reverse();
-        let l = bytes.len();
-        // Discard the two most significant bits.
-        bytes[l - 1] &= 0b00111111;
-
-        let scalar = F::from_bytes(&bytes).unwrap();
-        let result = Num::from_scalar(scalar);
-
-        s.intern_num(result)
-    }
-
-    fn has_circuit(&self) -> bool {
-        true
-    }
-}
-
-impl<F: LurkField> Sha256Coprocessor<F> {
-    pub(crate) fn new(n: usize) -> Self {
-        Self {
-            n,
-            _p: Default::default(),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Coproc, Serialize, Deserialize)]
-enum Sha256Coproc<F: LurkField> {
-    SC(Sha256Coprocessor<F>),
 }
 
 /// Run the example in this file with

--- a/examples/sha256_nivc.rs
+++ b/examples/sha256_nivc.rs
@@ -120,7 +120,7 @@ fn main() {
 
     if res {
         println!(
-            "Congratulations! You proved and verified a SHA256 hash calculation in {:?} time!",
+            "Congratulations! You proved and verified a NIVC SHA256 hash calculation in {:?} time!",
             pp_end + proof_end + verify_end
         );
     }

--- a/examples/sha256_nivc.rs
+++ b/examples/sha256_nivc.rs
@@ -1,34 +1,22 @@
-use std::marker::PhantomData;
-use std::sync::Arc;
-use std::time::Instant;
-
-use lurk::circuit::circuit_frame::MultiFrame;
-use lurk::circuit::gadgets::data::GlobalAllocations;
-use lurk::circuit::gadgets::pointer::{AllocatedContPtr, AllocatedPtr};
-use lurk::coprocessor::{CoCircuit, Coprocessor};
-use lurk::eval::{empty_sym_env, lang::Lang};
-use lurk::field::LurkField;
-use lurk::proof::{supernova::SuperNovaProver, Prover};
-use lurk::ptr::Ptr;
-
-use lurk::public_parameters::instance::{Instance, Kind};
-use lurk::public_parameters::{public_params_default_dir, supernova_public_params};
-use lurk::state::user_sym;
-use lurk::store::Store;
-use lurk::tag::{ExprTag, Tag};
-use lurk::Num;
-use lurk_macros::Coproc;
-
-use bellpepper::gadgets::multipack::pack_bits;
-use bellpepper::gadgets::sha256::sha256;
-use bellpepper_core::boolean::Boolean;
-use bellpepper_core::{ConstraintSystem, SynthesisError};
-
 use pasta_curves::pallas::Scalar as Fr;
-use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
+use std::{sync::Arc, time::Instant};
 use tracing_subscriber::{fmt, prelude::*, EnvFilter, Registry};
 use tracing_texray::TeXRayLayer;
+
+use lurk::{
+    circuit::circuit_frame::MultiFrame,
+    coprocessor::sha256::{Sha256Coproc, Sha256Coprocessor},
+    eval::{empty_sym_env, lang::Lang},
+    field::LurkField,
+    proof::{supernova::SuperNovaProver, Prover},
+    ptr::Ptr,
+    public_parameters::{
+        instance::{Instance, Kind},
+        public_params_default_dir, supernova_public_params,
+    },
+    state::user_sym,
+    store::Store,
+};
 
 const REDUCTION_COUNT: usize = 10;
 
@@ -61,115 +49,6 @@ fn sha256_nivc<F: LurkField>(store: &mut Store<F>, n: usize, input: Vec<usize>) 
     );
 
     store.read(&program).unwrap()
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct Sha256Coprocessor<F: LurkField> {
-    n: usize,
-    pub(crate) _p: PhantomData<F>,
-}
-
-impl<F: LurkField> CoCircuit<F> for Sha256Coprocessor<F> {
-    fn arity(&self) -> usize {
-        self.n
-    }
-
-    fn synthesize<CS: ConstraintSystem<F>>(
-        &self,
-        cs: &mut CS,
-        _g: &GlobalAllocations<F>,
-        _store: &Store<F>,
-        input_exprs: &[AllocatedPtr<F>],
-        input_env: &AllocatedPtr<F>,
-        input_cont: &AllocatedContPtr<F>,
-    ) -> Result<(AllocatedPtr<F>, AllocatedPtr<F>, AllocatedContPtr<F>), SynthesisError> {
-        let zero = Boolean::constant(false);
-
-        let mut bits = vec![];
-
-        // println!("{:?}", input_exprs);
-
-        for input_ptr in input_exprs {
-            let tag_bits = input_ptr
-                .tag()
-                .to_bits_le_strict(&mut cs.namespace(|| "preimage_tag_bits"))?;
-            let hash_bits = input_ptr
-                .hash()
-                .to_bits_le_strict(&mut cs.namespace(|| "preimage_hash_bits"))?;
-
-            bits.extend(tag_bits);
-            bits.push(zero.clone()); // need 256 bits (or some multiple of 8).
-            bits.extend(hash_bits);
-            bits.push(zero.clone()); // need 256 bits (or some multiple of 8).
-        }
-
-        bits.reverse();
-
-        let mut digest_bits = sha256(cs.namespace(|| "digest_bits"), &bits)?;
-
-        digest_bits.reverse();
-
-        // Fine to lose the last <1 bit of precision.
-        let digest_scalar = pack_bits(cs.namespace(|| "digest_scalar"), &digest_bits)?;
-        let output_expr = AllocatedPtr::alloc_tag(
-            &mut cs.namespace(|| "output_expr"),
-            ExprTag::Num.to_field(),
-            digest_scalar,
-        )?;
-        Ok((output_expr, input_env.clone(), input_cont.clone()))
-    }
-}
-
-impl<F: LurkField> Coprocessor<F> for Sha256Coprocessor<F> {
-    fn eval_arity(&self) -> usize {
-        self.n
-    }
-
-    fn simple_evaluate(&self, s: &Store<F>, args: &[Ptr<F>]) -> Ptr<F> {
-        let mut hasher = Sha256::new();
-
-        let mut input = vec![0u8; 64 * self.n];
-
-        for (i, input_ptr) in args.iter().enumerate() {
-            let input_zptr = s.hash_expr(input_ptr).unwrap();
-            let tag_zptr: F = input_zptr.tag().to_field();
-            let hash_zptr = input_zptr.value();
-            input[(64 * i)..(64 * i + 32)].copy_from_slice(&tag_zptr.to_bytes());
-            input[(64 * i + 32)..(64 * (i + 1))].copy_from_slice(&hash_zptr.to_bytes());
-        }
-
-        input.reverse();
-
-        hasher.update(input);
-        let mut bytes = hasher.finalize();
-        bytes.reverse();
-        let l = bytes.len();
-        // Discard the two most significant bits.
-        bytes[l - 1] &= 0b00111111;
-
-        let scalar = F::from_bytes(&bytes).unwrap();
-        let result = Num::from_scalar(scalar);
-
-        s.intern_num(result)
-    }
-
-    fn has_circuit(&self) -> bool {
-        true
-    }
-}
-
-impl<F: LurkField> Sha256Coprocessor<F> {
-    pub(crate) fn new(n: usize) -> Self {
-        Self {
-            n,
-            _p: Default::default(),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Coproc, Serialize, Deserialize)]
-enum Sha256Coproc<F: LurkField> {
-    SC(Sha256Coprocessor<F>),
 }
 
 /// Run the example in this file with

--- a/examples/sha256_nivc_lem.rs
+++ b/examples/sha256_nivc_lem.rs
@@ -126,7 +126,7 @@ fn main() {
 
     if res {
         println!(
-            "Congratulations! You proved and verified a SHA256 hash calculation in {:?} time!",
+            "Congratulations! You proved and verified a LEM NIVC SHA256 hash calculation in {:?} time!",
             pp_end + proof_end + verify_end
         );
     }

--- a/examples/sha256_nivc_lem.rs
+++ b/examples/sha256_nivc_lem.rs
@@ -1,0 +1,133 @@
+use pasta_curves::pallas::Scalar as Fr;
+use std::{sync::Arc, time::Instant};
+use tracing_subscriber::{fmt, prelude::*, EnvFilter, Registry};
+use tracing_texray::TeXRayLayer;
+
+use lurk::{
+    coprocessor::sha256::Sha256Coprocessor,
+    eval::lang::Lang,
+    field::LurkField,
+    lem::{
+        eval::{evaluate, make_eval_step_from_lang},
+        multiframe::MultiFrame,
+        pointers::Ptr,
+        store::Store,
+    },
+    proof::{supernova::SuperNovaProver, Prover},
+    public_parameters::{
+        instance::{Instance, Kind},
+        public_params_default_dir, supernova_public_params,
+    },
+    state::user_sym,
+};
+
+const REDUCTION_COUNT: usize = 10;
+
+fn sha256_nivc<F: LurkField>(store: &Store<F>, n: usize, input: Vec<usize>) -> Ptr<F> {
+    assert_eq!(n, input.len());
+    let input = input
+        .iter()
+        .map(|i| i.to_string())
+        .collect::<Vec<String>>()
+        .join(" ");
+    let input = format!("({})", input);
+    let program = format!(
+        r#"
+(letrec ((encode-1 (lambda (term) 
+            (let ((type (car term))
+                  (value (cdr term)))
+                (if (eq 'sha256 type)
+                    (eval (cons 'sha256_nivc_{n} value))
+                    (if (eq 'lurk type)
+                        (commit value)
+                        (if (eq 'id type)
+                            value))))))
+      (encode (lambda (input)
+                (if input
+                    (cons 
+                        (encode-1 (car input))
+                        (encode (cdr input)))))))
+  (encode '((sha256 . {input}))))
+"#
+    );
+
+    store.read_with_default_state(&program).unwrap()
+}
+
+/// Run the example in this file with
+/// `cargo run --release --example sha256_nivc_lem <n>`
+/// where `n` is the needed arity (default is 1)
+fn main() {
+    let subscriber = Registry::default()
+        .with(fmt::layer().pretty())
+        .with(EnvFilter::from_default_env())
+        .with(TeXRayLayer::new());
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+
+    let args = std::env::args().collect::<Vec<_>>();
+    let n = args.get(1).unwrap_or(&"1".into()).parse().unwrap();
+
+    let store = &Store::<Fr>::default();
+    let cproc_sym = user_sym(&format!("sha256_nivc_{n}"));
+
+    let call = sha256_nivc(store, n, (0..n).collect());
+
+    let mut lang = Lang::<Fr, Sha256Coprocessor<Fr>>::new();
+    lang.add_coprocessor_lem(cproc_sym, Sha256Coprocessor::new(n), store);
+    let lang_rc = Arc::new(lang.clone());
+
+    let lurk_step = make_eval_step_from_lang(&lang, false);
+    let (frames, _) = evaluate(Some((&lurk_step, &lang)), call, store, 1000).unwrap();
+
+    let supernova_prover = SuperNovaProver::<Fr, Sha256Coprocessor<Fr>, MultiFrame<'_, _, _>>::new(
+        REDUCTION_COUNT,
+        lang,
+    );
+
+    println!("Setting up running claim parameters (rc = {REDUCTION_COUNT})...");
+    let pp_start = Instant::now();
+
+    let instance_primary = Instance::new(
+        REDUCTION_COUNT,
+        lang_rc.clone(),
+        true,
+        Kind::SuperNovaAuxParams,
+    );
+    let pp = supernova_public_params::<_, _, MultiFrame<'_, _, _>>(
+        &instance_primary,
+        &public_params_default_dir(),
+    )
+    .unwrap();
+
+    let pp_end = pp_start.elapsed();
+    println!("Running claim parameters took {:?}", pp_end);
+
+    println!("Beginning proof step...");
+    let proof_start = Instant::now();
+    let (proof, z0, zi, num_steps, last_circuit_index) =
+        tracing_texray::examine(tracing::info_span!("bang!")).in_scope(|| {
+            supernova_prover
+                .prove(&pp, &frames, store, lang_rc)
+                .unwrap()
+        });
+    let proof_end = proof_start.elapsed();
+
+    println!("Proofs took {:?}", proof_end);
+
+    println!("Verifying proof...");
+
+    let verify_start = Instant::now();
+    let res = proof
+        .verify(&pp, last_circuit_index, num_steps, &z0, &zi)
+        .unwrap();
+    let verify_end = verify_start.elapsed();
+
+    println!("Verify took {:?}", verify_end);
+
+    if res {
+        println!(
+            "Congratulations! You proved and verified a SHA256 hash calculation in {:?} time!",
+            pp_end + proof_end + verify_end
+        );
+    }
+}

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -244,7 +244,7 @@ impl<'a, F: LurkField, C: Coprocessor<F> + 'a> MultiFrameTrait<'a, F, C> for Mul
         ))
     }
 
-    fn blank(folding_config: Arc<FoldingConfig<F, C>>, meta: Meta<F>) -> Self {
+    fn blank(folding_config: Arc<FoldingConfig<F, C>>, meta: Meta<F>, _pc: usize) -> Self {
         MultiFrame::blank(folding_config, meta)
     }
 

--- a/src/cli/lurk_proof.rs
+++ b/src/cli/lurk_proof.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
-use ::nova::traits::Group;
+use ::nova::{
+    supernova::NonUniformCircuit,
+    traits::{circuit_supernova::StepCircuit as SuperStepCircuit, Group},
+};
 use abomonation::Abomonation;
 use anyhow::Result;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -11,6 +14,7 @@ use crate::{
     field::LurkField,
     proof::{
         nova::{self, CurveCycleEquipped, G1, G2},
+        supernova::C2,
         MultiFrameTrait,
     },
     public_parameters::{
@@ -109,7 +113,10 @@ where
 
 impl<
         F: CurveCycleEquipped + DeserializeOwned,
-        M: MultiFrameTrait<'static, F, Coproc<F>> + 'static,
+        M: MultiFrameTrait<'static, F, Coproc<F>>
+            + SuperStepCircuit<F>
+            + NonUniformCircuit<G1<F>, G2<F>, M, C2<F>>
+            + 'static,
     > LurkProof<'static, F, Coproc<F>, M>
 where
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -16,6 +16,7 @@ use crate::tag::Tag;
 use crate::z_data::z_ptr::ZExprPtr;
 
 pub mod circom;
+pub mod sha256;
 pub mod trie;
 
 /// `Coprocessor` is a trait that represents a generalized interface for coprocessors.

--- a/src/coprocessor/sha256.rs
+++ b/src/coprocessor/sha256.rs
@@ -12,10 +12,12 @@ use crate::{
         pointer::{AllocatedContPtr, AllocatedPtr},
     },
     field::LurkField,
+    lem::{pointers::Ptr as LEMPtr, store::Store as LEMStore},
     num::Num,
     ptr::Ptr,
     store::Store,
     tag::{ExprTag, Tag},
+    z_ptr::ZPtr,
 };
 
 use super::{CoCircuit, Coprocessor};
@@ -24,6 +26,67 @@ use super::{CoCircuit, Coprocessor};
 pub struct Sha256Coprocessor<F: LurkField> {
     n: usize,
     pub(crate) _p: PhantomData<F>,
+}
+
+fn synthesize_sha256<F: LurkField, CS: ConstraintSystem<F>>(
+    cs: &mut CS,
+    ptrs: &[AllocatedPtr<F>],
+) -> Result<AllocatedPtr<F>, SynthesisError> {
+    let zero = Boolean::constant(false);
+
+    let mut bits = vec![];
+
+    for ptr in ptrs {
+        let tag_bits = ptr
+            .tag()
+            .to_bits_le_strict(&mut cs.namespace(|| "preimage_tag_bits"))?;
+        let hash_bits = ptr
+            .hash()
+            .to_bits_le_strict(&mut cs.namespace(|| "preimage_hash_bits"))?;
+
+        bits.extend(tag_bits);
+        bits.push(zero.clone()); // need 256 bits (or some multiple of 8).
+        bits.extend(hash_bits);
+        bits.push(zero.clone()); // need 256 bits (or some multiple of 8).
+    }
+
+    bits.reverse();
+
+    let mut digest_bits = sha256(cs.namespace(|| "digest_bits"), &bits)?;
+
+    digest_bits.reverse();
+
+    // Fine to lose the last <1 bit of precision.
+    let digest_scalar = pack_bits(cs.namespace(|| "digest_scalar"), &digest_bits)?;
+    AllocatedPtr::alloc_tag(
+        &mut cs.namespace(|| "output_expr"),
+        ExprTag::Num.to_field(),
+        digest_scalar,
+    )
+}
+
+fn compute_sha256<F: LurkField, T: Tag>(n: usize, z_ptrs: &[ZPtr<T, F>]) -> F {
+    let mut hasher = Sha256::new();
+
+    let mut input = vec![0u8; 64 * n];
+
+    for (i, z_ptr) in z_ptrs.iter().enumerate() {
+        let tag_zptr: F = z_ptr.tag().to_field();
+        let hash_zptr = z_ptr.value();
+        input[(64 * i)..(64 * i + 32)].copy_from_slice(&tag_zptr.to_bytes());
+        input[(64 * i + 32)..(64 * (i + 1))].copy_from_slice(&hash_zptr.to_bytes());
+    }
+
+    input.reverse();
+
+    hasher.update(input);
+    let mut bytes = hasher.finalize();
+    bytes.reverse();
+    let l = bytes.len();
+    // Discard the two most significant bits.
+    bytes[l - 1] &= 0b00111111;
+
+    F::from_bytes(&bytes).unwrap()
 }
 
 impl<F: LurkField> CoCircuit<F> for Sha256Coprocessor<F> {
@@ -40,38 +103,23 @@ impl<F: LurkField> CoCircuit<F> for Sha256Coprocessor<F> {
         input_env: &AllocatedPtr<F>,
         input_cont: &AllocatedContPtr<F>,
     ) -> Result<(AllocatedPtr<F>, AllocatedPtr<F>, AllocatedContPtr<F>), SynthesisError> {
-        let zero = Boolean::constant(false);
+        Ok((
+            synthesize_sha256(cs, input_exprs)?,
+            input_env.clone(),
+            input_cont.clone(),
+        ))
+    }
 
-        let mut bits = vec![];
-
-        for input_ptr in input_exprs {
-            let tag_bits = input_ptr
-                .tag()
-                .to_bits_le_strict(&mut cs.namespace(|| "preimage_tag_bits"))?;
-            let hash_bits = input_ptr
-                .hash()
-                .to_bits_le_strict(&mut cs.namespace(|| "preimage_hash_bits"))?;
-
-            bits.extend(tag_bits);
-            bits.push(zero.clone()); // need 256 bits (or some multiple of 8).
-            bits.extend(hash_bits);
-            bits.push(zero.clone()); // need 256 bits (or some multiple of 8).
-        }
-
-        bits.reverse();
-
-        let mut digest_bits = sha256(cs.namespace(|| "digest_bits"), &bits)?;
-
-        digest_bits.reverse();
-
-        // Fine to lose the last <1 bit of precision.
-        let digest_scalar = pack_bits(cs.namespace(|| "digest_scalar"), &digest_bits)?;
-        let output_expr = AllocatedPtr::alloc_tag(
-            &mut cs.namespace(|| "output_expr"),
-            ExprTag::Num.to_field(),
-            digest_scalar,
-        )?;
-        Ok((output_expr, input_env.clone(), input_cont.clone()))
+    #[inline]
+    fn synthesize_lem_simple<CS: ConstraintSystem<F>>(
+        &self,
+        cs: &mut CS,
+        _g: &lurk::lem::circuit::GlobalAllocator<F>,
+        _s: &lurk::lem::store::Store<F>,
+        _not_dummy: &Boolean,
+        args: &[AllocatedPtr<F>],
+    ) -> Result<AllocatedPtr<F>, SynthesisError> {
+        synthesize_sha256(cs, args)
     }
 }
 
@@ -81,35 +129,24 @@ impl<F: LurkField> Coprocessor<F> for Sha256Coprocessor<F> {
     }
 
     fn simple_evaluate(&self, s: &Store<F>, args: &[Ptr<F>]) -> Ptr<F> {
-        let mut hasher = Sha256::new();
-
-        let mut input = vec![0u8; 64 * self.n];
-
-        for (i, input_ptr) in args.iter().enumerate() {
-            let input_zptr = s.hash_expr(input_ptr).unwrap();
-            let tag_zptr: F = input_zptr.tag().to_field();
-            let hash_zptr = input_zptr.value();
-            input[(64 * i)..(64 * i + 32)].copy_from_slice(&tag_zptr.to_bytes());
-            input[(64 * i + 32)..(64 * (i + 1))].copy_from_slice(&hash_zptr.to_bytes());
-        }
-
-        input.reverse();
-
-        hasher.update(input);
-        let mut bytes = hasher.finalize();
-        bytes.reverse();
-        let l = bytes.len();
-        // Discard the two most significant bits.
-        bytes[l - 1] &= 0b00111111;
-
-        let scalar = F::from_bytes(&bytes).unwrap();
-        let result = Num::from_scalar(scalar);
-
+        let z_ptrs = args
+            .iter()
+            .map(|ptr| s.hash_expr(ptr).unwrap())
+            .collect::<Vec<_>>();
+        let result = Num::from_scalar(compute_sha256(self.n, &z_ptrs));
         s.intern_num(result)
     }
 
     fn has_circuit(&self) -> bool {
         true
+    }
+
+    fn evaluate_lem_simple(&self, s: &LEMStore<F>, args: &[LEMPtr<F>]) -> LEMPtr<F> {
+        let z_ptrs = args
+            .iter()
+            .map(|ptr| s.hash_ptr(ptr).unwrap())
+            .collect::<Vec<_>>();
+        LEMPtr::num(compute_sha256(self.n, &z_ptrs))
     }
 }
 

--- a/src/coprocessor/sha256.rs
+++ b/src/coprocessor/sha256.rs
@@ -1,0 +1,128 @@
+use bellpepper::gadgets::{multipack::pack_bits, sha256::sha256};
+use bellpepper_core::{boolean::Boolean, ConstraintSystem, SynthesisError};
+use lurk_macros::Coproc;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::marker::PhantomData;
+
+use crate::{
+    self as lurk,
+    circuit::gadgets::{
+        data::GlobalAllocations,
+        pointer::{AllocatedContPtr, AllocatedPtr},
+    },
+    field::LurkField,
+    num::Num,
+    ptr::Ptr,
+    store::Store,
+    tag::{ExprTag, Tag},
+};
+
+use super::{CoCircuit, Coprocessor};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Sha256Coprocessor<F: LurkField> {
+    n: usize,
+    pub(crate) _p: PhantomData<F>,
+}
+
+impl<F: LurkField> CoCircuit<F> for Sha256Coprocessor<F> {
+    fn arity(&self) -> usize {
+        self.n
+    }
+
+    fn synthesize<CS: ConstraintSystem<F>>(
+        &self,
+        cs: &mut CS,
+        _g: &GlobalAllocations<F>,
+        _store: &Store<F>,
+        input_exprs: &[AllocatedPtr<F>],
+        input_env: &AllocatedPtr<F>,
+        input_cont: &AllocatedContPtr<F>,
+    ) -> Result<(AllocatedPtr<F>, AllocatedPtr<F>, AllocatedContPtr<F>), SynthesisError> {
+        let zero = Boolean::constant(false);
+
+        let mut bits = vec![];
+
+        for input_ptr in input_exprs {
+            let tag_bits = input_ptr
+                .tag()
+                .to_bits_le_strict(&mut cs.namespace(|| "preimage_tag_bits"))?;
+            let hash_bits = input_ptr
+                .hash()
+                .to_bits_le_strict(&mut cs.namespace(|| "preimage_hash_bits"))?;
+
+            bits.extend(tag_bits);
+            bits.push(zero.clone()); // need 256 bits (or some multiple of 8).
+            bits.extend(hash_bits);
+            bits.push(zero.clone()); // need 256 bits (or some multiple of 8).
+        }
+
+        bits.reverse();
+
+        let mut digest_bits = sha256(cs.namespace(|| "digest_bits"), &bits)?;
+
+        digest_bits.reverse();
+
+        // Fine to lose the last <1 bit of precision.
+        let digest_scalar = pack_bits(cs.namespace(|| "digest_scalar"), &digest_bits)?;
+        let output_expr = AllocatedPtr::alloc_tag(
+            &mut cs.namespace(|| "output_expr"),
+            ExprTag::Num.to_field(),
+            digest_scalar,
+        )?;
+        Ok((output_expr, input_env.clone(), input_cont.clone()))
+    }
+}
+
+impl<F: LurkField> Coprocessor<F> for Sha256Coprocessor<F> {
+    fn eval_arity(&self) -> usize {
+        self.n
+    }
+
+    fn simple_evaluate(&self, s: &Store<F>, args: &[Ptr<F>]) -> Ptr<F> {
+        let mut hasher = Sha256::new();
+
+        let mut input = vec![0u8; 64 * self.n];
+
+        for (i, input_ptr) in args.iter().enumerate() {
+            let input_zptr = s.hash_expr(input_ptr).unwrap();
+            let tag_zptr: F = input_zptr.tag().to_field();
+            let hash_zptr = input_zptr.value();
+            input[(64 * i)..(64 * i + 32)].copy_from_slice(&tag_zptr.to_bytes());
+            input[(64 * i + 32)..(64 * (i + 1))].copy_from_slice(&hash_zptr.to_bytes());
+        }
+
+        input.reverse();
+
+        hasher.update(input);
+        let mut bytes = hasher.finalize();
+        bytes.reverse();
+        let l = bytes.len();
+        // Discard the two most significant bits.
+        bytes[l - 1] &= 0b00111111;
+
+        let scalar = F::from_bytes(&bytes).unwrap();
+        let result = Num::from_scalar(scalar);
+
+        s.intern_num(result)
+    }
+
+    fn has_circuit(&self) -> bool {
+        true
+    }
+}
+
+impl<F: LurkField> Sha256Coprocessor<F> {
+    pub fn new(n: usize) -> Self {
+        Self {
+            n,
+            _p: Default::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Coproc, Serialize, Deserialize)]
+pub enum Sha256Coproc<F: LurkField> {
+    SC(Sha256Coprocessor<F>),
+}

--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -232,7 +232,7 @@ pub fn make_eval_step_from_lang<F: LurkField, C: Coprocessor<F>>(
     )
 }
 
-pub fn make_eval_step(cprocs: &[(&Symbol, usize)], ivc: bool) -> Func {
+fn make_eval_step(cprocs: &[(&Symbol, usize)], ivc: bool) -> Func {
     let reduce = reduce(cprocs);
     let apply_cont = apply_cont(cprocs, ivc);
     let make_thunk = make_thunk();
@@ -377,7 +377,7 @@ fn run_cproc(cproc_sym: Symbol, arity: usize) -> Func {
     Func::new("run_cproc".into(), func_inp, 3, block).unwrap()
 }
 
-pub(crate) fn make_cprocs_funcs_from_lang<F: LurkField, C: Coprocessor<F>>(
+pub fn make_cprocs_funcs_from_lang<F: LurkField, C: Coprocessor<F>>(
     lang: &Lang<F, C>,
 ) -> std::sync::Arc<[Func]> {
     lang.coprocessors()

--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -112,15 +112,9 @@ pub fn build_frames<
         }
         pc = get_pc(&expr, store, lang);
     }
+    // TODO: remove this
     if iterations < limit {
-        let (frame, _) = lurk_step.call(
-            &input,
-            store,
-            Preimages::new_from_func(lurk_step),
-            &mut vec![],
-            lang,
-            pc,
-        )?;
+        let frame = lurk_step.call_simple(&input, store, lang, pc)?;
         frames.push(frame);
     }
     Ok((frames, iterations))

--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -112,7 +112,7 @@ pub fn build_frames<
         }
         pc = get_pc(&expr, store, lang);
     }
-    // TODO: remove this
+    // TODO: remove this after #729 is merged
     if iterations < limit {
         let frame = lurk_step.call_simple(&input, store, lang, pc)?;
         frames.push(frame);
@@ -218,6 +218,13 @@ pub fn evaluate_simple<F: LurkField, C: Coprocessor<F>>(
     }
 }
 
+/// Creates a LEM `Func` corresponding to Lurk's step function from a `Lang`.
+/// The `ivc` flag tells whether the generated step function is used for IVC or
+/// NIVC. In the IVC case, the step function is capable of reducing calls to the
+/// coprocessors present in `Lang` and their circuit will go in the circuit of
+/// the step function. In the NIVC case, the step function won't be able to reduce
+/// calls to coprocessors and sets up a loop via the `Expr::Cproc` tag, meaning
+/// that the reduction must be done from outside.
 pub fn make_eval_step_from_lang<F: LurkField, C: Coprocessor<F>>(
     lang: &Lang<F, C>,
     ivc: bool,
@@ -377,6 +384,8 @@ fn run_cproc(cproc_sym: Symbol, arity: usize) -> Func {
     Func::new("run_cproc".into(), func_inp, 3, block).unwrap()
 }
 
+/// Creates the `Func`s used to call coprocessors in the NIVC scenario. Each
+/// coprocessor in the `Lang` will have its own specialized `Func`
 pub fn make_cprocs_funcs_from_lang<F: LurkField, C: Coprocessor<F>>(
     lang: &Lang<F, C>,
 ) -> std::sync::Arc<[Func]> {

--- a/src/lem/interpreter.rs
+++ b/src/lem/interpreter.rs
@@ -556,4 +556,24 @@ impl Func {
 
         Ok(res)
     }
+
+    #[inline]
+    pub fn call_simple<F: LurkField, C: Coprocessor<F>>(
+        &self,
+        args: &[Ptr<F>],
+        store: &Store<F>,
+        lang: &Lang<F, C>,
+        pc: usize,
+    ) -> Result<Frame<F>> {
+        Ok(self
+            .call(
+                args,
+                store,
+                Preimages::new_from_func(self),
+                &mut vec![],
+                lang,
+                pc,
+            )?
+            .0)
+    }
 }

--- a/src/lem/multiframe.rs
+++ b/src/lem/multiframe.rs
@@ -1,17 +1,22 @@
-use crate::eval::Meta;
-use crate::proof::supernova::FoldingConfig;
+use abomonation::Abomonation;
 use anyhow::Result;
 use bellpepper::util_cs::witness_cs::WitnessCS;
 use bellpepper_core::{num::AllocatedNum, Circuit, ConstraintSystem, SynthesisError};
+use ff::PrimeField;
+use nova::{supernova::NonUniformCircuit, traits::Group};
 use std::sync::Arc;
 
 use crate::{
     circuit::gadgets::pointer::AllocatedPtr,
     coprocessor::Coprocessor,
     error::{ProofError, ReductionError},
-    eval::lang::Lang,
+    eval::{lang::Lang, Meta},
     field::LurkField,
-    proof::{CEKState, EvaluationStore, FrameLike, MultiFrameTrait, Provable},
+    proof::{
+        nova::{CurveCycleEquipped, G1, G2},
+        supernova::{FoldingConfig, C2},
+        CEKState, EvaluationStore, FrameLike, MultiFrameTrait, Provable,
+    },
     state::initial_lurk_state,
     store,
     tag::ContTag,
@@ -37,6 +42,19 @@ pub struct MultiFrame<'a, F: LurkField, C: Coprocessor<F>> {
     pub frames: Option<Vec<Frame<F>>>,
     pub cached_witness: Option<WitnessCS<F>>,
     pub reduction_count: usize,
+    pub folding_config: Arc<FoldingConfig<F, C>>,
+    pub pc: usize,
+    pub next_pc: usize,
+}
+
+impl<'a, F: LurkField, C: Coprocessor<F>> MultiFrame<'a, F, C> {
+    fn get_func(&self) -> &Func {
+        if self.pc == 0 {
+            &self.lurk_step
+        } else {
+            &self.cprocs.as_ref().unwrap()[self.pc - 1]
+        }
+    }
 }
 
 impl<F: LurkField> CEKState<Ptr<F>, Ptr<F>> for Vec<Ptr<F>> {
@@ -158,9 +176,9 @@ impl<'a, F: LurkField, C: Coprocessor<F> + 'a> MultiFrameTrait<'a, F, C> for Mul
                     }
                 }
                 let bound_allocations = &mut BoundAllocations::new();
-                self.lurk_step.add_input(&input, bound_allocations);
-                let output = self
-                    .lurk_step
+                let func = self.get_func();
+                func.add_input(&input, bound_allocations);
+                let output = func
                     .synthesize_frame(
                         &mut cs.namespace(|| format!("frame {i}")),
                         store,
@@ -176,8 +194,8 @@ impl<'a, F: LurkField, C: Coprocessor<F> + 'a> MultiFrameTrait<'a, F, C> for Mul
         Ok(output)
     }
 
-    fn blank(folding_config: Arc<FoldingConfig<F, C>>, _meta: Meta<F>) -> Self {
-        let (lang, lurk_step, cprocs, reduction_count) = match &*folding_config {
+    fn blank(folding_config: Arc<FoldingConfig<F, C>>, _meta: Meta<F>, pc: usize) -> Self {
+        let (lang, lurk_step, cprocs, rc) = match &*folding_config {
             FoldingConfig::IVC(lang, rc) => (
                 lang.clone(),
                 Arc::new(make_eval_step_from_lang(lang, true)),
@@ -191,6 +209,7 @@ impl<'a, F: LurkField, C: Coprocessor<F> + 'a> MultiFrameTrait<'a, F, C> for Mul
                 *rc,
             ),
         };
+        let reduction_count = if pc == 0 { rc } else { 1 };
         Self {
             store: None,
             lang,
@@ -201,6 +220,9 @@ impl<'a, F: LurkField, C: Coprocessor<F> + 'a> MultiFrameTrait<'a, F, C> for Mul
             frames: None,
             cached_witness: None,
             reduction_count,
+            folding_config,
+            pc,
+            next_pc: 0,
         }
     }
 
@@ -218,38 +240,118 @@ impl<'a, F: LurkField, C: Coprocessor<F> + 'a> MultiFrameTrait<'a, F, C> for Mul
                 let lurk_step = Arc::new(make_eval_step_from_lang(lang, true));
                 let cprocs = None;
                 for chunk in frames.chunks(reduction_count) {
-                    let last_frame = chunk.last().expect("chunk must not be empty");
+                    let output = chunk
+                        .last()
+                        .expect("chunk must not be empty")
+                        .output
+                        .to_vec();
                     let inner_frames = if chunk.len() < reduction_count {
                         let mut inner_frames = Vec::with_capacity(reduction_count);
                         inner_frames.extend(chunk.to_vec());
-                        inner_frames.resize(reduction_count, last_frame.clone());
+                        let padding_frame = lurk_step
+                            .call_simple(&output, store, lang, 0)
+                            .expect("reduction step failed");
+                        assert_eq!(padding_frame.input, padding_frame.output);
+                        inner_frames.resize(reduction_count, padding_frame.clone());
                         inner_frames
                     } else {
                         chunk.to_vec()
                     };
-
-                    let output = last_frame.output.clone();
-                    let input = chunk[0].input.clone();
 
                     let mf = MultiFrame {
                         store: Some(store),
                         lang: lang.clone(),
                         lurk_step: lurk_step.clone(),
                         cprocs: cprocs.clone(),
-                        input: Some(input),
+                        input: Some(chunk[0].input.to_vec()),
                         output: Some(output),
                         frames: Some(inner_frames),
                         cached_witness: None,
                         reduction_count,
+                        folding_config: folding_config.clone(),
+                        pc: 0,
+                        next_pc: 0,
                     };
 
                     multi_frames.push(mf);
                 }
             }
             FoldingConfig::NIVC(lang, _) => {
-                let _lurk_step = Arc::new(make_eval_step_from_lang(lang, false));
-                let _cprocs = make_cprocs_funcs_from_lang(lang);
-                todo!()
+                let lurk_step = Arc::new(make_eval_step_from_lang(lang, false));
+                let cprocs = make_cprocs_funcs_from_lang(lang);
+                let mut chunk_start_idx = 0;
+                while chunk_start_idx < frames.len() {
+                    let first_frame = &frames[chunk_start_idx];
+                    let mf = if first_frame.pc == 0 {
+                        let mut inner_frames = Vec::with_capacity(reduction_count);
+                        let mut next_pc = 0;
+                        let chunk_start_idx_saved = chunk_start_idx;
+                        // fill `inner_frames` with `reduction_count` frames unless
+                        // we don't have enough frames or we find some frame whose
+                        // `pc` is not `0` on the way
+                        for i in 0..reduction_count {
+                            let current_frame_idx = chunk_start_idx_saved + i;
+                            inner_frames.push(frames[current_frame_idx].clone());
+                            // update `chunk_start_idx` with the next index, which
+                            // might be the index of the first frame in the next
+                            // multiframe
+                            chunk_start_idx = current_frame_idx + 1;
+                            if let Some(next_frame) = frames.get(chunk_start_idx) {
+                                next_pc = next_frame.pc;
+                                if next_pc != 0 {
+                                    // incompatible `pc` incoming
+                                    break;
+                                }
+                            } else {
+                                // not enough frames
+                                break;
+                            }
+                        }
+                        let output = inner_frames
+                            .last()
+                            .expect("empty inner_frames")
+                            .output
+                            .to_vec();
+                        if inner_frames.len() < reduction_count {
+                            let padding_frame = lurk_step
+                                .call_simple(&output, store, lang, 0)
+                                .expect("reduction step failed");
+                            assert_eq!(padding_frame.input, padding_frame.output);
+                            inner_frames.resize(reduction_count, padding_frame);
+                        }
+                        MultiFrame {
+                            store: Some(store),
+                            lang: lang.clone(),
+                            lurk_step: lurk_step.clone(),
+                            cprocs: Some(cprocs.clone()),
+                            input: Some(first_frame.input.clone()),
+                            output: Some(output),
+                            frames: Some(inner_frames),
+                            cached_witness: None,
+                            reduction_count,
+                            folding_config: folding_config.clone(),
+                            pc: 0,
+                            next_pc,
+                        }
+                    } else {
+                        chunk_start_idx += 1;
+                        MultiFrame {
+                            store: Some(store),
+                            lang: lang.clone(),
+                            lurk_step: lurk_step.clone(),
+                            cprocs: Some(cprocs.clone()),
+                            input: Some(first_frame.input.clone()),
+                            output: Some(first_frame.output.clone()),
+                            frames: Some(vec![first_frame.clone()]),
+                            cached_witness: None,
+                            reduction_count: 1,
+                            folding_config: folding_config.clone(),
+                            pc: first_frame.pc,
+                            next_pc: 0,
+                        }
+                    };
+                    multi_frames.push(mf);
+                }
             }
         }
 
@@ -295,6 +397,9 @@ impl<'a, F: LurkField, C: Coprocessor<F> + 'a> MultiFrameTrait<'a, F, C> for Mul
             frames,
             cached_witness: None,
             reduction_count,
+            folding_config,
+            pc: 0,
+            next_pc: 0,
         }
     }
 
@@ -424,9 +529,8 @@ impl<'a, F: LurkField, C: Coprocessor<F>> Circuit<F> for MultiFrame<'a, F, C> {
             None => {
                 assert!(self.frames.is_none());
                 let dummy_io = [Ptr::dummy(); 3];
-                let func = &self.lurk_step;
                 let store = Store::default();
-                let blank_frame = Frame::blank(func, 0);
+                let blank_frame = Frame::blank(self.get_func(), self.pc);
                 let frames = vec![blank_frame; self.reduction_count];
                 synth(&store, &frames, &dummy_io, &dummy_io)
             }
@@ -493,15 +597,17 @@ impl<'a, F: LurkField, C: Coprocessor<F>> nova::traits::circuit::StepCircuit<F>
 
         let output_ptrs = match self.frames.as_ref() {
             Some(frames) => {
+                if self.pc != 0 {
+                    assert_eq!(frames.len(), 1);
+                }
                 let store = self.store.expect("store missing");
                 let g = self.lurk_step.alloc_globals(cs, store)?;
                 self.synthesize_frames(cs, store, input, frames, &g)?
             }
             None => {
                 assert!(self.store.is_none());
-                let func = &self.lurk_step;
                 let store = Store::default();
-                let blank_frame = Frame::blank(func, 0);
+                let blank_frame = Frame::blank(self.get_func(), self.pc);
                 let frames = vec![blank_frame; self.reduction_count];
                 let g = self.lurk_step.alloc_globals(cs, &store)?;
                 self.synthesize_frames(cs, &store, input, &frames, &g)?
@@ -515,5 +621,57 @@ impl<'a, F: LurkField, C: Coprocessor<F>> nova::traits::circuit::StepCircuit<F>
         }
 
         Ok(output)
+    }
+}
+
+impl<'a, F: LurkField, C: Coprocessor<F>> nova::traits::circuit_supernova::StepCircuit<F>
+    for MultiFrame<'a, F, C>
+{
+    fn arity(&self) -> usize {
+        2 * self.lurk_step.input_params.len()
+    }
+
+    fn synthesize<CS: ConstraintSystem<F>>(
+        &self,
+        cs: &mut CS,
+        _pc: Option<&AllocatedNum<F>>,
+        z: &[AllocatedNum<F>],
+    ) -> Result<(Option<AllocatedNum<F>>, Vec<AllocatedNum<F>>), SynthesisError> {
+        let next_pc = AllocatedNum::alloc_infallible(&mut cs.namespace(|| "next_pc"), || {
+            F::from_u64(self.next_pc as u64)
+        });
+        let output = <MultiFrame<'_, F, C> as nova::traits::circuit::StepCircuit<F>>::synthesize(
+            self, cs, z,
+        )?;
+        Ok((Some(next_pc), output))
+    }
+}
+
+impl<'a, F, C> NonUniformCircuit<G1<F>, G2<F>, MultiFrame<'a, F, C>, C2<F>> for MultiFrame<'a, F, C>
+where
+    F: CurveCycleEquipped + LurkField,
+    C: Coprocessor<F> + 'a,
+    <<G1<F> as Group>::Scalar as PrimeField>::Repr: Abomonation,
+    <<G2<F> as Group>::Scalar as PrimeField>::Repr: Abomonation,
+{
+    fn num_circuits(&self) -> usize {
+        assert_eq!(self.pc, 0);
+        self.lang.coprocessor_count() + 1
+    }
+
+    fn primary_circuit(&self, circuit_index: usize) -> MultiFrame<'a, F, C> {
+        if circuit_index == 0 {
+            self.clone()
+        } else {
+            Self::blank(
+                self.folding_config.clone(),
+                Default::default(),
+                circuit_index,
+            )
+        }
+    }
+
+    fn secondary_circuit(&self) -> C2<F> {
+        Default::default()
     }
 }

--- a/src/lem/multiframe.rs
+++ b/src/lem/multiframe.rs
@@ -645,6 +645,10 @@ impl<'a, F: LurkField, C: Coprocessor<F>> nova::traits::circuit_supernova::StepC
         )?;
         Ok((Some(next_pc), output))
     }
+
+    fn circuit_index(&self) -> usize {
+        self.pc
+    }
 }
 
 impl<'a, F, C> NonUniformCircuit<G1<F>, G2<F>, MultiFrame<'a, F, C>, C2<F>> for MultiFrame<'a, F, C>

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -146,7 +146,7 @@ pub trait MultiFrameTrait<'a, F: LurkField, C: Coprocessor<F> + 'a>:
     ) -> Result<Self::AllocatedIO, SynthesisError>;
 
     /// Synthesize a blank circuit.
-    fn blank(folding_config: Arc<FoldingConfig<F, C>>, meta: Meta<F>) -> Self;
+    fn blank(folding_config: Arc<FoldingConfig<F, C>>, meta: Meta<F>, pc: usize) -> Self;
 
     /// Create an instance from some `Self::Frame`s.
     fn from_frames(

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -200,12 +200,17 @@ where
 ///
 /// Note: For now, we use ad-hoc circuit cache keys.
 /// See: [crate::public_parameters::instance]
-pub fn circuit_cache_key<F: CurveCycleEquipped, C: Coprocessor<F>>(
+pub fn circuit_cache_key<
+    'a,
+    F: CurveCycleEquipped,
+    C: Coprocessor<F> + 'a,
+    M: MultiFrameTrait<'a, F, C>,
+>(
     rc: usize,
     lang: Arc<Lang<F, C>>,
 ) -> F {
     let folding_config = Arc::new(FoldingConfig::new_ivc(lang, 2));
-    let circuit = MultiFrame::blank(folding_config, Meta::Lurk);
+    let circuit = M::blank(folding_config, Meta::Lurk, 0);
     F::from(rc as u64) * nova::circuit_digest::<F::G1, F::G2, _>(&circuit)
 }
 

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -1,5 +1,4 @@
 #![allow(non_snake_case)]
-use std::{marker::PhantomData, sync::Mutex};
 
 use abomonation::Abomonation;
 use bellpepper::util_cs::witness_cs::WitnessCS;
@@ -20,18 +19,27 @@ use nova::{
 use pasta_curves::{pallas, vesta};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use std::{
+    marker::PhantomData,
+    sync::{Arc, Mutex},
+};
 
-use crate::config::CONFIG;
-
-use crate::coprocessor::Coprocessor;
-use crate::error::ProofError;
-use crate::eval::{lang::Lang, Meta};
-use crate::field::LurkField;
-use crate::proof::{supernova::FoldingConfig, MultiFrameTrait, Prover};
-use crate::store::Store;
-
-use super::FrameLike;
+use crate::{
+    circuit::{
+        gadgets::{
+            data::GlobalAllocations,
+            pointer::{AllocatedContPtr, AllocatedPtr},
+        },
+        CircuitFrame, MultiFrame,
+    },
+    config::CONFIG,
+    coprocessor::Coprocessor,
+    error::ProofError,
+    eval::{lang::Lang, Meta},
+    field::LurkField,
+    proof::{supernova::FoldingConfig, FrameLike, MultiFrameTrait, Prover},
+    store::Store,
+};
 
 /// This trait defines most of the requirements for programming generically over the supported Nova curve cycles
 /// (currently Pallas/Vesta and BN254/Grumpkin). It being pegged on the `LurkField` trait encodes that we do
@@ -237,7 +245,7 @@ pub fn circuits<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a, M: MultiFrame
 ) -> (M, C2<F>) {
     let folding_config = Arc::new(FoldingConfig::new_ivc(lang, count));
     (
-        M::blank(folding_config, Meta::Lurk),
+        M::blank(folding_config, Meta::Lurk, 0),
         TrivialCircuit::default(),
     )
 }
@@ -513,14 +521,6 @@ where
         vec![<G2<F> as Group>::Scalar::ZERO]
     }
 }
-
-use crate::circuit::{
-    gadgets::{
-        data::GlobalAllocations,
-        pointer::{AllocatedContPtr, AllocatedPtr},
-    },
-    CircuitFrame, MultiFrame,
-};
 
 impl<'a, F: LurkField, C: Coprocessor<F>> StepCircuit<F> for MultiFrame<'a, F, C> {
     fn arity(&self) -> usize {

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -1,42 +1,38 @@
 #![allow(non_snake_case)]
-use std::marker::PhantomData;
-use std::ops::Index;
 
 use abomonation::Abomonation;
-use tracing::{debug, info};
-
 use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
+use ff::{Field, PrimeField};
 use nova::{
-    self,
-    supernova::{self, error::SuperNovaError, CircuitDigests, NonUniformCircuit, RecursiveSNARK},
+    supernova::{
+        self, error::SuperNovaError, AuxParams, CircuitDigests, NonUniformCircuit, RecursiveSNARK,
+    },
     traits::{
         circuit_supernova::{StepCircuit as SuperStepCircuit, TrivialSecondaryCircuit},
         Group,
     },
 };
-
-use ff::{Field, PrimeField};
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use std::{marker::PhantomData, ops::Index, sync::Arc};
+use tracing::{debug, info};
 
-use crate::circuit::MultiFrame;
-
-use crate::coprocessor::Coprocessor;
-
-use crate::error::ProofError;
-use crate::eval::{lang::Lang, Meta};
-use crate::field::LurkField;
-use crate::proof::nova::{CurveCycleEquipped, G1, G2};
-use crate::proof::{MultiFrameTrait, Provable, Prover};
-
-use super::nova::NovaCircuitShape;
-use super::FrameLike;
+use crate::{
+    circuit::MultiFrame,
+    coprocessor::Coprocessor,
+    error::ProofError,
+    eval::{lang::Lang, Meta},
+    field::LurkField,
+    proof::{
+        nova::{CurveCycleEquipped, NovaCircuitShape, G1, G2},
+        {FrameLike, MultiFrameTrait, Provable, Prover},
+    },
+};
 
 /// Type alias for a Trivial Test Circuit with G2 scalar field elements.
 pub type C2<F> = TrivialSecondaryCircuit<<G2<F> as Group>::Scalar>;
 
 /// Type alias for SuperNova Aux Parameters with the curve cycle types defined above.
-pub type SuperNovaAuxParams<F> = supernova::AuxParams<G1<F>, G2<F>>;
+pub type SuperNovaAuxParams<F> = AuxParams<G1<F>, G2<F>>;
 
 /// Type alias for SuperNova Public Parameters with the curve cycle types defined above.
 pub type SuperNovaPublicParams<F, C1> = supernova::PublicParams<G1<F>, G2<F>, C1, C2<F>>;
@@ -95,7 +91,7 @@ where
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     let folding_config = Arc::new(FoldingConfig::new_nivc(lang, rc));
-    let non_uniform_circuit = M::blank(folding_config, Meta::Lurk);
+    let non_uniform_circuit = M::blank(folding_config, Meta::Lurk, 0);
     let pp = SuperNovaPublicParams::<F, M>::new(&non_uniform_circuit);
     PublicParams { pp }
 }

--- a/src/proof/tests/mod.rs
+++ b/src/proof/tests/mod.rs
@@ -175,7 +175,7 @@ where
 
     let mut cs_blank = MetricCS::<F>::new();
 
-    let blank = M::blank(folding_config, Meta::Lurk);
+    let blank = M::blank(folding_config, Meta::Lurk, 0);
     blank
         .synthesize(&mut cs_blank)
         .expect("failed to synthesize blank");

--- a/src/public_parameters/disk_cache.rs
+++ b/src/public_parameters/disk_cache.rs
@@ -39,7 +39,10 @@ where
         })
     }
 
-    pub(crate) fn read(&self, instance: &Instance<F, C>) -> Result<PublicParams<F, M>, Error> {
+    pub(crate) fn read(
+        &self,
+        instance: &Instance<'a, F, C, M>,
+    ) -> Result<PublicParams<F, M>, Error> {
         let file = instance.open(&self.dir)?;
         let reader = BufReader::new(file);
         bincode::deserialize_from(reader).map_err(|e| {
@@ -49,7 +52,7 @@ where
 
     pub(crate) fn read_bytes(
         &self,
-        instance: &Instance<F, C>,
+        instance: &Instance<'a, F, C, M>,
         byte_sink: &mut Vec<u8>,
     ) -> Result<(), Error> {
         let file = instance.open(&self.dir)?;
@@ -60,7 +63,7 @@ where
 
     pub(crate) fn write(
         &self,
-        instance: &Instance<F, C>,
+        instance: &Instance<'a, F, C, M>,
         data: &PublicParams<F, M>,
     ) -> Result<(), Error> {
         let file = instance.create(&self.dir)?;
@@ -72,7 +75,7 @@ where
 
     pub(crate) fn write_abomonated<V: Abomonation>(
         &self,
-        instance: &Instance<F, C>,
+        instance: &Instance<'a, F, C, M>,
         data: &V,
     ) -> Result<(), Error> {
         let mut file = instance.create(&self.dir)?;

--- a/src/public_parameters/instance.rs
+++ b/src/public_parameters/instance.rs
@@ -123,10 +123,7 @@ where
     pub fn new(rc: usize, lang: Arc<Lang<F, C>>, abomonated: bool, kind: Kind) -> Self {
         let cache_key = match kind {
             Kind::NovaPublicParams => nova::circuit_cache_key(rc, lang.clone()),
-            Kind::SuperNovaAuxParams => {
-                let cache_keys = supernova::circuit_cache_keys(rc, lang.clone());
-                cache_keys.digest()
-            }
+            Kind::SuperNovaAuxParams => supernova::circuit_cache_keys(rc, lang.clone()).digest(),
             Kind::SuperNovaCircuitParams(circuit_index) => {
                 supernova::circuit_cache_key(rc, lang.clone(), circuit_index)
             }

--- a/src/public_parameters/mem_cache.rs
+++ b/src/public_parameters/mem_cache.rs
@@ -42,10 +42,10 @@ impl PublicParamMemCache {
         F: CurveCycleEquipped,
         C: Coprocessor<F> + 'static,
         M: MultiFrameTrait<'static, F, C>,
-        Fn: FnOnce(&Instance<F, C>) -> Arc<PublicParams<F, M>>,
+        Fn: FnOnce(&Instance<'static, F, C, M>) -> Arc<PublicParams<F, M>>,
     >(
         &'static self,
-        instance: &Instance<F, C>,
+        instance: &Instance<'static, F, C, M>,
         default: Fn,
         disk_cache_path: &Utf8Path,
     ) -> Result<Arc<PublicParams<F, M>>, Error>
@@ -103,10 +103,10 @@ impl PublicParamMemCache {
         F: CurveCycleEquipped,
         C: Coprocessor<F> + 'static,
         M: MultiFrameTrait<'static, F, C>,
-        Fn: FnOnce(&Instance<F, C>) -> Arc<PublicParams<F, M>>,
+        Fn: FnOnce(&Instance<'static, F, C, M>) -> Arc<PublicParams<F, M>>,
     >(
         &'static self,
-        instance: &Instance<F, C>,
+        instance: &Instance<'static, F, C, M>,
         default: Fn,
         disk_cache_path: &Utf8Path,
     ) -> Result<Arc<PublicParams<F, M>>, Error>

--- a/tests/lurk-nivc-test.rs
+++ b/tests/lurk-nivc-test.rs
@@ -10,3 +10,13 @@ fn test_sha256_nivc() {
     cmd.args(["run", "--release", "--example", "sha256_nivc"]);
     cmd.assert().success();
 }
+
+/// TODO: replace this test for more granular ones, specific for the NIVC
+/// pipeline steps
+#[test]
+#[ignore]
+fn test_sha256_nivc_lem() {
+    let mut cmd = Command::new("cargo");
+    cmd.args(["run", "--release", "--example", "sha256_nivc_lem"]);
+    cmd.assert().success();
+}


### PR DESCRIPTION
This PR implements an NIVC example for LEM. It was also necessary to make `lurk::proof::supernova::circuit_cache_key` and `lurk::proof::nova::circuit_cache_key` generic on the `MultiFrameTrait` instead of hardcoding the call to `MultiFrame::blank`.

This PR also centralizes the implementation of the SHA-256 coprocessor because it was implemented in like 3 different places.