### PR TITLE
Safer hydration mechanics

### DIFF
--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -127,6 +127,10 @@ impl<F: LurkField> EvaluationStore for Store<F> {
         Store::get_cont_terminal(self)
     }
 
+    fn hydrate_z_cache(&self) {
+        self.hydrate_scalar_cache()
+    }
+
     fn ptr_eq(&self, left: &Self::Ptr, right: &Self::Ptr) -> Result<bool, Self::Error> {
         self.ptr_eq(left, right)
     }

--- a/src/lem/multiframe.rs
+++ b/src/lem/multiframe.rs
@@ -103,6 +103,10 @@ impl<F: LurkField> EvaluationStore for Store<F> {
         Ptr::null(Tag::Cont(ContTag::Terminal))
     }
 
+    fn hydrate_z_cache(&self) {
+        self.hydrate_z_cache()
+    }
+
     fn ptr_eq(&self, left: &Self::Ptr, right: &Self::Ptr) -> Result<bool, Self::Error> {
         Ok(self.hash_ptr(left)? == self.hash_ptr(right)?)
     }

--- a/src/lem/pointers.rs
+++ b/src/lem/pointers.rs
@@ -103,6 +103,11 @@ impl<F: LurkField> Ptr<F> {
     }
 
     #[inline]
+    pub fn is_tuple(&self) -> bool {
+        matches!(self, Ptr::Tuple2(..) | Ptr::Tuple3(..) | Ptr::Tuple4(..))
+    }
+
+    #[inline]
     pub fn get_atom(&self) -> Option<&F> {
         match self {
             Ptr::Atom(_, f) => Some(f),

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -68,6 +68,9 @@ pub trait EvaluationStore {
     /// getting the terminal continuation pointer
     fn get_cont_terminal(&self) -> Self::ContPtr;
 
+    /// cache hashes for pointers enqueued for hydration
+    fn hydrate_z_cache(&self);
+
     /// hash-equality of the expressions represented by Ptrs
     fn ptr_eq(&self, left: &Self::Ptr, right: &Self::Ptr) -> Result<bool, Self::Error>;
 }

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -37,7 +37,7 @@ use crate::{
     error::ProofError,
     eval::{lang::Lang, Meta},
     field::LurkField,
-    proof::{supernova::FoldingConfig, FrameLike, MultiFrameTrait, Prover},
+    proof::{supernova::FoldingConfig, EvaluationStore, FrameLike, MultiFrameTrait, Prover},
     store::Store,
 };
 
@@ -306,6 +306,7 @@ where
         store: &'a M::Store,
         lang: &Arc<Lang<F, C>>,
     ) -> Result<(Proof<'a, F, C, M>, Vec<F>, Vec<F>, usize), ProofError> {
+        store.hydrate_z_cache();
         let z0 = M::io_to_scalar_vector(store, frames[0].input()).map_err(|e| e.into())?;
         let zi =
             M::io_to_scalar_vector(store, frames.last().unwrap().output()).map_err(|e| e.into())?;

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -24,7 +24,7 @@ use crate::{
     field::LurkField,
     proof::{
         nova::{CurveCycleEquipped, NovaCircuitShape, G1, G2},
-        {FrameLike, MultiFrameTrait, Provable, Prover},
+        {EvaluationStore, FrameLike, MultiFrameTrait, Provable, Prover},
     },
 };
 
@@ -269,6 +269,7 @@ where
         store: &'a M::Store,
         lang: Arc<Lang<F, C>>,
     ) -> Result<(Proof<'a, F, C, M>, Vec<F>, Vec<F>, usize, usize), ProofError> {
+        store.hydrate_z_cache();
         let z0 = M::io_to_scalar_vector(store, frames[0].input()).map_err(|e| e.into())?;
         let zi =
             M::io_to_scalar_vector(store, frames.last().unwrap().output()).map_err(|e| e.into())?;


### PR DESCRIPTION
Alpha's `Store::hash_expr`/`Store::hash_cont` and LEM's `Store::hash_ptr` are recursive and present a risk of exceeding the recursion depth limit if the Lurk data being content-addressed is too deep.

This PR assures that hydration is called right at the start of proving, which eliminates that risk in such scenarios.

This change doesn't bring relevant improvements in the proving benchmarks, which makes sense because the stores' hashing functions are fast enough by themselves even without hydration.

### Changes specific to LEM's `Store`

1. Introduce safe APIs for hashing pointers in contexts where hydration is not assumed to have been performed, such as interpretation
2. Set a chunk size limit of 256 for parallel hashing motivated by memory limit safety

Unexpectedly, the chunk size limit made LEM's hydration slightly faster:
```text
hydration_benchmark/hydration_go_base_bls12/_10_16
                        time:   [105.62 ns 105.63 ns 105.64 ns]
                        change: [-3.4599% -3.3969% -3.3387%] (p = 0.00 < 0.05)
                        Performance has improved.
hydration_benchmark/hydration_go_base_pallas/_10_16
                        time:   [105.66 ns 105.74 ns 105.83 ns]
                        change: [-5.0526% -4.9272% -4.7995%] (p = 0.00 < 0.05)
                        Performance has improved.
hydration_benchmark/hydration_go_base_bls12/_10_160
                        time:   [105.59 ns 105.59 ns 105.60 ns]
                        change: [-3.2606% -3.2189% -3.1799%] (p = 0.00 < 0.05)
                        Performance has improved.
hydration_benchmark/hydration_go_base_pallas/_10_160
                        time:   [105.60 ns 105.77 ns 106.04 ns]
                        change: [-4.6223% -4.4255% -4.1310%] (p = 0.00 < 0.05)
                        Performance has improved.
```