### PR TITLE
Benchmarks for LEM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ clap = { workspace = true, features = ["derive"] }
 config = "0.13.3"
 dashmap = "5.5.0"
 ff = { workspace = true }
+fxhash = "0.2.1"
 generic-array = "0.14.7"
 hex = { version = "0.4.3", features = ["serde"] }
 indexmap = { version = "1.9.3", features = ["rayon", "serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,10 @@ name = "end2end"
 harness = false
 
 [[bench]]
+name = "end2end_lem"
+harness = false
+
+[[bench]]
 name = "fibonacci"
 harness = false
 

--- a/src/lem/pointers.rs
+++ b/src/lem/pointers.rs
@@ -147,6 +147,13 @@ impl<F: LurkField> Ptr<F> {
 /// when interpreting LEMs and delay the need for `ZPtr`s as much as possible.
 pub type ZPtr<F> = crate::z_data::z_ptr::ZPtr<Tag, F>;
 
+impl<F: LurkField> ZPtr<F> {
+    #[inline]
+    pub fn dummy() -> Self {
+        Self(Tag::Expr(Nil), F::ZERO)
+    }
+}
+
 /// `ZChildren` keeps track of the children of `ZPtr`s, in case they have any.
 /// This information is saved during hydration and is needed to content-address
 /// a store.

--- a/src/lem/var_map.rs
+++ b/src/lem/var_map.rs
@@ -1,5 +1,7 @@
+use std::collections::hash_map::Entry;
+
 use anyhow::{bail, Result};
-use std::collections::{hash_map::Entry, HashMap};
+use fxhash::FxHashMap;
 use tracing::info;
 
 use super::Var;
@@ -9,13 +11,13 @@ use super::Var;
 /// variables before using them, so we don't expect to need some piece of
 /// information from a variable that hasn't been defined.
 #[derive(Clone, Debug)]
-pub struct VarMap<V>(HashMap<Var, V>);
+pub struct VarMap<V>(FxHashMap<Var, V>);
 
 impl<V> VarMap<V> {
     /// Creates an empty `VarMap`
     #[inline]
     pub(crate) fn new() -> VarMap<V> {
-        VarMap(HashMap::default())
+        VarMap(FxHashMap::default())
     }
 
     /// Inserts new data into a `VarMap`


### PR DESCRIPTION
1. Benchmarking infra for LEM
2. A fix for the manual count of constraints
3. Some tweaks in the model that resulted in a reduction of ~400 constraints and some speed up in interpretation
4. An improvement in `VarMap`'s hashmap, the main responsible for cutting the 30x interpretation slowdown down to 17x

```text
end2end_benchmark/end2end_go_base_nova/_10_0
                        time:   [1.1855 s 1.1907 s 1.1949 s]
                        change: [-18.116% -17.702% -17.267%] (p = 0.00 < 0.05)
                        Performance has improved.

store_benchmark/store_go_base_bls12/_10_16
                        time:   [149.36 µs 149.40 µs 149.43 µs]
                        change: [+0.5304% +0.6076% +0.6923%] (p = 0.00 < 0.05)
                        Change within noise threshold.
store_benchmark/store_go_base_pallas/_10_16
                        time:   [158.67 µs 158.72 µs 158.76 µs]
                        change: [+3.2666% +3.5636% +3.8114%] (p = 0.00 < 0.05)
                        Performance has regressed.
store_benchmark/store_go_base_bls12/_10_160
                        time:   [154.97 µs 155.27 µs 155.68 µs]
                        change: [+2.5685% +2.8525% +3.1248%] (p = 0.00 < 0.05)
                        Performance has regressed.
store_benchmark/store_go_base_pallas/_10_160
                        time:   [155.86 µs 155.92 µs 155.98 µs]
                        change: [+4.9757% +5.0983% +5.2242%] (p = 0.00 < 0.05)
                        Performance has regressed.

hydration_benchmark/hydration_go_base_bls12/_10_16
                        time:   [110.19 ns 110.25 ns 110.33 ns]
                        change: [-50.966% -50.346% -49.985%] (p = 0.00 < 0.05)
                        Performance has improved.
hydration_benchmark/hydration_go_base_pallas/_10_16
                        time:   [109.74 ns 109.79 ns 109.86 ns]
                        change: [-50.163% -50.104% -50.053%] (p = 0.00 < 0.05)
                        Performance has improved.
hydration_benchmark/hydration_go_base_bls12/_10_160
                        time:   [109.28 ns 109.33 ns 109.39 ns]
                        change: [-50.348% -50.308% -50.259%] (p = 0.00 < 0.05)
                        Performance has improved.
hydration_benchmark/hydration_go_base_pallas/_10_160
                        time:   [109.41 ns 109.57 ns 109.80 ns]
                        change: [-50.195% -50.154% -50.103%] (p = 0.00 < 0.05)
                        Performance has improved.

eval_benchmark/eval_go_base_bls12/_10_16
                        time:   [8.9762 ms 8.9838 ms 8.9917 ms]
                        change: [+1721.4% +1747.0% +1761.1%] (p = 0.00 < 0.05)
                        Performance has regressed.
eval_benchmark/eval_go_base_pallas/_10_16
                        time:   [8.6910 ms 8.6952 ms 8.6996 ms]
                        change: [+1666.8% +1689.1% +1701.0%] (p = 0.00 < 0.05)
                        Performance has regressed.
eval_benchmark/eval_go_base_bls12/_10_160
                        time:   [85.603 ms 85.641 ms 85.680 ms]
                        change: [+1758.7% +1761.9% +1764.4%] (p = 0.00 < 0.05)
                        Performance has regressed.
eval_benchmark/eval_go_base_pallas/_10_160
                        time:   [82.411 ms 82.464 ms 82.517 ms]
                        change: [+1682.0% +1686.8% +1690.6%] (p = 0.00 < 0.05)
                        Performance has regressed.

prove_benchmark/prove_go_base_nova/_10_0
                        time:   [1.1551 s 1.1649 s 1.1721 s]
                        change: [-19.213% -18.429% -17.628%] (p = 0.00 < 0.05)
                        Performance has improved.

prove_compressed_benchmark/prove_compressed_go_base_nova/_10_0
                        time:   [5.1400 s 5.1506 s 5.1602 s]
                        change: [-5.8087% -5.5557% -5.2944%] (p = 0.00 < 0.05)
                        Performance has improved.

verify_benchmark/verify_go_base_nova/_10_0
                        time:   [153.25 ms 154.25 ms 155.22 ms]
                        change: [-16.267% -15.504% -14.747%] (p = 0.00 < 0.05)
                        Performance has improved.

verify_compressed_benchmark/verify_compressed_go_base_nova/_10_0
                        time:   [188.81 ms 189.77 ms 190.67 ms]
                        change: [-1.1278% +0.0074% +1.3270%] (p = 0.99 > 0.05)
                        No change in performance detected.
```