### PR TITLE
match `supernova::Proof::verify` to `nova::Proof::verify`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ clap = "4.3.17"
 ff = "0.13"
 metrics = "0.21.1"
 neptune = { git = "https://github.com/lurk-lab/neptune", branch = "dev" }
-nova = { git = "https://github.com/lurk-lab/arecibo", branch = "dev", package = "nova-snark" }
+nova = { git = "https://github.com/lurk-lab/arecibo", branch = "supernova_verify", package = "nova-snark" }
 once_cell = "1.18.0"
 pairing = { version = "0.23" }
 pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch = "dev" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ clap = "4.3.17"
 ff = "0.13"
 metrics = "0.21.1"
 neptune = { git = "https://github.com/lurk-lab/neptune", branch = "dev" }
-nova = { git = "https://github.com/lurk-lab/arecibo", branch = "supernova_verify", package = "nova-snark" }
+nova = { git = "https://github.com/lurk-lab/arecibo", branch = "dev", package = "nova-snark" }
 once_cell = "1.18.0"
 pairing = { version = "0.23" }
 pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch = "dev" }

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -197,14 +197,14 @@ where
     ) -> Result<bool, SuperNovaError> {
         let (z0_primary, zi_primary) = (z0, zi);
         let z0_secondary = Self::z0_secondary();
-        let zi_secondary = z0_secondary.clone();
+        let zi_secondary = &z0_secondary;
 
         let (zi_primary_verified, zi_secondary_verified) = match self {
             Self::Recursive(p) => p.verify(&pp.pp, circuit_index, z0_primary, &z0_secondary),
             Self::Compressed(_) => unimplemented!(),
         }?;
 
-        Ok(zi_primary == zi_primary_verified && zi_secondary == zi_secondary_verified)
+        Ok(zi_primary == zi_primary_verified && *zi_secondary == zi_secondary_verified)
     }
 
     fn z0_secondary() -> Vec<<F::G2 as Group>::Scalar> {

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -195,14 +195,16 @@ where
         z0: &[F],
         zi: &[F],
     ) -> Result<bool, SuperNovaError> {
-        let (z0_primary, _zi_primary) = (z0, zi);
+        let (z0_primary, zi_primary) = (z0, zi);
         let z0_secondary = Self::z0_secondary();
+        let zi_secondary = z0_secondary.clone();
 
-        match self {
+        let (zi_primary_verified, zi_secondary_verified) = match self {
             Self::Recursive(p) => p.verify(&pp.pp, circuit_index, z0_primary, &z0_secondary),
             Self::Compressed(_) => unimplemented!(),
         }?;
-        Ok(true)
+
+        Ok(zi_primary == zi_primary_verified && zi_secondary == zi_secondary_verified)
     }
 
     fn z0_secondary() -> Vec<<F::G2 as Group>::Scalar> {


### PR DESCRIPTION
This PR addresses #695 by matching the `nova::Proof::verify` implementaton.

Do not merge until PR [#72](https://github.com/lurk-lab/arecibo/pull/72) in Arecibo is merged, and the `cargo.toml` change can be reverted. 