### PR TITLE
Slot allocation of bit decomposition

### DIFF
--- a/src/lem/circuit.rs
+++ b/src/lem/circuit.rs
@@ -48,7 +48,7 @@ use crate::{
 };
 
 use super::{
-    interpreter::{Frame, PreimageData},
+    interpreter::Frame,
     pointers::{Ptr, ZPtr},
     slot::*,
     store::Store,
@@ -173,6 +173,7 @@ fn allocate_img_for_slot<F: LurkField, CS: ConstraintSystem<F>>(
                 let lt = or(&mut cs.namespace(|| "or"), &and1, &and2)?;
                 AllocatedVal::Boolean(lt)
             }
+            SlotType::BitDecomp => todo!(),
         }
     };
     Ok(preallocated_img)
@@ -201,6 +202,7 @@ fn allocate_slots<F: LurkField, CS: ConstraintSystem<F>>(
                 idx: slot_idx,
                 typ: slot_type,
             };
+            assert!(slot_type.is_compatible(preimg_data));
 
             // Allocate the preimage because the image depends on it
             let mut preallocated_preimg = Vec::with_capacity(slot_type.preimg_size());
@@ -259,6 +261,7 @@ fn allocate_slots<F: LurkField, CS: ConstraintSystem<F>>(
                         || *b,
                     ));
                 }
+                PreimageData::F(..) => todo!(),
             }
 
             // Allocate the image by calling the arithmetic function according

--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -1691,15 +1691,14 @@ mod tests {
     use blstrs::Scalar as Fr;
 
     const NUM_INPUTS: usize = 1;
-    const NUM_AUX: usize = 9737;
-    const NUM_CONSTRAINTS: usize = 11664;
+    const NUM_AUX: usize = 9390;
+    const NUM_CONSTRAINTS: usize = 11322;
     const NUM_SLOTS: SlotsCounter = SlotsCounter {
         hash4: 14,
         hash6: 3,
         hash8: 4,
         commitment: 1,
-        less_than: 1,
-        bit_decomp: 1,
+        bit_decomp: 3,
     };
 
     #[test]

--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -1699,6 +1699,7 @@ mod tests {
         hash8: 4,
         commitment: 1,
         less_than: 1,
+        bit_decomp: 1,
     };
 
     #[test]

--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -1691,8 +1691,8 @@ mod tests {
     use blstrs::Scalar as Fr;
 
     const NUM_INPUTS: usize = 1;
-    const NUM_AUX: usize = 10510;
-    const NUM_CONSTRAINTS: usize = 12437;
+    const NUM_AUX: usize = 9737;
+    const NUM_CONSTRAINTS: usize = 11664;
     const NUM_SLOTS: SlotsCounter = SlotsCounter {
         hash4: 14,
         hash6: 3,

--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 use super::{
-    interpreter::{Frame, Preimages},
+    interpreter::{Advices, Frame},
     pointers::Ptr,
     store::Store,
     Ctrl, Func, Op, Tag, Var,
@@ -72,7 +72,7 @@ fn compute_frame<F: LurkField, C: Coprocessor<F>>(
             .expect("Program counter outside range")
     };
     assert_eq!(func.input_params.len(), input.len());
-    let preimages = Preimages::new_from_func(func);
+    let preimages = Advices::new_from_func(func);
     let (frame, _) = func.call(input, store, preimages, emitted, lang, pc)?;
     let must_break = matches!(frame.output[2].tag(), Tag::Cont(Terminal | Error));
     Ok((frame, must_break))

--- a/src/lem/interpreter.rs
+++ b/src/lem/interpreter.rs
@@ -2,7 +2,8 @@ use anyhow::{anyhow, bail, Result};
 use std::collections::VecDeque;
 
 use super::{
-    path::Path, pointers::Ptr, store::Store, var_map::VarMap, Block, Ctrl, Func, Op, Tag, Var,
+    path::Path, pointers::Ptr, slot::PreimageData, store::Store, var_map::VarMap, Block, Ctrl,
+    Func, Op, Tag, Var,
 };
 
 use crate::{
@@ -13,13 +14,6 @@ use crate::{
     state::initial_lurk_state,
     tag::ExprTag::{Comm, Nil, Num, Sym},
 };
-
-#[derive(Clone, Debug)]
-pub enum PreimageData<F: LurkField> {
-    PtrVec(Vec<Ptr<F>>),
-    FPtr(F, Ptr<F>),
-    FPair(F, F),
-}
 
 pub enum Val<F: LurkField> {
     Pointer(Ptr<F>),
@@ -297,6 +291,7 @@ impl Block {
                     assert!(*n <= 64);
                     let a = bindings.get_ptr(a)?;
                     let c = if let Ptr::Atom(_, f) = a {
+                        preimages.less_than.push(Some(PreimageData::F(f)));
                         let b = if *n < 64 { (1 << *n) - 1 } else { u64::MAX };
                         Ptr::Atom(Tag::Expr(Num), F::from_u64(f.to_u64_unchecked() & b))
                     } else {

--- a/src/lem/interpreter.rs
+++ b/src/lem/interpreter.rs
@@ -2,8 +2,8 @@ use anyhow::{anyhow, bail, Result};
 use std::collections::VecDeque;
 
 use super::{
-    path::Path, pointers::Ptr, slot::PreimageData, store::Store, var_map::VarMap, Block, Ctrl,
-    Func, Op, Tag, Var,
+    path::Path, pointers::Ptr, slot::SlotData, store::Store, var_map::VarMap, Block, Ctrl, Func,
+    Op, Tag, Var,
 };
 
 use crate::{
@@ -49,22 +49,22 @@ impl<F: LurkField> VarMap<Val<F>> {
 }
 
 #[derive(Clone, Debug, Default)]
-/// `Preimages` hold the non-deterministic advices for hashes and `Func` calls.
+/// `Advices` hold the non-deterministic advices for hashes and `Func` calls.
 /// The hash preimages must have the same shape as the allocated slots for the
 /// `Func`, and the `None` values are used to fill the unused slots, which are
 /// later filled by dummy values.
-pub struct Preimages<F: LurkField> {
-    pub hash4: Vec<Option<PreimageData<F>>>,
-    pub hash6: Vec<Option<PreimageData<F>>>,
-    pub hash8: Vec<Option<PreimageData<F>>>,
-    pub commitment: Vec<Option<PreimageData<F>>>,
-    pub bit_decomp: Vec<Option<PreimageData<F>>>,
+pub struct Advices<F: LurkField> {
+    pub hash4: Vec<Option<SlotData<F>>>,
+    pub hash6: Vec<Option<SlotData<F>>>,
+    pub hash8: Vec<Option<SlotData<F>>>,
+    pub commitment: Vec<Option<SlotData<F>>>,
+    pub bit_decomp: Vec<Option<SlotData<F>>>,
     pub call_outputs: VecDeque<Vec<Ptr<F>>>,
     pub cproc_outputs: Vec<Vec<Ptr<F>>>,
 }
 
-impl<F: LurkField> Preimages<F> {
-    pub fn new_from_func(func: &Func) -> Preimages<F> {
+impl<F: LurkField> Advices<F> {
+    pub fn new_from_func(func: &Func) -> Advices<F> {
         let slot = func.slot;
         let hash4 = Vec::with_capacity(slot.hash4);
         let hash6 = Vec::with_capacity(slot.hash6);
@@ -73,7 +73,7 @@ impl<F: LurkField> Preimages<F> {
         let bit_decomp = Vec::with_capacity(slot.bit_decomp);
         let call_outputs = VecDeque::new();
         let cproc_outputs = Vec::new();
-        Preimages {
+        Advices {
             hash4,
             hash6,
             hash8,
@@ -84,7 +84,7 @@ impl<F: LurkField> Preimages<F> {
         }
     }
 
-    pub fn blank(func: &Func) -> Preimages<F> {
+    pub fn blank(func: &Func) -> Advices<F> {
         let slot = func.slot;
         let hash4 = vec![None; slot.hash4];
         let hash6 = vec![None; slot.hash6];
@@ -93,7 +93,7 @@ impl<F: LurkField> Preimages<F> {
         let bit_decomp = vec![None; slot.bit_decomp];
         let call_outputs = VecDeque::new();
         let cproc_outputs = Vec::new();
-        Preimages {
+        Advices {
             hash4,
             hash6,
             hash8,
@@ -115,7 +115,7 @@ pub struct Frame<F: LurkField> {
     pub input: Vec<Ptr<F>>,
     pub output: Vec<Ptr<F>>,
     pub emitted: Vec<Ptr<F>>,
-    pub preimages: Preimages<F>,
+    pub advices: Advices<F>,
     pub blank: bool,
     pub pc: usize,
 }
@@ -124,12 +124,12 @@ impl<F: LurkField> Frame<F> {
     pub fn blank(func: &Func, pc: usize) -> Frame<F> {
         let input = vec![Ptr::null(Tag::Expr(Nil)); func.input_params.len()];
         let output = vec![Ptr::null(Tag::Expr(Nil)); func.output_size];
-        let preimages = Preimages::blank(func);
+        let advices = Advices::blank(func);
         Frame {
             input,
             output,
             emitted: Vec::default(),
-            preimages,
+            advices,
             blank: true,
             pc,
         }
@@ -145,7 +145,7 @@ impl Block {
         input: &[Ptr<F>],
         store: &Store<F>,
         mut bindings: VarMap<Val<F>>,
-        mut preimages: Preimages<F>,
+        mut advices: Advices<F>,
         mut path: Path,
         emitted: &mut Vec<Ptr<F>>,
         lang: &Lang<F, C>,
@@ -165,7 +165,7 @@ impl Block {
                     for (var, ptr) in out.iter().zip(&out_ptrs) {
                         bindings.insert(var.clone(), Val::Pointer(*ptr));
                     }
-                    preimages.cproc_outputs.push(out_ptrs);
+                    advices.cproc_outputs.push(out_ptrs);
                 }
                 Op::Call(out, func, inp) => {
                     // Get the argument values
@@ -176,10 +176,10 @@ impl Block {
                     // save all the inner call outputs, push the output of the call in front
                     // of it, then extend `call_outputs`
                     let mut inner_call_outputs = VecDeque::new();
-                    std::mem::swap(&mut inner_call_outputs, &mut preimages.call_outputs);
+                    std::mem::swap(&mut inner_call_outputs, &mut advices.call_outputs);
                     let (mut frame, func_path) =
-                        func.call(&inp_ptrs, store, preimages, emitted, lang, pc)?;
-                    std::mem::swap(&mut inner_call_outputs, &mut frame.preimages.call_outputs);
+                        func.call(&inp_ptrs, store, advices, emitted, lang, pc)?;
+                    std::mem::swap(&mut inner_call_outputs, &mut frame.advices.call_outputs);
 
                     // Extend the path and bind the output variables to the output values
                     path.extend_from_path(&func_path);
@@ -187,10 +187,10 @@ impl Block {
                         bindings.insert_ptr(var.clone(), *ptr);
                     }
 
-                    // Update `preimages` correctly
+                    // Update `advices` correctly
                     inner_call_outputs.push_front(frame.output);
-                    preimages = frame.preimages;
-                    preimages.call_outputs.extend(inner_call_outputs);
+                    advices = frame.advices;
+                    advices.call_outputs.extend(inner_call_outputs);
                 }
                 Op::Null(tgt, tag) => {
                     bindings.insert_ptr(tgt.clone(), Ptr::null(*tag));
@@ -279,11 +279,9 @@ impl Block {
                     let b = bindings.get_ptr(b)?;
                     let c = if let (Ptr::Atom(_, f), Ptr::Atom(_, g)) = (a, b) {
                         let diff = f - g;
-                        preimages.bit_decomp.push(Some(PreimageData::F(f + f)));
-                        preimages.bit_decomp.push(Some(PreimageData::F(g + g)));
-                        preimages
-                            .bit_decomp
-                            .push(Some(PreimageData::F(diff + diff)));
+                        advices.bit_decomp.push(Some(SlotData::F(f + f)));
+                        advices.bit_decomp.push(Some(SlotData::F(g + g)));
+                        advices.bit_decomp.push(Some(SlotData::F(diff + diff)));
                         let f = BaseNum::Scalar(f);
                         let g = BaseNum::Scalar(g);
                         f < g
@@ -296,7 +294,7 @@ impl Block {
                     assert!(*n <= 64);
                     let a = bindings.get_ptr(a)?;
                     let c = if let Ptr::Atom(_, f) = a {
-                        preimages.bit_decomp.push(Some(PreimageData::F(f)));
+                        advices.bit_decomp.push(Some(SlotData::F(f)));
                         let b = if *n < 64 { (1 << *n) - 1 } else { u64::MAX };
                         Ptr::Atom(Tag::Expr(Num), F::from_u64(f.to_u64_unchecked() & b))
                     } else {
@@ -331,18 +329,14 @@ impl Block {
                     let preimg_ptrs = bindings.get_many_ptr(preimg)?;
                     let tgt_ptr = store.intern_2_ptrs(*tag, preimg_ptrs[0], preimg_ptrs[1]);
                     bindings.insert_ptr(img.clone(), tgt_ptr);
-                    preimages
-                        .hash4
-                        .push(Some(PreimageData::PtrVec(preimg_ptrs)));
+                    advices.hash4.push(Some(SlotData::PtrVec(preimg_ptrs)));
                 }
                 Op::Cons3(img, tag, preimg) => {
                     let preimg_ptrs = bindings.get_many_ptr(preimg)?;
                     let tgt_ptr =
                         store.intern_3_ptrs(*tag, preimg_ptrs[0], preimg_ptrs[1], preimg_ptrs[2]);
                     bindings.insert_ptr(img.clone(), tgt_ptr);
-                    preimages
-                        .hash6
-                        .push(Some(PreimageData::PtrVec(preimg_ptrs)));
+                    advices.hash6.push(Some(SlotData::PtrVec(preimg_ptrs)));
                 }
                 Op::Cons4(img, tag, preimg) => {
                     let preimg_ptrs = bindings.get_many_ptr(preimg)?;
@@ -354,9 +348,7 @@ impl Block {
                         preimg_ptrs[3],
                     );
                     bindings.insert_ptr(img.clone(), tgt_ptr);
-                    preimages
-                        .hash8
-                        .push(Some(PreimageData::PtrVec(preimg_ptrs)));
+                    advices.hash8.push(Some(SlotData::PtrVec(preimg_ptrs)));
                 }
                 Op::Decons2(preimg, img) => {
                     let img_ptr = bindings.get_ptr(img)?;
@@ -370,9 +362,9 @@ impl Block {
                     for (var, ptr) in preimg.iter().zip(preimg_ptrs.iter()) {
                         bindings.insert_ptr(var.clone(), *ptr);
                     }
-                    preimages
+                    advices
                         .hash4
-                        .push(Some(PreimageData::PtrVec(preimg_ptrs.to_vec())));
+                        .push(Some(SlotData::PtrVec(preimg_ptrs.to_vec())));
                 }
                 Op::Decons3(preimg, img) => {
                     let img_ptr = bindings.get_ptr(img)?;
@@ -386,9 +378,9 @@ impl Block {
                     for (var, ptr) in preimg.iter().zip(preimg_ptrs.iter()) {
                         bindings.insert_ptr(var.clone(), *ptr);
                     }
-                    preimages
+                    advices
                         .hash6
-                        .push(Some(PreimageData::PtrVec(preimg_ptrs.to_vec())));
+                        .push(Some(SlotData::PtrVec(preimg_ptrs.to_vec())));
                 }
                 Op::Decons4(preimg, img) => {
                     let img_ptr = bindings.get_ptr(img)?;
@@ -402,9 +394,9 @@ impl Block {
                     for (var, ptr) in preimg.iter().zip(preimg_ptrs.iter()) {
                         bindings.insert_ptr(var.clone(), *ptr);
                     }
-                    preimages
+                    advices
                         .hash8
-                        .push(Some(PreimageData::PtrVec(preimg_ptrs.to_vec())));
+                        .push(Some(SlotData::PtrVec(preimg_ptrs.to_vec())));
                 }
                 Op::Hide(tgt, sec, src) => {
                     let src_ptr = bindings.get_ptr(src)?;
@@ -412,9 +404,9 @@ impl Block {
                         bail!("{sec} is not a numeric pointer")
                     };
                     let tgt_ptr = store.hide(secret, src_ptr)?;
-                    preimages
+                    advices
                         .commitment
-                        .push(Some(PreimageData::FPtr(secret, src_ptr)));
+                        .push(Some(SlotData::FPtr(secret, src_ptr)));
                     bindings.insert_ptr(tgt.clone(), tgt_ptr);
                 }
                 Op::Open(tgt_secret, tgt_ptr, comm) => {
@@ -426,9 +418,7 @@ impl Block {
                     };
                     bindings.insert_ptr(tgt_ptr.clone(), *ptr);
                     bindings.insert_ptr(tgt_secret.clone(), Ptr::Atom(Tag::Expr(Num), *secret));
-                    preimages
-                        .commitment
-                        .push(Some(PreimageData::FPtr(*secret, *ptr)))
+                    advices.commitment.push(Some(SlotData::FPtr(*secret, *ptr)))
                 }
             }
         }
@@ -438,13 +428,13 @@ impl Block {
                 let tag = ptr.tag();
                 if let Some(block) = cases.get(tag) {
                     path.push_tag_inplace(*tag);
-                    block.run(input, store, bindings, preimages, path, emitted, lang, pc)
+                    block.run(input, store, bindings, advices, path, emitted, lang, pc)
                 } else {
                     path.push_default_inplace();
                     let Some(def) = def else {
                         bail!("No match for tag {}", tag)
                     };
-                    def.run(input, store, bindings, preimages, path, emitted, lang, pc)
+                    def.run(input, store, bindings, advices, path, emitted, lang, pc)
                 }
             }
             Ctrl::MatchSymbol(match_var, cases, def) => {
@@ -457,22 +447,22 @@ impl Block {
                 };
                 if let Some(block) = cases.get(&sym) {
                     path.push_symbol_inplace(sym);
-                    block.run(input, store, bindings, preimages, path, emitted, lang, pc)
+                    block.run(input, store, bindings, advices, path, emitted, lang, pc)
                 } else {
                     path.push_default_inplace();
                     let Some(def) = def else {
                         bail!("No match for symbol {sym}")
                     };
-                    def.run(input, store, bindings, preimages, path, emitted, lang, pc)
+                    def.run(input, store, bindings, advices, path, emitted, lang, pc)
                 }
             }
             Ctrl::If(b, true_block, false_block) => {
                 let b = bindings.get_bool(b)?;
                 path.push_bool_inplace(b);
                 if b {
-                    true_block.run(input, store, bindings, preimages, path, emitted, lang, pc)
+                    true_block.run(input, store, bindings, advices, path, emitted, lang, pc)
                 } else {
-                    false_block.run(input, store, bindings, preimages, path, emitted, lang, pc)
+                    false_block.run(input, store, bindings, advices, path, emitted, lang, pc)
                 }
             }
             Ctrl::Return(output_vars) => {
@@ -486,7 +476,7 @@ impl Block {
                         input,
                         output,
                         emitted: emitted.clone(),
-                        preimages,
+                        advices,
                         blank: false,
                         pc,
                     },
@@ -502,7 +492,7 @@ impl Func {
         &self,
         args: &[Ptr<F>],
         store: &Store<F>,
-        preimages: Preimages<F>,
+        advices: Advices<F>,
         emitted: &mut Vec<Ptr<F>>,
         lang: &Lang<F, C>,
         pc: usize,
@@ -513,45 +503,45 @@ impl Func {
         }
 
         // We must fill any unused slots with `None` values so we save
-        // the initial size of preimages, which might not be zero
-        let hash4_init = preimages.hash4.len();
-        let hash6_init = preimages.hash6.len();
-        let hash8_init = preimages.hash8.len();
-        let commitment_init = preimages.commitment.len();
-        let bit_decomp_init = preimages.bit_decomp.len();
+        // the initial size of advices, which might not be zero
+        let hash4_init = advices.hash4.len();
+        let hash6_init = advices.hash6.len();
+        let hash8_init = advices.hash8.len();
+        let commitment_init = advices.commitment.len();
+        let bit_decomp_init = advices.bit_decomp.len();
 
         let mut res = self.body.run(
             args,
             store,
             bindings,
-            preimages,
+            advices,
             Path::default(),
             emitted,
             lang,
             pc,
         )?;
-        let preimages = &mut res.0.preimages;
+        let advices = &mut res.0.advices;
 
-        let hash4_used = preimages.hash4.len() - hash4_init;
-        let hash6_used = preimages.hash6.len() - hash6_init;
-        let hash8_used = preimages.hash8.len() - hash8_init;
-        let commitment_used = preimages.commitment.len() - commitment_init;
-        let bit_decomp_used = preimages.bit_decomp.len() - bit_decomp_init;
+        let hash4_used = advices.hash4.len() - hash4_init;
+        let hash6_used = advices.hash6.len() - hash6_init;
+        let hash8_used = advices.hash8.len() - hash8_init;
+        let commitment_used = advices.commitment.len() - commitment_init;
+        let bit_decomp_used = advices.bit_decomp.len() - bit_decomp_init;
 
         for _ in hash4_used..self.slot.hash4 {
-            preimages.hash4.push(None);
+            advices.hash4.push(None);
         }
         for _ in hash6_used..self.slot.hash6 {
-            preimages.hash6.push(None);
+            advices.hash6.push(None);
         }
         for _ in hash8_used..self.slot.hash8 {
-            preimages.hash8.push(None);
+            advices.hash8.push(None);
         }
         for _ in commitment_used..self.slot.commitment {
-            preimages.commitment.push(None);
+            advices.commitment.push(None);
         }
         for _ in bit_decomp_used..self.slot.bit_decomp {
-            preimages.bit_decomp.push(None);
+            advices.bit_decomp.push(None);
         }
 
         Ok(res)
@@ -569,7 +559,7 @@ impl Func {
             .call(
                 args,
                 store,
-                Preimages::new_from_func(self),
+                Advices::new_from_func(self),
                 &mut vec![],
                 lang,
                 pc,

--- a/src/lem/slot.rs
+++ b/src/lem/slot.rs
@@ -270,16 +270,15 @@ impl SlotType {
     }
 
     pub(crate) fn is_compatible<F: LurkField>(&self, preimg: &PreimageData<F>) -> bool {
-        use PreimageData::*;
-        match (self, preimg) {
-            (Self::Hash4, PtrVec(..))
-            | (Self::Hash6, PtrVec(..))
-            | (Self::Hash8, PtrVec(..))
-            | (Self::Commitment, FPtr(..))
-            | (Self::LessThan, FPair(..))
-            | (Self::BitDecomp, F(..)) => true,
-            _ => false,
-        }
+        matches!(
+            (self, preimg),
+            (Self::Hash4, PreimageData::PtrVec(..))
+                | (Self::Hash6, PreimageData::PtrVec(..))
+                | (Self::Hash8, PreimageData::PtrVec(..))
+                | (Self::Commitment, PreimageData::FPtr(..))
+                | (Self::LessThan, PreimageData::FPair(..))
+                | (Self::BitDecomp, PreimageData::F(..))
+        )
     }
 }
 

--- a/src/lem/slot.rs
+++ b/src/lem/slot.rs
@@ -230,7 +230,7 @@ impl Block {
 }
 
 #[derive(Clone, Debug)]
-pub enum PreimageData<F: LurkField> {
+pub enum SlotData<F: LurkField> {
     PtrVec(Vec<Ptr<F>>),
     FPtr(F, Ptr<F>),
     F(F),
@@ -256,14 +256,14 @@ impl SlotType {
         }
     }
 
-    pub(crate) fn is_compatible<F: LurkField>(&self, preimg: &PreimageData<F>) -> bool {
+    pub(crate) fn is_compatible<F: LurkField>(&self, slot_data: &SlotData<F>) -> bool {
         matches!(
-            (self, preimg),
-            (Self::Hash4, PreimageData::PtrVec(..))
-                | (Self::Hash6, PreimageData::PtrVec(..))
-                | (Self::Hash8, PreimageData::PtrVec(..))
-                | (Self::Commitment, PreimageData::FPtr(..))
-                | (Self::BitDecomp, PreimageData::F(..))
+            (self, slot_data),
+            (Self::Hash4, SlotData::PtrVec(..))
+                | (Self::Hash6, SlotData::PtrVec(..))
+                | (Self::Hash8, SlotData::PtrVec(..))
+                | (Self::Commitment, SlotData::FPtr(..))
+                | (Self::BitDecomp, SlotData::F(..))
         )
     }
 }

--- a/src/lem/tests/misc.rs
+++ b/src/lem/tests/misc.rs
@@ -123,7 +123,7 @@ fn handles_non_ssa() {
     });
 
     let inputs = vec![Ptr::num(Fr::from_u64(42))];
-    synthesize_test_helper(&func, inputs, SlotsCounter::new((2, 0, 0, 0, 0, 0)));
+    synthesize_test_helper(&func, inputs, SlotsCounter::new((2, 0, 0, 0, 0)));
 }
 
 #[test]
@@ -184,7 +184,7 @@ fn test_hash_slots() {
     });
 
     let inputs = vec![Ptr::num(Fr::from_u64(42)), Ptr::char('c')];
-    synthesize_test_helper(&lem, inputs, SlotsCounter::new((2, 2, 2, 0, 0, 0)));
+    synthesize_test_helper(&lem, inputs, SlotsCounter::new((2, 2, 2, 0, 0)));
 }
 
 #[test]
@@ -218,7 +218,7 @@ fn test_unhash_slots() {
     });
 
     let inputs = vec![Ptr::num(Fr::from_u64(42)), Ptr::char('c')];
-    synthesize_test_helper(&lem, inputs, SlotsCounter::new((3, 3, 3, 0, 0, 0)));
+    synthesize_test_helper(&lem, inputs, SlotsCounter::new((3, 3, 3, 0, 0)));
 }
 
 #[test]
@@ -265,5 +265,5 @@ fn test_unhash_nested_slots() {
     });
 
     let inputs = vec![Ptr::num(Fr::from_u64(42)), Ptr::char('c')];
-    synthesize_test_helper(&lem, inputs, SlotsCounter::new((4, 4, 4, 0, 0, 0)));
+    synthesize_test_helper(&lem, inputs, SlotsCounter::new((4, 4, 4, 0, 0)));
 }

--- a/src/lem/tests/misc.rs
+++ b/src/lem/tests/misc.rs
@@ -123,7 +123,7 @@ fn handles_non_ssa() {
     });
 
     let inputs = vec![Ptr::num(Fr::from_u64(42))];
-    synthesize_test_helper(&func, inputs, SlotsCounter::new((2, 0, 0, 0, 0)));
+    synthesize_test_helper(&func, inputs, SlotsCounter::new((2, 0, 0, 0, 0, 0)));
 }
 
 #[test]
@@ -184,7 +184,7 @@ fn test_hash_slots() {
     });
 
     let inputs = vec![Ptr::num(Fr::from_u64(42)), Ptr::char('c')];
-    synthesize_test_helper(&lem, inputs, SlotsCounter::new((2, 2, 2, 0, 0)));
+    synthesize_test_helper(&lem, inputs, SlotsCounter::new((2, 2, 2, 0, 0, 0)));
 }
 
 #[test]
@@ -218,7 +218,7 @@ fn test_unhash_slots() {
     });
 
     let inputs = vec![Ptr::num(Fr::from_u64(42)), Ptr::char('c')];
-    synthesize_test_helper(&lem, inputs, SlotsCounter::new((3, 3, 3, 0, 0)));
+    synthesize_test_helper(&lem, inputs, SlotsCounter::new((3, 3, 3, 0, 0, 0)));
 }
 
 #[test]
@@ -265,5 +265,5 @@ fn test_unhash_nested_slots() {
     });
 
     let inputs = vec![Ptr::num(Fr::from_u64(42)), Ptr::char('c')];
-    synthesize_test_helper(&lem, inputs, SlotsCounter::new((4, 4, 4, 0, 0)));
+    synthesize_test_helper(&lem, inputs, SlotsCounter::new((4, 4, 4, 0, 0, 0)));
 }


### PR DESCRIPTION
This PR replaces slot allocation for "less-than" operations with slot allocation for bit decomposition.
Slot allocating bit decomposition allows us to reuse bit decomposition in truncate operations, leading to 1k less constraints/auxiliaries