### PR TITLE
Trie path fix

### DIFF
--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -788,7 +788,7 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
         let (arity_bits, bits_needed) = Self::path_bit_dimensions();
         let path = bits[bits.len() - bits_needed..]
             .chunks(arity_bits)
-            .map(|chunk| chunk.into())
+            .map(|chunk| chunk.to_owned().into_iter().rev().collect())
             .collect();
         Ok(path)
     }
@@ -1055,7 +1055,7 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
 }
 
 fn index_from_bits(bits: &[Boolean]) -> usize {
-    bits.iter().fold(0, |mut acc, bit| {
+    bits.iter().rev().fold(0, |mut acc, bit| {
         acc *= 2;
         if bit.get_value().unwrap_or(false) {
             acc += 1

--- a/src/proof/tests/nova_tests_lurk.rs
+++ b/src/proof/tests/nova_tests_lurk.rs
@@ -3398,7 +3398,7 @@ fn test_trie_lang_circuit() {
             s.read_with_state(state.clone(), "(.lurk.trie.insert 0x1cc5b90039db85fd519af975afa1de9d2b92960a585a546637b653b115bc3b53 123 456)").unwrap();
     let res3 = s
         .read_with_state(
-            state,
+            state.clone(),
             "0x1b22dc5a394231c34e4529af674dc56a736fbd07508acfd1d12c0e67c8b4de27",
         )
         .unwrap();
@@ -3414,6 +3414,38 @@ fn test_trie_lang_circuit() {
         DEFAULT_REDUCTION_COUNT,
         false,
         None,
-        lang,
+        lang.clone(),
+    );
+
+    nova_test_full_aux2::<_, _, C1Lurk<'_, _, TrieCoproc<_>>>(
+        s,
+        expr,
+        Some(res),
+        None,
+        Some(terminal),
+        None,
+        4,
+        DEFAULT_REDUCTION_COUNT,
+        false,
+        None,
+        lang.clone(),
+    );
+
+    let expr4 =
+            s.read_with_state(state, "(.lurk.trie.lookup 0x1b22dc5a394231c34e4529af674dc56a736fbd07508acfd1d12c0e67c8b4de27 123)").unwrap();
+    let res4 = s.intern_opaque_comm(Fr::from(456));
+
+    nova_test_full_aux2::<_, _, C1Lurk<'_, _, TrieCoproc<_>>>(
+        s,
+        expr4,
+        Some(res4),
+        None,
+        Some(terminal),
+        None,
+        2,
+        DEFAULT_REDUCTION_COUNT,
+        false,
+        None,
+        lang.clone(),
     );
 }


### PR DESCRIPTION
This adds a test for the positive lookup case (i.e. where something is found) of the Trie circuit. This missing test obscured that the bits of the path segment were backward (big-endian rather than little-endian). An empty trie is defined to find zero at the end of every path so can't be used to check this. I had a deferred the check to finalize this until the missing test could exercise it, but that test (apparently) never got written. Both issues should be fixed here.