### PR TITLE
tweak: change the HashMap hash algorithm in VarMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ clap = { workspace = true, features = ["derive"] }
 config = "0.13.3"
 dashmap = "5.5.0"
 ff = { workspace = true }
+fxhash = "0.2.1"
 generic-array = "0.14.7"
 hex = { version = "0.4.3", features = ["serde"] }
 indexmap = { version = "1.9.3", features = ["rayon", "serde"] }

--- a/src/lem/var_map.rs
+++ b/src/lem/var_map.rs
@@ -1,5 +1,7 @@
+use std::collections::hash_map::Entry;
+
 use anyhow::{bail, Result};
-use std::collections::{hash_map::Entry, HashMap};
+use fxhash::FxHashMap;
 use tracing::info;
 
 use super::Var;
@@ -9,13 +11,13 @@ use super::Var;
 /// variables before using them, so we don't expect to need some piece of
 /// information from a variable that hasn't been defined.
 #[derive(Clone, Debug)]
-pub struct VarMap<V>(HashMap<Var, V>);
+pub struct VarMap<V>(FxHashMap<Var, V>);
 
 impl<V> VarMap<V> {
     /// Creates an empty `VarMap`
     #[inline]
     pub(crate) fn new() -> VarMap<V> {
-        VarMap(HashMap::default())
+        VarMap(FxHashMap::default())
     }
 
     /// Inserts new data into a `VarMap`


### PR DESCRIPTION
> [!Note]
> the same approach may well yield improvements elsewhere, I've just used it in this one place.

```
group                                                               fxhash                                 main
-----                                                               ------                                 ----
end2end_benchmark/end2end_go_base_nova/_10_0                        1.00    432.0±3.73ms          1.01    436.2±2.14ms
eval_benchmark/eval_go_base_bls12/_10_16                            1.00     10.6±0.03ms          1.45     15.3±0.05ms
eval_benchmark/eval_go_base_bls12/_10_160                           1.00    101.4±1.16ms          1.38    140.3±0.80ms
eval_benchmark/eval_go_base_pallas/_10_16                           1.00      9.2±0.08ms          1.50     13.7±0.04ms
eval_benchmark/eval_go_base_pallas/_10_160                          1.00     85.4±0.80ms          1.48    126.8±0.57ms
hydration_benchmark/hydration_go_base_bls12/_10_16                  1.03    105.0±0.63ns          1.00    101.9±0.51ns
hydration_benchmark/hydration_go_base_bls12/_10_160                 1.00    104.6±0.60ns          1.01    105.6±0.21ns
hydration_benchmark/hydration_go_base_pallas/_10_16                 1.00    105.7±0.77ns          1.00    106.1±0.23ns
hydration_benchmark/hydration_go_base_pallas/_10_160                1.00    105.8±0.74ns          1.00    106.0±0.15ns
prove_benchmark/prove_go_base_nova/_10_0                            1.00    421.7±0.72ms          1.03   436.0±13.93ms
prove_compressed_benchmark/prove_compressed_go_base_nova/_10_0      1.00  1935.3±21.32ms          1.17       2.3±0.41s
store_benchmark/store_go_base_bls12/_10_16                          1.00    146.6±1.41µs          1.00    146.3±0.53µs
store_benchmark/store_go_base_bls12/_10_160                         1.00    145.4±0.97µs          1.03    149.2±0.36µs
store_benchmark/store_go_base_pallas/_10_16                         1.00    145.7±0.98µs          1.02    148.3±0.27µs
store_benchmark/store_go_base_pallas/_10_160                        1.00    146.0±0.92µs          1.00    146.3±1.22µs
verify_benchmark/verify_go_base_nova/_10_0                          1.00     36.5±0.78ms          1.09     39.7±3.32ms
verify_compressed_benchmark/verify_compressed_go_base_nova/_10_0    1.00     33.9±0.98ms          1.11     37.7±2.40ms
```
This compares lem-benchmark (main) at 32ad202b66460d4dcdcae163b158df92e46aa51d with this commit, so we should re-do a benchmark run to get a fresh apples-to-apples comparison between master and lem.