### PR TITLE
Repair nightly

### DIFF
--- a/clutch/demo/chained-functional-commitment.lurk
+++ b/clutch/demo/chained-functional-commitment.lurk
@@ -9,7 +9,7 @@
 
 ;; We chain a next commitment by applying the committed function to a value of 9.
 
-!(chain 0x2da6ae5854eb3055c31cbcd632f4d833a2a73fae5f5be4ee20fad3100285a28a 9)
+!(chain 0x06042852d90bf409974d1ee3bc153c0f48ea5512c9b4f697561df9ad7b5abbe0 9)
 
 ;; The new counter value is 9, and the function returns a new functional commitment.
 
@@ -25,7 +25,7 @@
 
 ;; Now let's chain another call to the new head, adding 12 to the counter.
 
-!(chain 0x30773603a363eac816a6e6e80e39c8eda0342635ffeb63e9c2412e3d3fb4da5b 12)
+!(chain 0x251ccd3ecf6ae912eeb6558733b04b50e0b0c374a2dd1b797fcca84b0d9a8794 12)
 
 ;; Now the counter is 21, and we have a new head commitment.
 
@@ -39,7 +39,7 @@
 
 ;; One more time, we'll add 14 to the head commitment's internal state.
 
-!(chain 0x0d628d7c6def025fe258334476b4950cfac1f86cadc68c06497aaee27f208532 14)
+!(chain 0x281605259696cd2529c00806465c9726d81df4ccd2c3500312c991c1fd572592 14)
 
 ;; 21 + 14 = 35, as expected.
 

--- a/clutch/demo/functional-commitment.lurk
+++ b/clutch/demo/functional-commitment.lurk
@@ -10,7 +10,7 @@
 
 ;; We open the functional commitment on input 5: Evaluate f(5).
 
-!(call 0x3238c07bcc3c57b7466ee2370571a7cb862368036943abf41e956aa7f95bcd3d 5)
+!(call 0x178453ec28175e52c42a6467520df4a1322dd03e06abb3dfc829425ac590e48c 5)
 
 ;; We can prove the functional-commitment opening.
 

--- a/fcomm/examples/Makefile
+++ b/fcomm/examples/Makefile
@@ -40,10 +40,10 @@ chained-opening.json : chained-function.json chained-input.lurk chained-commitme
 	cargo run --release open --function chained-function.json --input chained-input.lurk --proof chained-opening.json --chain
 
 chained2-opening chained2-opening.json : chained-input.lurk chained-opening
-	# NOTE: This concrete commitment (19ca81b443bf0bdf8b6edb5fb6d1571d8e405f24459f6e2f880076b76e2510a1) can be found
+	# NOTE: This concrete commitment (18d939e4cacdcc3c9b3752f84edd34e8455fc83c90b56059f27d79629da46e16) can be found
 	# in chained-opening.json, but its identity is determistic based on the secret and 'second return value' (cdr)
 	# of the function specified in chained-function.json.
-	cargo run --release open --commitment 19ca81b443bf0bdf8b6edb5fb6d1571d8e405f24459f6e2f880076b76e2510a1 --input chained-input.lurk --proof chained2-opening.json --chain
+	cargo run --release open --commitment 18d939e4cacdcc3c9b3752f84edd34e8455fc83c90b56059f27d79629da46e16 --input chained-input.lurk --proof chained2-opening.json --chain
 
 chained2-from_req-opening chained2-from_req-opening.json : chained2-opening chained-request.json
 	cargo run --release open --request chained-request.json --proof chained2-from_req-opening.json

--- a/fcomm/examples/chained-request.json
+++ b/fcomm/examples/chained-request.json
@@ -1,1 +1,1 @@
-{"commitment":"19ca81b443bf0bdf8b6edb5fb6d1571d8e405f24459f6e2f880076b76e2510a1","input":{"expr":{"Source":"9"}},"chain":true}
+{"commitment":"1a25fa00d461d94e16a9be54cc43d9e132043fc938b818d8dd97ea6602a2832a","input":{"expr":{"Source":"9"}},"chain":true}

--- a/fcomm/src/bin/fcomm.rs
+++ b/fcomm/src/bin/fcomm.rs
@@ -509,7 +509,7 @@ fn expression<P: AsRef<Path>, F: LurkField + Serialize + DeserializeOwned>(
 fn opening_request<P: AsRef<Path>, F: LurkField + Serialize + DeserializeOwned>(
     request_path: P,
 ) -> Result<OpeningRequest<F>, error::Error> {
-    OpeningRequest::read_from_path(request_path)
+    OpeningRequest::read_from_json_path(request_path)
 }
 
 // Get proof from supplied path or else from stdin.

--- a/fcomm/tests/makefile_tests.rs
+++ b/fcomm/tests/makefile_tests.rs
@@ -16,6 +16,19 @@ fn test_make_fcomm_examples() {
         "Failed to find the fcomm examples directory"
     );
 
+    // Make clean
+    let make_clean_output = Command::new("make")
+        .arg("clean")
+        .current_dir(examples_dir)
+        .output()
+        .expect("Failed to run the make command, is make installed?");
+
+    assert!(
+        make_clean_output.status.success(),
+        "Make command exited with an error: {}",
+        String::from_utf8_lossy(&make_clean_output.stderr)
+    );
+
     // Run the make command in the examples directory
     let cpus = num_cpus::get();
 


### PR DESCRIPTION
- repairs the clutch tests,
- repairs the fcomm tests and execute `make clean` before running Makefile tests.