### PR TITLE
ci: Switch GPU runner to Paperspace

### DIFF
--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -36,7 +36,7 @@ concurrency:
 jobs:
   cuda:
     name: Rust tests on CUDA
-    runs-on: [self-hosted, gpu]
+    runs-on: [self-hosted, gpu-ci]
     env:
       NVIDIA_VISIBLE_DEVICES: all
       NVIDIA_DRIVER_CAPABILITITES: compute,utility
@@ -63,13 +63,12 @@ jobs:
       - name: CUDA tests
         env: 
           EC_GPU_FRAMEWORK: cuda
-        # Temporarily skipping CLI test due to cudaMallocAsync error: https://github.com/lurk-lab/lurk-rs/issues/596
         run: |
-          cargo nextest run --profile ci --cargo-profile dev-ci --features cuda -E 'all() - test(test_prove_and_verify)'
+          cargo nextest run --profile ci --cargo-profile dev-ci --features cuda
 
   opencl:
     name: Rust tests on OpenCL
-    runs-on: [self-hosted, gpu]
+    runs-on: [self-hosted, gpu-ci]
     env:
       NVIDIA_VISIBLE_DEVICES: all
       NVIDIA_DRIVER_CAPABILITITES: compute,utility
@@ -98,6 +97,5 @@ jobs:
       - name: OpenCL tests
         env:
           EC_GPU_FRAMEWORK: opencl
-        # Temporarily skipping CLI test due to cudaMallocAsync error: https://github.com/lurk-lab/lurk-rs/issues/596
         run: |
-          cargo nextest run --profile ci --cargo-profile dev-ci --features cuda,opencl -E 'all() - test(test_prove_and_verify)'
+          cargo nextest run --profile ci --cargo-profile dev-ci --features cuda,opencl


### PR DESCRIPTION
The current Vultr vGPU instance has issues with supporting the `cudaMallocAsync` function as seen in #595, so this PR switches GPU CI to run on a standalone Paperspace Nvidia A4000 instance. This also happens to lower the workflow time from 40 mins to 20.

Before: https://github.com/lurk-lab/lurk-rs/actions/runs/6581414040
After: https://github.com/samuelburnham/lurk-rs/actions/runs/6591626061

If the Vultr issue resolves we may eventually switch back to save a bit of compute cost.

Closes #595