### PR TITLE
More LEM benchmarks and `Coproc` derivied implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,11 +179,23 @@ name = "fibonacci"
 harness = false
 
 [[bench]]
+name = "fibonacci_lem"
+harness = false
+
+[[bench]]
 name = "synthesis"
 harness = false
 
 [[bench]]
+name = "synthesis_lem"
+harness = false
+
+[[bench]]
 name = "sha256"
+harness = false
+
+[[bench]]
+name = "sha256_lem"
 harness = false
 
 [[bench]]

--- a/benches/end2end_lem.rs
+++ b/benches/end2end_lem.rs
@@ -95,7 +95,7 @@ fn store_benchmark_lem(c: &mut Criterion) {
     let state = State::init_lurk_state().rccell();
 
     // todo!() rfc out into more flexible test cases
-    let sizes = vec![(10, 16), (10, 160)];
+    let sizes = [(10, 16), (10, 160)];
     for size in sizes {
         let parameter_string = format!("_{}_{}", size.0, size.1);
 
@@ -134,7 +134,7 @@ fn hydration_benchmark_lem(c: &mut Criterion) {
     let state = State::init_lurk_state().rccell();
 
     // todo!() rfc out into more flexible test cases
-    let sizes = vec![(10, 16), (10, 160)];
+    let sizes = [(10, 16), (10, 160)];
     for size in sizes {
         let parameter_string = format!("_{}_{}", size.0, size.1);
 
@@ -174,7 +174,7 @@ fn eval_benchmark_lem(c: &mut Criterion) {
     let state = State::init_lurk_state().rccell();
 
     // todo!() rfc out into more flexible test cases
-    let sizes = vec![(10, 16), (10, 160)];
+    let sizes = [(10, 16), (10, 160)];
     for size in sizes {
         let parameter_string = format!("_{}_{}", size.0, size.1);
 
@@ -327,7 +327,7 @@ fn verify_benchmark_lem(c: &mut Criterion) {
     let pp: PublicParams<Fq, MultiFrame<'_, Fq, Coproc<Fq>>> =
         public_params(reduction_count, lang.clone());
 
-    let sizes = vec![(10, 0)];
+    let sizes = [(10, 0)];
     for size in sizes {
         let parameter_string = format!("_{}_{}", size.0, size.1);
         let benchmark_id = BenchmarkId::new("verify_go_base_nova", &parameter_string);
@@ -370,7 +370,7 @@ fn verify_compressed_benchmark_lem(c: &mut Criterion) {
     let pp: PublicParams<Fq, MultiFrame<'_, Fq, Coproc<Fq>>> =
         public_params(reduction_count, lang.clone());
 
-    let sizes = vec![(10, 0)];
+    let sizes = [(10, 0)];
     for size in sizes {
         let parameter_string = format!("_{}_{}", size.0, size.1);
         let benchmark_id = BenchmarkId::new("verify_compressed_go_base_nova", &parameter_string);

--- a/benches/fibonacci_lem.rs
+++ b/benches/fibonacci_lem.rs
@@ -1,0 +1,160 @@
+use std::{cell::RefCell, rc::Rc, sync::Arc, time::Duration};
+
+use camino::Utf8Path;
+use criterion::{
+    black_box, criterion_group, criterion_main, measurement, BatchSize, BenchmarkGroup,
+    BenchmarkId, Criterion, SamplingMode,
+};
+
+use pasta_curves::pallas;
+
+use lurk::{
+    eval::lang::{Coproc, Lang},
+    field::LurkField,
+    lem::{eval::evaluate, multiframe::MultiFrame, pointers::Ptr, store::Store},
+    proof::nova::NovaProver,
+    proof::Prover,
+    public_parameters::{
+        instance::{Instance, Kind},
+        public_params,
+    },
+    state::State,
+};
+
+const PUBLIC_PARAMS_PATH: &str = "/var/tmp/lurk_benches/public_params";
+
+fn fib<F: LurkField>(store: &Store<F>, state: Rc<RefCell<State>>, _a: u64) -> Ptr<F> {
+    let program = r#"
+(letrec ((next (lambda (a b) (next b (+ a b))))
+           (fib (next 0 1)))
+  (fib))
+"#;
+
+    store.read(state, program).unwrap()
+}
+
+// The env output in the `fib_frame`th frame of the above, infinite Fibonacci computation will contain a binding of the
+// nth Fibonacci number to `a`.
+// means of computing it.]
+fn fib_frame(n: usize) -> usize {
+    11 + 16 * n
+}
+
+// Set the limit so the last step will be filled exactly, since Lurk currently only pads terminal/error continuations.
+fn fib_limit(n: usize, rc: usize) -> usize {
+    let frame = fib_frame(n);
+    rc * (frame / rc + usize::from(frame % rc != 0))
+}
+
+struct ProveParams {
+    fib_n: usize,
+    reduction_count: usize,
+}
+
+impl ProveParams {
+    fn name(&self) -> String {
+        let date = env!("VERGEN_GIT_COMMIT_DATE");
+        let sha = env!("VERGEN_GIT_SHA");
+        format!("{date}:{sha}:Fibonacci-rc={}", self.reduction_count)
+    }
+}
+
+fn fibo_prove<M: measurement::Measurement>(
+    prove_params: ProveParams,
+    c: &mut BenchmarkGroup<'_, M>,
+    state: Rc<RefCell<State>>,
+) {
+    let ProveParams {
+        fib_n,
+        reduction_count,
+    } = prove_params;
+
+    let limit = fib_limit(fib_n, reduction_count);
+    let lang_pallas = Lang::<pallas::Scalar, Coproc<pallas::Scalar>>::new();
+    let lang_rc = Arc::new(lang_pallas.clone());
+
+    // use cached public params
+    let instance = Instance::new(
+        reduction_count,
+        lang_rc.clone(),
+        true,
+        Kind::NovaPublicParams,
+    );
+    let pp =
+        public_params::<_, _, MultiFrame<'_, _, _>>(&instance, Utf8Path::new(PUBLIC_PARAMS_PATH))
+            .unwrap();
+
+    c.bench_with_input(
+        BenchmarkId::new(prove_params.name(), fib_n),
+        &prove_params,
+        |b, prove_params| {
+            let store = Store::default();
+
+            let ptr = fib::<pasta_curves::Fq>(
+                &store,
+                state.clone(),
+                black_box(prove_params.fib_n as u64),
+            );
+            let prover = NovaProver::new(prove_params.reduction_count, lang_pallas.clone());
+
+            let frames =
+                &evaluate::<pasta_curves::Fq, Coproc<pasta_curves::Fq>>(None, ptr, &store, limit)
+                    .unwrap()
+                    .0;
+
+            b.iter_batched(
+                || (frames, lang_rc.clone()),
+                |(frames, lang_rc)| {
+                    let result = prover.prove(&pp, frames, &store, &lang_rc);
+                    let _ = black_box(result);
+                },
+                BatchSize::LargeInput,
+            )
+        },
+    );
+}
+
+fn fibonacci_prove(c: &mut Criterion) {
+    tracing::debug!("{:?}", &*lurk::config::CONFIG);
+    let reduction_counts = [100, 600, 700, 800, 900];
+    let batch_sizes = [100, 200];
+    let mut group: BenchmarkGroup<'_, _> = c.benchmark_group("Prove");
+    group.sampling_mode(SamplingMode::Flat); // This can take a *while*
+    group.sample_size(10);
+    let state = State::init_lurk_state().rccell();
+
+    for fib_n in batch_sizes.iter() {
+        for reduction_count in reduction_counts.iter() {
+            let prove_params = ProveParams {
+                fib_n: *fib_n,
+                reduction_count: *reduction_count,
+            };
+            fibo_prove(prove_params, &mut group, state.clone());
+        }
+    }
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "flamegraph")] {
+        criterion_group! {
+            name = benches;
+            config = Criterion::default()
+            .measurement_time(Duration::from_secs(120))
+            .sample_size(10)
+            .with_profiler(pprof::criterion::PProfProfiler::new(100, pprof::criterion::Output::Flamegraph(None)));
+            targets =
+             fibonacci_prove,
+         }
+    } else {
+        criterion_group! {
+            name = benches;
+            config = Criterion::default()
+            .measurement_time(Duration::from_secs(120))
+            .sample_size(10);
+            targets =
+             fibonacci_prove,
+         }
+    }
+}
+
+criterion_main!(benches);

--- a/benches/sha256_lem.rs
+++ b/benches/sha256_lem.rs
@@ -1,0 +1,396 @@
+//! This benchmark measures the IVC performance of coprocessors, by adding a `sha256`
+//! circuit alongside the lurk primary circuit. When supernova is integrated as a backend,
+//! then NIVC performance can also be tested. This benchmark serves as a baseline for that
+//! performance.
+//!
+//! Note: The example [example/sha256_ivc.rs] is this same benchmark but as an example
+//! that's easier to play with and run.
+
+use camino::Utf8Path;
+use criterion::{
+    black_box, criterion_group, criterion_main, measurement, BatchSize, BenchmarkGroup,
+    BenchmarkId, Criterion, SamplingMode,
+};
+use pasta_curves::pallas::Scalar as Fr;
+use std::{cell::RefCell, rc::Rc, sync::Arc, time::Duration};
+
+use lurk::{
+    coprocessor::sha256::{Sha256Coproc, Sha256Coprocessor},
+    eval::lang::Lang,
+    field::LurkField,
+    lem::{
+        eval::{evaluate, make_eval_step_from_lang},
+        multiframe::MultiFrame,
+        pointers::Ptr,
+        store::Store,
+    },
+    proof::{nova::NovaProver, supernova::SuperNovaProver, Prover},
+    public_parameters::{
+        instance::{Instance, Kind},
+        public_params, supernova_public_params,
+    },
+    state::{user_sym, State},
+};
+
+const PUBLIC_PARAMS_PATH: &str = "/var/tmp/lurk_benches/public_params";
+
+fn sha256_ivc<F: LurkField>(
+    store: &Store<F>,
+    state: Rc<RefCell<State>>,
+    arity: usize,
+    n: usize,
+    input: Vec<usize>,
+) -> Ptr<F> {
+    assert_eq!(n, input.len());
+    let input = input
+        .iter()
+        .map(|i| format!("(sha256 . {i})"))
+        .collect::<Vec<String>>()
+        .join(" ");
+    let input = format!("'({input})");
+    let program = format!(
+        r#"
+(letrec ((encode-1 (lambda (term)
+            (let ((type (car term))
+                  (value (cdr term)))
+                (if (eq 'sha256 type)
+                    (eval (cons 'sha256_ivc_{arity} value))
+                    (if (eq 'lurk type)
+                        (commit value)
+                        (if (eq 'id type)
+                            value))))))
+        (encode (lambda (input)
+                (if input
+                    (cons
+                        (encode-1 (car input))
+                        (encode (cdr input)))))))
+  (encode '((lurk . 5) (id . 15) {input})))
+"#
+    );
+
+    store.read(state, &program).unwrap()
+}
+
+struct ProveParams {
+    arity: usize,
+    n: usize,
+    reduction_count: usize,
+}
+
+impl ProveParams {
+    fn name(&self) -> String {
+        let date = env!("VERGEN_GIT_COMMIT_DATE");
+        let sha = env!("VERGEN_GIT_SHA");
+        format!(
+            "{date}:{sha}:rc={}:sha256_ivc_{}",
+            self.reduction_count, self.arity
+        )
+    }
+}
+
+fn sha256_ivc_prove<M: measurement::Measurement>(
+    prove_params: ProveParams,
+    c: &mut BenchmarkGroup<'_, M>,
+    state: Rc<RefCell<State>>,
+) {
+    let ProveParams {
+        arity,
+        n: _,
+        reduction_count,
+    } = prove_params;
+
+    let limit = 10000;
+
+    let store = &Store::<Fr>::default();
+    let cproc_sym = user_sym(&format!("sha256_ivc_{arity}"));
+
+    let mut lang = Lang::<Fr, Sha256Coproc<Fr>>::new();
+    lang.add_coprocessor_lem(cproc_sym, Sha256Coprocessor::new(arity), store);
+    let lang_rc = Arc::new(lang.clone());
+
+    let lurk_step = make_eval_step_from_lang(&lang, true);
+
+    // use cached public params
+
+    let instance: Instance<'_, Fr, Sha256Coproc<Fr>, MultiFrame<'_, _, _>> = Instance::new(
+        reduction_count,
+        lang_rc.clone(),
+        true,
+        Kind::NovaPublicParams,
+    );
+    let pp =
+        public_params::<_, _, MultiFrame<'_, _, _>>(&instance, Utf8Path::new(PUBLIC_PARAMS_PATH))
+            .unwrap();
+
+    c.bench_with_input(
+        BenchmarkId::new(prove_params.name(), arity),
+        &prove_params,
+        |b, prove_params| {
+            let ptr = sha256_ivc(
+                store,
+                state.clone(),
+                black_box(prove_params.arity),
+                black_box(prove_params.n),
+                (0..prove_params.n).collect(),
+            );
+
+            let prover = NovaProver::new(prove_params.reduction_count, lang.clone());
+
+            let frames = &evaluate(Some((&lurk_step, &lang)), ptr, store, limit)
+                .unwrap()
+                .0;
+
+            b.iter_batched(
+                || (frames, lang_rc.clone()),
+                |(frames, lang_rc)| {
+                    let result = prover.prove(&pp, frames, store, &lang_rc);
+                    let _ = black_box(result);
+                },
+                BatchSize::LargeInput,
+            )
+        },
+    );
+}
+
+fn ivc_prove_benchmarks(c: &mut Criterion) {
+    tracing::debug!("{:?}", &*lurk::config::CONFIG);
+    let reduction_counts = [10, 100];
+    let batch_sizes = [1, 2, 5, 10, 20];
+    let mut group: BenchmarkGroup<'_, _> = c.benchmark_group("prove");
+    group.sampling_mode(SamplingMode::Flat); // This can take a *while*
+    group.sample_size(10);
+    let state = State::init_lurk_state().rccell();
+
+    for &n in batch_sizes.iter() {
+        for &reduction_count in reduction_counts.iter() {
+            let prove_params = ProveParams {
+                arity: 1,
+                n,
+                reduction_count,
+            };
+            sha256_ivc_prove(prove_params, &mut group, state.clone());
+        }
+    }
+}
+
+fn sha256_ivc_prove_compressed<M: measurement::Measurement>(
+    prove_params: ProveParams,
+    c: &mut BenchmarkGroup<'_, M>,
+    state: Rc<RefCell<State>>,
+) {
+    let ProveParams {
+        arity,
+        n: _,
+        reduction_count,
+    } = prove_params;
+
+    let limit = 10000;
+
+    let store = &Store::<Fr>::default();
+    let cproc_sym = user_sym(&format!("sha256_ivc_{arity}"));
+
+    let mut lang = Lang::<Fr, Sha256Coproc<Fr>>::new();
+    lang.add_coprocessor_lem(cproc_sym, Sha256Coprocessor::new(arity), store);
+    let lang_rc = Arc::new(lang.clone());
+
+    let lurk_step = make_eval_step_from_lang(&lang, true);
+
+    // use cached public params
+    let instance = Instance::new(
+        reduction_count,
+        lang_rc.clone(),
+        true,
+        Kind::NovaPublicParams,
+    );
+    let pp =
+        public_params::<_, _, MultiFrame<'_, _, _>>(&instance, Utf8Path::new(PUBLIC_PARAMS_PATH))
+            .unwrap();
+
+    c.bench_with_input(
+        BenchmarkId::new(prove_params.name(), arity),
+        &prove_params,
+        |b, prove_params| {
+            let ptr = sha256_ivc(
+                store,
+                state.clone(),
+                black_box(prove_params.arity),
+                black_box(prove_params.n),
+                (0..prove_params.n).collect(),
+            );
+
+            let prover = NovaProver::new(prove_params.reduction_count, lang.clone());
+
+            let frames = &evaluate(Some((&lurk_step, &lang)), ptr, store, limit)
+                .unwrap()
+                .0;
+
+            b.iter_batched(
+                || (frames, lang_rc.clone()),
+                |(frames, lang_rc)| {
+                    let (proof, _, _, _) = prover.prove(&pp, frames, store, &lang_rc).unwrap();
+                    let compressed_result = proof.compress(&pp).unwrap();
+
+                    let _ = black_box(compressed_result);
+                },
+                BatchSize::LargeInput,
+            )
+        },
+    );
+}
+
+fn ivc_prove_compressed_benchmarks(c: &mut Criterion) {
+    tracing::debug!("{:?}", &*lurk::config::CONFIG);
+    let reduction_counts = [10, 100];
+    let batch_sizes = [1, 2, 5, 10, 20];
+    let mut group: BenchmarkGroup<'_, _> = c.benchmark_group("prove_compressed");
+    group.sampling_mode(SamplingMode::Flat); // This can take a *while*
+    group.sample_size(10);
+    let state = State::init_lurk_state().rccell();
+
+    for &n in batch_sizes.iter() {
+        for &reduction_count in reduction_counts.iter() {
+            let prove_params = ProveParams {
+                arity: 1,
+                n,
+                reduction_count,
+            };
+            sha256_ivc_prove_compressed(prove_params, &mut group, state.clone());
+        }
+    }
+}
+
+fn sha256_nivc_prove<M: measurement::Measurement>(
+    prove_params: ProveParams,
+    c: &mut BenchmarkGroup<'_, M>,
+    state: Rc<RefCell<State>>,
+) {
+    let ProveParams {
+        arity,
+        n: _,
+        reduction_count,
+    } = prove_params;
+
+    let limit = 10000;
+
+    let store = &Store::<Fr>::default();
+    let cproc_sym = user_sym(&format!("sha256_ivc_{arity}"));
+
+    let mut lang = Lang::<Fr, Sha256Coproc<Fr>>::new();
+    lang.add_coprocessor_lem(cproc_sym, Sha256Coprocessor::new(arity), store);
+    let lang_rc = Arc::new(lang.clone());
+
+    let lurk_step = make_eval_step_from_lang(&lang, false);
+
+    // use cached public params
+    let instance = Instance::new(
+        reduction_count,
+        lang_rc.clone(),
+        true,
+        Kind::SuperNovaAuxParams,
+    );
+    let pp = supernova_public_params::<_, _, MultiFrame<'_, _, _>>(
+        &instance,
+        Utf8Path::new(PUBLIC_PARAMS_PATH),
+    )
+    .unwrap();
+
+    c.bench_with_input(
+        BenchmarkId::new(prove_params.name(), arity),
+        &prove_params,
+        |b, prove_params| {
+            let ptr = sha256_ivc(
+                store,
+                state.clone(),
+                black_box(prove_params.arity),
+                black_box(prove_params.n),
+                (0..prove_params.n).collect(),
+            );
+
+            let prover = SuperNovaProver::new(prove_params.reduction_count, lang.clone());
+
+            let frames = &evaluate(Some((&lurk_step, &lang)), ptr, store, limit)
+                .unwrap()
+                .0;
+
+            b.iter_batched(
+                || (frames, lang_rc.clone()),
+                |(frames, lang_rc)| {
+                    let result = prover.prove(&pp, frames, store, lang_rc);
+                    let _ = black_box(result);
+                },
+                BatchSize::LargeInput,
+            )
+        },
+    );
+}
+
+fn nivc_prove_benchmarks(c: &mut Criterion) {
+    tracing::debug!("{:?}", &*lurk::config::CONFIG);
+    let reduction_counts = [10, 100];
+    let batch_sizes = [1, 2, 5, 10, 20];
+    let mut group: BenchmarkGroup<'_, _> = c.benchmark_group("prove");
+    group.sampling_mode(SamplingMode::Flat); // This can take a *while*
+    group.sample_size(10);
+    let state = State::init_lurk_state().rccell();
+
+    for &n in batch_sizes.iter() {
+        for &reduction_count in reduction_counts.iter() {
+            let prove_params = ProveParams {
+                arity: 1,
+                n,
+                reduction_count,
+            };
+            sha256_nivc_prove(prove_params, &mut group, state.clone());
+        }
+    }
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "flamegraph")] {
+        criterion_group! {
+            name = ivc_benches;
+            config = Criterion::default()
+            .measurement_time(Duration::from_secs(120))
+            .sample_size(10)
+            .with_profiler(pprof::criterion::PProfProfiler::new(100, pprof::criterion::Output::Flamegraph(None)));
+            targets =
+                ivc_prove_benchmarks,
+                ivc_prove_compressed_benchmarks
+         }
+         criterion_group! {
+            name = nivc_benches;
+            config = Criterion::default()
+            .measurement_time(Duration::from_secs(120))
+            .sample_size(10)
+            .with_profiler(pprof::criterion::PProfProfiler::new(100, pprof::criterion::Output::Flamegraph(None)));
+            targets =
+                nivc_prove_benchmarks
+                // TODO: Add when compressed SNARK is implemented for SuperNova
+                // https://github.com/lurk-lab/arecibo/issues/27https://github.com/lurk-lab/arecibo/issues/27
+                // nivc_prove_compressed_benchmarks
+         }
+    } else {
+        criterion_group! {
+            name = ivc_benches;
+            config = Criterion::default()
+            .measurement_time(Duration::from_secs(120))
+            .sample_size(10);
+            targets =
+                ivc_prove_benchmarks,
+                ivc_prove_compressed_benchmarks
+         }
+         criterion_group! {
+             name = nivc_benches;
+             config = Criterion::default()
+             .measurement_time(Duration::from_secs(120))
+             .sample_size(10);
+             targets =
+                 nivc_prove_benchmarks
+                 // TODO: Add when compressed SNARK is implemented for SuperNova
+                 // https://github.com/lurk-lab/arecibo/issues/27https://github.com/lurk-lab/arecibo/issues/27
+                 // nivc_prove_compressed_benchmarks
+          }
+    }
+}
+
+criterion_main!(ivc_benches, nivc_benches);

--- a/benches/synthesis_lem.rs
+++ b/benches/synthesis_lem.rs
@@ -1,0 +1,109 @@
+use std::{cell::RefCell, rc::Rc, sync::Arc, time::Duration};
+
+use bellpepper::util_cs::witness_cs::WitnessCS;
+use bellpepper_core::{Circuit, ConstraintSystem};
+use criterion::{
+    black_box, criterion_group, criterion_main, measurement, BatchSize, BenchmarkGroup,
+    BenchmarkId, Criterion, SamplingMode,
+};
+use pasta_curves::Fq;
+
+use lurk::{
+    eval::lang::{Coproc, Lang},
+    field::LurkField,
+    lem::{eval::evaluate, multiframe::MultiFrame, pointers::Ptr, store::Store},
+    proof::{supernova::FoldingConfig, MultiFrameTrait},
+    state::State,
+};
+
+fn fib<F: LurkField>(store: &Store<F>, state: Rc<RefCell<State>>, a: u64) -> Ptr<F> {
+    let program = format!(
+        r#"
+(let ((fib (lambda (target)
+              (letrec ((next (lambda (a b target)
+                               (if (= 0 target)
+                                     a
+                                     (next b
+                                           (+ a b)
+                                           (- target 1))))))
+                (next 0 1 target)))))
+  (fib {a}))
+"#
+    );
+
+    store.read(state, &program).unwrap()
+}
+
+fn synthesize<M: measurement::Measurement>(
+    name: &str,
+    reduction_count: usize,
+    c: &mut BenchmarkGroup<'_, M>,
+) {
+    let limit = 1_000_000;
+    let lang_rc = Arc::new(Lang::<Fq, Coproc<Fq>>::new());
+    let state = State::init_lurk_state().rccell();
+
+    c.bench_with_input(
+        BenchmarkId::new(name.to_string(), reduction_count),
+        &reduction_count,
+        |b, reduction_count| {
+            let store = Store::default();
+            let fib_n = (reduction_count / 3) as u64; // Heuristic, since one fib is 35 iterations.
+            let ptr = fib::<pasta_curves::Fq>(&store, state.clone(), black_box(fib_n));
+            let (frames, _) = evaluate::<Fq, Coproc<Fq>>(None, ptr, &store, limit).unwrap();
+
+            let folding_config =
+                Arc::new(FoldingConfig::new_ivc(lang_rc.clone(), *reduction_count));
+
+            let multiframe =
+                MultiFrame::from_frames(*reduction_count, &frames, &store, folding_config)[0]
+                    .clone();
+
+            b.iter_batched(
+                || (multiframe.clone()), // avoid cloning the frames in the benchmark
+                |multiframe| {
+                    let mut cs = WitnessCS::new();
+                    let result = multiframe.synthesize(&mut cs);
+                    let _ = black_box(result);
+                },
+                BatchSize::LargeInput,
+            )
+        },
+    );
+}
+
+fn fibonacci_synthesize(c: &mut Criterion) {
+    let batch_sizes = [5, 10, 100, 200];
+    let mut group: BenchmarkGroup<'_, _> = c.benchmark_group("synthesis");
+    group.sampling_mode(SamplingMode::Flat); // This can take a *while*
+    group.sample_size(10);
+
+    for size in batch_sizes.iter() {
+        synthesize("Synthesis-rc", *size, &mut group);
+    }
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "flamegraph")] {
+        criterion_group! {
+            name = benches;
+            config = Criterion::default()
+            .measurement_time(Duration::from_secs(120))
+            .sample_size(10)
+            .with_profiler(pprof::criterion::PProfProfiler::new(100, pprof::criterion::Output::Flamegraph(None)));
+            targets =
+            fibonacci_synthesize
+        }
+    } else {
+        criterion_group! {
+            name = benches;
+            config = Criterion::default()
+            .measurement_time(Duration::from_secs(120))
+            .sample_size(10);
+            targets =
+            fibonacci_synthesize,
+        }
+    }
+}
+
+criterion_main!(benches);

--- a/examples/sha256_nivc_lem.rs
+++ b/examples/sha256_nivc_lem.rs
@@ -4,7 +4,7 @@ use tracing_subscriber::{fmt, prelude::*, EnvFilter, Registry};
 use tracing_texray::TeXRayLayer;
 
 use lurk::{
-    coprocessor::sha256::Sha256Coprocessor,
+    coprocessor::sha256::{Sha256Coproc, Sha256Coprocessor},
     eval::lang::Lang,
     field::LurkField,
     lem::{
@@ -72,17 +72,15 @@ fn main() {
 
     let call = sha256_nivc(store, n, (0..n).collect());
 
-    let mut lang = Lang::<Fr, Sha256Coprocessor<Fr>>::new();
+    let mut lang = Lang::<Fr, Sha256Coproc<Fr>>::new();
     lang.add_coprocessor_lem(cproc_sym, Sha256Coprocessor::new(n), store);
     let lang_rc = Arc::new(lang.clone());
 
     let lurk_step = make_eval_step_from_lang(&lang, false);
     let (frames, _) = evaluate(Some((&lurk_step, &lang)), call, store, 1000).unwrap();
 
-    let supernova_prover = SuperNovaProver::<Fr, Sha256Coprocessor<Fr>, MultiFrame<'_, _, _>>::new(
-        REDUCTION_COUNT,
-        lang,
-    );
+    let supernova_prover =
+        SuperNovaProver::<Fr, Sha256Coproc<Fr>, MultiFrame<'_, _, _>>::new(REDUCTION_COUNT, lang);
 
     println!("Setting up running claim parameters (rc = {REDUCTION_COUNT})...");
     let pp_start = Instant::now();

--- a/lurk-macros/src/lib.rs
+++ b/lurk-macros/src/lib.rs
@@ -35,10 +35,16 @@ fn impl_enum_coproc(name: &Ident, variants: &DataEnum) -> TokenStream {
     let eval_arity_arms = eval_arity_match_arms(name, variants);
     let evaluate_arms = evaluate_match_arms(name, variants);
     let simple_evaluate_arms = simple_evaluate_match_arms(name, variants);
+    let evaluate_lem_internal_arms = evaluate_lem_internal_match_arms(name, variants);
+    let evaluate_lem_arms = evaluate_lem_match_arms(name, variants);
+    let evaluate_lem_simple_arms = evaluate_lem_simple_match_arms(name, variants);
     let has_circuit_arms = has_circuit_match_arms(name, variants);
 
     let arity_arms = arity_match_arms(name, variants);
     let synthesize_arms = synthesize_match_arms(name, variants);
+    let synthesize_lem_internal_arms = synthesize_lem_internal_match_arms(name, variants);
+    let synthesize_lem_arms = synthesize_lem_match_arms(name, variants);
+    let synthesize_lem_simple_arms = synthesize_lem_simple_match_arms(name, variants);
 
     let from_impls = from_impls(name, variants);
 
@@ -59,6 +65,24 @@ fn impl_enum_coproc(name: &Ident, variants: &DataEnum) -> TokenStream {
             fn simple_evaluate(&self, s: &lurk::store::Store<F>, args: &[lurk::ptr::Ptr<F>]) -> lurk::ptr::Ptr<F> {
                 match self {
                     #simple_evaluate_arms
+                }
+            }
+
+            fn evaluate_lem_internal(&self, s: &lurk::lem::store::Store<F>, ptrs: &[lurk::lem::pointers::Ptr<F>]) -> Vec<lurk::lem::pointers::Ptr<F>> {
+                match self {
+                    #evaluate_lem_internal_arms
+                }
+            }
+
+            fn evaluate_lem(&self, s: &lurk::lem::store::Store<F>, args: &[lurk::lem::pointers::Ptr<F>], env: &lurk::lem::pointers::Ptr<F>, cont: &lurk::lem::pointers::Ptr<F>) -> Vec<lurk::lem::pointers::Ptr<F>> {
+                match self {
+                    #evaluate_lem_arms
+                }
+            }
+
+            fn evaluate_lem_simple(&self, s: &lurk::lem::store::Store<F>, args: &[lurk::lem::pointers::Ptr<F>]) -> lurk::lem::pointers::Ptr<F> {
+                match self {
+                    #evaluate_lem_simple_arms
                 }
             }
 
@@ -87,6 +111,47 @@ fn impl_enum_coproc(name: &Ident, variants: &DataEnum) -> TokenStream {
             ) -> Result<(lurk::circuit::gadgets::pointer::AllocatedPtr<F>, lurk::circuit::gadgets::pointer::AllocatedPtr<F>, lurk::circuit::gadgets::pointer::AllocatedContPtr<F>), bellpepper_core::SynthesisError> {
                 match self {
                     #synthesize_arms
+                }
+            }
+
+            fn synthesize_lem_internal<CS: bellpepper_core::ConstraintSystem<F>>(
+                &self,
+                cs: &mut CS,
+                g: &lurk::lem::circuit::GlobalAllocator<F>,
+                s: &lurk::lem::store::Store<F>,
+                not_dummy: &bellpepper::gadgets::boolean::Boolean,
+                ptrs: &[lurk::circuit::gadgets::pointer::AllocatedPtr<F>],
+            ) -> Result<Vec<lurk::circuit::gadgets::pointer::AllocatedPtr<F>>, bellpepper_core::SynthesisError> {
+                match self {
+                    #synthesize_lem_internal_arms
+                }
+            }
+
+            fn synthesize_lem<CS: bellpepper_core::ConstraintSystem<F>>(
+                &self,
+                cs: &mut CS,
+                g: &lurk::lem::circuit::GlobalAllocator<F>,
+                s: &lurk::lem::store::Store<F>,
+                not_dummy: &bellpepper::gadgets::boolean::Boolean,
+                args: &[lurk::circuit::gadgets::pointer::AllocatedPtr<F>],
+                env: &lurk::circuit::gadgets::pointer::AllocatedPtr<F>,
+                cont: &lurk::circuit::gadgets::pointer::AllocatedPtr<F>,
+            ) -> Result<Vec<lurk::circuit::gadgets::pointer::AllocatedPtr<F>>, bellpepper_core::SynthesisError> {
+                match self {
+                    #synthesize_lem_arms
+                }
+            }
+
+            fn synthesize_lem_simple<CS: bellpepper_core::ConstraintSystem<F>>(
+                &self,
+                cs: &mut CS,
+                g: &lurk::lem::circuit::GlobalAllocator<F>,
+                s: &lurk::lem::store::Store<F>,
+                not_dummy: &bellpepper::gadgets::boolean::Boolean,
+                args: &[lurk::circuit::gadgets::pointer::AllocatedPtr<F>],
+            ) -> Result<lurk::circuit::gadgets::pointer::AllocatedPtr<F>, bellpepper_core::SynthesisError> {
+                match self {
+                    #synthesize_lem_simple_arms
                 }
             }
         }
@@ -132,6 +197,42 @@ fn simple_evaluate_match_arms(name: &Ident, variants: &DataEnum) -> proc_macro2:
     match_arms
 }
 
+fn evaluate_lem_internal_match_arms(name: &Ident, variants: &DataEnum) -> proc_macro2::TokenStream {
+    let mut match_arms = quote! {};
+    for variant in variants.variants.iter() {
+        let variant_ident = &variant.ident;
+
+        match_arms.extend(quote! {
+            #name::#variant_ident(coprocessor) => coprocessor.evaluate_lem_internal(s, ptrs),
+        });
+    }
+    match_arms
+}
+
+fn evaluate_lem_match_arms(name: &Ident, variants: &DataEnum) -> proc_macro2::TokenStream {
+    let mut match_arms = quote! {};
+    for variant in variants.variants.iter() {
+        let variant_ident = &variant.ident;
+
+        match_arms.extend(quote! {
+            #name::#variant_ident(coprocessor) => coprocessor.evaluate_lem(s, args, env, cont),
+        });
+    }
+    match_arms
+}
+
+fn evaluate_lem_simple_match_arms(name: &Ident, variants: &DataEnum) -> proc_macro2::TokenStream {
+    let mut match_arms = quote! {};
+    for variant in variants.variants.iter() {
+        let variant_ident = &variant.ident;
+
+        match_arms.extend(quote! {
+            #name::#variant_ident(coprocessor) => coprocessor.evaluate_lem_simple(s, args),
+        });
+    }
+    match_arms
+}
+
 fn has_circuit_match_arms(name: &Ident, variants: &DataEnum) -> proc_macro2::TokenStream {
     let mut match_arms = quote! {};
     for variant in variants.variants.iter() {
@@ -163,6 +264,45 @@ fn synthesize_match_arms(name: &Ident, variants: &DataEnum) -> proc_macro2::Toke
 
         match_arms.extend(quote! {
             #name::#variant_ident(cocircuit) => cocircuit.synthesize(cs, g, store, input_exprs, input_env, input_cont),
+        });
+    }
+    match_arms
+}
+
+fn synthesize_lem_internal_match_arms(
+    name: &Ident,
+    variants: &DataEnum,
+) -> proc_macro2::TokenStream {
+    let mut match_arms = quote! {};
+    for variant in variants.variants.iter() {
+        let variant_ident = &variant.ident;
+
+        match_arms.extend(quote! {
+            #name::#variant_ident(cocircuit) => cocircuit.synthesize_lem_internal(cs, g, s, not_dummy, ptrs),
+        });
+    }
+    match_arms
+}
+
+fn synthesize_lem_match_arms(name: &Ident, variants: &DataEnum) -> proc_macro2::TokenStream {
+    let mut match_arms = quote! {};
+    for variant in variants.variants.iter() {
+        let variant_ident = &variant.ident;
+
+        match_arms.extend(quote! {
+            #name::#variant_ident(cocircuit) => cocircuit.synthesize_lem(cs, g, s, not_dummy, args, env, cont),
+        });
+    }
+    match_arms
+}
+
+fn synthesize_lem_simple_match_arms(name: &Ident, variants: &DataEnum) -> proc_macro2::TokenStream {
+    let mut match_arms = quote! {};
+    for variant in variants.variants.iter() {
+        let variant_ident = &variant.ident;
+
+        match_arms.extend(quote! {
+            #name::#variant_ident(cocircuit) => cocircuit.synthesize_lem_simple(cs, g, s, not_dummy, args),
         });
     }
     match_arms

--- a/src/lem/tests/eval_tests.rs
+++ b/src/lem/tests/eval_tests.rs
@@ -2437,9 +2437,11 @@ fn test_eval_non_symbol_binding_error() {
 
 #[test]
 fn test_dumb_lang() {
-    use crate::{coprocessor::test::DumbCoprocessor, state::user_sym};
+    use crate::{
+        coprocessor::test::DumbCoprocessor, eval::tests::coproc::DumbCoproc, state::user_sym,
+    };
 
-    let mut lang = Lang::<Fr, DumbCoprocessor<Fr>>::new();
+    let mut lang = Lang::<Fr, DumbCoproc<Fr>>::new();
     let dumb = DumbCoprocessor::new();
     let name = user_sym("cproc-dumb");
 

--- a/src/proof/tests/nova_tests_lem.rs
+++ b/src/proof/tests/nova_tests_lem.rs
@@ -3080,11 +3080,11 @@ fn test_prove_head_with_sym_mimicking_value() {
 
 #[test]
 fn test_dumb_lang() {
-    use crate::coprocessor::test::DumbCoprocessor;
+    use crate::{coprocessor::test::DumbCoprocessor, eval::tests::coproc::DumbCoproc};
 
     let s = &Store::<Fr>::default();
 
-    let mut lang = Lang::<Fr, DumbCoprocessor<Fr>>::new();
+    let mut lang = Lang::<Fr, DumbCoproc<Fr>>::new();
     let name = user_sym("cproc-dumb");
     let dumb = DumbCoprocessor::new();
 
@@ -3104,7 +3104,7 @@ fn test_dumb_lang() {
     let error = Ptr::null(Tag::Cont(Error));
     let lang = Arc::new(lang);
 
-    test_aux::<_, _, C1LEM<'_, _, DumbCoprocessor<_>>>(
+    test_aux::<_, _, C1LEM<'_, _, DumbCoproc<_>>>(
         s,
         expr,
         Some(res),
@@ -3114,7 +3114,7 @@ fn test_dumb_lang() {
         3,
         Some(lang.clone()),
     );
-    test_aux::<_, _, C1LEM<'_, _, DumbCoprocessor<_>>>(
+    test_aux::<_, _, C1LEM<'_, _, DumbCoproc<_>>>(
         s,
         expr2,
         Some(res),
@@ -3124,7 +3124,7 @@ fn test_dumb_lang() {
         6,
         Some(lang.clone()),
     );
-    test_aux::<_, _, C1LEM<'_, _, DumbCoprocessor<_>>>(
+    test_aux::<_, _, C1LEM<'_, _, DumbCoproc<_>>>(
         s,
         expr3,
         None,
@@ -3134,7 +3134,7 @@ fn test_dumb_lang() {
         4,
         Some(lang.clone()),
     );
-    test_aux::<_, _, C1LEM<'_, _, DumbCoprocessor<_>>>(
+    test_aux::<_, _, C1LEM<'_, _, DumbCoproc<_>>>(
         s,
         expr4,
         None,


### PR DESCRIPTION
[Post #738]

This PR implement the missing benchmarks for LEM. Here's the data I collected on my machine w.r.t. Alpha:

### end2end proving
```
end2end_benchmark/end2end_go_base_nova/_10_0
                        time:   [1.1503 s 1.1551 s 1.1583 s]
                        change: [-19.754% -19.255% -18.666%] (p = 0.00 < 0.05)
                        Performance has improved.
```

### synthesis
```
synthesis/Synthesis-rc/5
                        time:   [7.2469 ms 7.2700 ms 7.2888 ms]
                        change: [-64.198% -64.043% -63.892%] (p = 0.00 < 0.05)
                        Performance has improved.
synthesis/Synthesis-rc/10
                        time:   [14.649 ms 14.656 ms 14.664 ms]
                        change: [-63.761% -63.730% -63.699%] (p = 0.00 < 0.05)
                        Performance has improved.
synthesis/Synthesis-rc/100
                        time:   [151.00 ms 151.11 ms 151.21 ms]
                        change: [-63.398% -63.337% -63.283%] (p = 0.00 < 0.05)
                        Performance has improved.
synthesis/Synthesis-rc/200
                        time:   [298.47 ms 299.53 ms 300.16 ms]
                        change: [-63.713% -63.527% -63.346%] (p = 0.00 < 0.05)
                        Performance has improved.
```
@winston-h-zhang was correct: synthesis is ~2.75x faster in LEM

### sha256 (IVC)
```
prove/2023-10-14:cff480d56f112511ebbfdba41799a31774492652:rc=10:sha256_ivc_1/1
                        time:   [7.7633 s 7.8085 s 7.8601 s]
                        change: [-31.809% -31.067% -30.408%] (p = 0.00 < 0.05)
                        Performance has improved.
```
I didn't have enough RAM for higher RCs

### sha256 (NIVC)
```
prove/2023-10-14:cff480d56f112511ebbfdba41799a31774492652:rc=10:sha256_ivc_1/1
                        time:   [3.6714 s 3.6822 s 3.6908 s]
                        change: [-18,164% -18,566% -18,912%] (p = 0.00 < 0.05)
                        Performance has improved.
```
I didn't have enough RAM for higher RCs
Note: there's a typo in the group name, where it says "ivc"

### fibonacci
```
Prove/2023-10-14:cff480d56f112511ebbfdba41799a31774492652:Fibonacci-rc=100/100
                        time:   [21.800 s 21.823 s 21.847 s]
                        change: [-19.070% -18.909% -18.743%] (p = 0.00 < 0.05)
                        Performance has improved.
```
I didn't have enough RAM for higher RCs