### PR TITLE
Distinguish fibonacci_lem from fibonacci in bench name.

### DIFF
--- a/benches/fibonacci_lem.rs
+++ b/benches/fibonacci_lem.rs
@@ -55,7 +55,7 @@ impl ProveParams {
     fn name(&self) -> String {
         let date = env!("VERGEN_GIT_COMMIT_DATE");
         let sha = env!("VERGEN_GIT_SHA");
-        format!("{date}:{sha}:Fibonacci-rc={}", self.reduction_count)
+        format!("{date}:{sha}:Fibonacci-LEM-rc={}", self.reduction_count)
     }
 }
 


### PR DESCRIPTION
Without this change, benchmark output makes the `fibonacci_lem` bench look the same as the `fibonacci` bench, interfering with post-hoc analysis of benchmark runs.