### PR TITLE
Fix coprocessor error handling/signaling in LEM

### DIFF
--- a/src/circuit/gadgets/pointer.rs
+++ b/src/circuit/gadgets/pointer.rs
@@ -35,7 +35,10 @@ pub struct AllocatedPtr<F: PrimeField> {
 
 impl<F: LurkField> From<AllocatedPtr<F>> for AllocatedContPtr<F> {
     fn from(other: AllocatedPtr<F>) -> Self {
-        Self::from_parts(&other.tag, &other.hash)
+        AllocatedContPtr {
+            tag: other.tag,
+            hash: other.hash,
+        }
     }
 }
 
@@ -556,7 +559,10 @@ pub struct AllocatedContPtr<F: LurkField> {
 
 impl<F: LurkField> From<AllocatedContPtr<F>> for AllocatedPtr<F> {
     fn from(other: AllocatedContPtr<F>) -> Self {
-        Self::from_parts(other.tag, other.hash)
+        AllocatedPtr {
+            tag: other.tag,
+            hash: other.hash,
+        }
     }
 }
 
@@ -872,13 +878,6 @@ impl<F: LurkField> AllocatedContPtr<F> {
             hash,
         };
         Ok((cont, not_dummy))
-    }
-
-    pub fn from_parts(tag: &AllocatedNum<F>, hash: &AllocatedNum<F>) -> Self {
-        Self {
-            tag: tag.clone(),
-            hash: hash.clone(),
-        }
     }
 }
 

--- a/src/circuit/gadgets/pointer.rs
+++ b/src/circuit/gadgets/pointer.rs
@@ -33,6 +33,12 @@ pub struct AllocatedPtr<F: PrimeField> {
     hash: AllocatedNum<F>,
 }
 
+impl<F: LurkField> From<AllocatedPtr<F>> for AllocatedContPtr<F> {
+    fn from(other: AllocatedPtr<F>) -> Self {
+        Self::from_parts(&other.tag, &other.hash)
+    }
+}
+
 impl<F: LurkField> Debug for AllocatedPtr<F> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let tag = format!(
@@ -546,6 +552,12 @@ impl<F: LurkField> AllocatedPtr<F> {
 pub struct AllocatedContPtr<F: LurkField> {
     tag: AllocatedNum<F>,
     hash: AllocatedNum<F>,
+}
+
+impl<F: LurkField> From<AllocatedContPtr<F>> for AllocatedPtr<F> {
+    fn from(other: AllocatedContPtr<F>) -> Self {
+        Self::from_parts(other.tag, other.hash)
+    }
 }
 
 impl<F: LurkField> Debug for AllocatedContPtr<F> {

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -297,13 +297,17 @@ pub(crate) mod test {
             let c_ptr = AllocatedPtr::alloc_tag(cs, ExprTag::Num.to_field(), c)?;
 
             let result_expr0 =
-                AllocatedPtr::pick(&mut cs.namespace(|| "result_expr0"), &a_is_num, &c_ptr, &a)?;
-            let result_expr1 = AllocatedPtr::pick(
+                AllocatedPtr::pick(&mut cs.namespace(|| "result_expr0"), &b_is_num, &c_ptr, &b)?;
+
+            // If `a` is not a `Num`, then that error takes precedence, and we return `a`. Otherwise, return either the
+            // correct result or `b`, depending on whether `b` is a `Num` or not.
+            let result_expr = AllocatedPtr::pick(
                 &mut cs.namespace(|| "result_expr"),
-                &b_is_num,
+                &a_is_num,
                 &result_expr0,
-                &b,
+                &a,
             )?;
+
             let result_cont = AllocatedPtr::pick(
                 &mut cs.namespace(|| "result_cont"),
                 &types_are_correct,
@@ -311,7 +315,7 @@ pub(crate) mod test {
                 &cont_error,
             )?;
 
-            Ok((result_expr1, input_env.clone(), result_cont))
+            Ok((result_expr, input_env.clone(), result_cont))
         }
     }
 

--- a/src/lem/circuit.rs
+++ b/src/lem/circuit.rs
@@ -57,6 +57,7 @@ use super::{
     Block, Ctrl, Func, Op, Tag, Var,
 };
 
+#[derive(Clone)]
 pub enum AllocatedVal<F: LurkField> {
     Pointer(AllocatedPtr<F>),
     Number(AllocatedNum<F>),
@@ -662,6 +663,9 @@ fn synthesize_block<F: LurkField, CS: ConstraintSystem<F>, C: Coprocessor<F>>(
             }
             Op::Decons4(preimg, img) => {
                 decons_helper!(preimg, img, SlotType::Hash8);
+            }
+            Op::Copy(tgt, src) => {
+                bound_allocations.insert(tgt.clone(), bound_allocations.get_cloned(src)?);
             }
             Op::Null(tgt, tag) => {
                 use crate::tag::ContTag::{Dummy, Error, Outermost, Terminal};
@@ -1396,7 +1400,7 @@ impl Func {
                         // three implies_u64, one sub and one linear
                         num_constraints += 197;
                     }
-                    Op::Not(..) | Op::Emit(_) | Op::Cproc(..) => (),
+                    Op::Not(..) | Op::Emit(_) | Op::Cproc(..) | Op::Copy(..) => (),
                     Op::Cons2(_, tag, _) => {
                         // tag for the image
                         globals.insert(FWrap(tag.to_field()));

--- a/src/lem/interpreter.rs
+++ b/src/lem/interpreter.rs
@@ -15,6 +15,7 @@ use crate::{
     tag::ExprTag::{Comm, Nil, Num, Sym},
 };
 
+#[derive(Clone)]
 pub enum Val<F: LurkField> {
     Pointer(Ptr<F>),
     Boolean(bool),
@@ -191,6 +192,9 @@ impl Block {
                     inner_call_outputs.push_front(frame.output);
                     hints = frame.hints;
                     hints.call_outputs.extend(inner_call_outputs);
+                }
+                Op::Copy(tgt, src) => {
+                    bindings.insert(tgt.clone(), bindings.get_cloned(src)?);
                 }
                 Op::Null(tgt, tag) => {
                     bindings.insert_ptr(tgt.clone(), Ptr::null(*tag));

--- a/src/lem/tests/eval_tests.rs
+++ b/src/lem/tests/eval_tests.rs
@@ -2739,7 +2739,7 @@ fn test_dumb_lang() {
     // 9^2 + 8 = 89
     let expr = "(cproc-dumb 9 8)";
 
-    // The dumb coprocessor cannot be shadowed
+    // coprocessors cannot be shadowed
     let expr2 = "(let ((cproc-dumb (lambda (a b) (* a b))))
                    (cproc-dumb 9 8))";
 
@@ -2749,9 +2749,18 @@ fn test_dumb_lang() {
     // wrong number of parameters
     let expr4 = "(cproc-dumb 9 8 123)";
     let expr5 = "(cproc-dumb 9)";
-    let expr6 = "(cproc-unknown 9)";
+
+    // wrong parameter type
+    let expr6 = "(cproc-dumb 'x' 0)";
+    let expr6_ = "(cproc-dumb 'x' 'y')";
+    let expr7 = "(cproc-dumb 0 'y')";
 
     let res = Ptr::num_u64(89);
+    let error4 = s.list(vec![Ptr::num_u64(123), Ptr::num_u64(8), Ptr::num_u64(9)]);
+    let error5 = s.list(vec![Ptr::num_u64(9)]);
+    let error6 = Ptr::char('x');
+    let error7 = Ptr::char('y');
+
     let error = Ptr::null(Tag::Cont(Error));
     let terminal = Ptr::null(Tag::Cont(Terminal));
 
@@ -2785,7 +2794,54 @@ fn test_dumb_lang() {
         9,
         &Some(&lang),
     );
-    test_aux(s, expr4, None, None, Some(error), None, 4, &Some(&lang));
-    test_aux(s, expr5, None, None, Some(error), None, 2, &Some(&lang));
-    test_aux(s, expr6, None, None, Some(error), None, 2, &Some(&lang));
+    test_aux(
+        s,
+        expr4,
+        Some(error4),
+        None,
+        Some(error),
+        None,
+        4,
+        &Some(&lang),
+    );
+    test_aux(
+        s,
+        expr5,
+        Some(error5),
+        None,
+        Some(error),
+        None,
+        2,
+        &Some(&lang),
+    );
+    test_aux(
+        s,
+        expr6,
+        Some(error6),
+        None,
+        Some(error),
+        None,
+        3,
+        &Some(&lang),
+    );
+    test_aux(
+        s,
+        expr6_,
+        Some(error6),
+        None,
+        Some(error),
+        None,
+        3,
+        &Some(&lang),
+    );
+    test_aux(
+        s,
+        expr7,
+        Some(error7),
+        None,
+        Some(error),
+        None,
+        3,
+        &Some(&lang),
+    );
 }


### PR DESCRIPTION
This PR is motivated by https://github.com/lurk-lab/lurk-rs/pull/752#discussion_r1359694110

It implements proper error handling for coprocessors in LEM and uses `DumbCoprocessor` to test the plumbing.