### PR TITLE
Trie implementations for LEM

### DIFF
--- a/src/circuit/gadgets/pointer.rs
+++ b/src/circuit/gadgets/pointer.rs
@@ -90,9 +90,9 @@ impl<F: LurkField> AllocatedPtr<F> {
         })
     }
 
-    pub fn alloc_constant<CS: ConstraintSystem<F>>(
+    pub fn alloc_constant<CS: ConstraintSystem<F>, T: Tag>(
         cs: &mut CS,
-        value: ZExprPtr<F>,
+        value: ZPtr<T, F>,
     ) -> Result<Self, SynthesisError> {
         let alloc_tag = allocate_constant(&mut cs.namespace(|| "tag"), value.tag_field());
         let alloc_hash = allocate_constant(&mut cs.namespace(|| "hash"), *value.value());

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -34,7 +34,8 @@ use crate::circuit::gadgets::pointer::{AllocatedContPtr, AllocatedPtr};
 use crate::coprocessor::{CoCircuit, Coprocessor};
 use crate::eval::lang::Lang;
 use crate::field::{FWrap, LurkField};
-use crate::hash::{HashArity, InversePoseidonCache, PoseidonCache};
+use crate::hash::{HashArity, HashConstants, InversePoseidonCache, PoseidonCache};
+use crate::lem::{pointers::Ptr as LEMPtr, store::Store as LEMStore};
 use crate::num::Num;
 use crate::ptr::Ptr;
 use crate::store::Store;
@@ -71,12 +72,17 @@ impl<F: LurkField> Coprocessor<F> for NewCoprocessor<F> {
     }
 
     fn simple_evaluate(&self, s: &Store<F>, _args: &[Ptr<F>]) -> Ptr<F> {
-        let trie: StandardTrie<'_, F> = Trie::new(s);
+        let trie: StandardTrie<'_, F> = Trie::new(&s.poseidon_cache, &s.inverse_poseidon_cache);
 
         let root = trie.root;
 
         // TODO: Use a custom type.
         s.intern_num(Num::Scalar(root))
+    }
+
+    fn evaluate_lem_simple(&self, s: &LEMStore<F>, _args: &[LEMPtr<F>]) -> LEMPtr<F> {
+        let trie: StandardTrie<'_, F> = Trie::new(&s.poseidon_cache, &s.inverse_poseidon_cache);
+        LEMPtr::num(trie.root)
     }
 
     fn has_circuit(&self) -> bool {
@@ -101,7 +107,8 @@ impl<F: LurkField> CoCircuit<F> for NewCoprocessor<F> {
         input_cont: &AllocatedContPtr<F>,
         _not_dummy: &Boolean,
     ) -> Result<(AllocatedPtr<F>, AllocatedPtr<F>, AllocatedContPtr<F>), SynthesisError> {
-        let trie: StandardTrie<'_, F> = Trie::new(store);
+        let trie: StandardTrie<'_, F> =
+            Trie::new(&store.poseidon_cache, &store.inverse_poseidon_cache);
 
         // TODO: Use a custom type.
         let root = store.intern_num(Num::Scalar(trie.root));
@@ -112,6 +119,23 @@ impl<F: LurkField> CoCircuit<F> for NewCoprocessor<F> {
             input_env.clone(),
             input_cont.clone(),
         ))
+    }
+
+    fn synthesize_lem_simple<CS: ConstraintSystem<F>>(
+        &self,
+        cs: &mut CS,
+        _g: &lurk::lem::circuit::GlobalAllocator<F>,
+        s: &LEMStore<F>,
+        _not_dummy: &Boolean,
+        _args: &[AllocatedPtr<F>],
+    ) -> Result<AllocatedPtr<F>, SynthesisError> {
+        let trie: StandardTrie<'_, F> = Trie::new(&s.poseidon_cache, &s.inverse_poseidon_cache);
+
+        // TODO: Use a custom type.
+        let root = LEMPtr::num(trie.root);
+        let root_z_ptr = s.hash_ptr(&root).unwrap();
+
+        AllocatedPtr::alloc_constant(cs, root_z_ptr)
     }
 }
 
@@ -132,16 +156,72 @@ impl<F: LurkField> Coprocessor<F> for LookupCoprocessor<F> {
         // TODO: Check tags.
         let root_scalar = *s.hash_expr(&root_ptr).unwrap().value();
         let key_scalar = *s.hash_expr(&key_ptr).unwrap().value();
-        let trie: StandardTrie<'_, F> = Trie::new_with_root(s, root_scalar);
+        let trie: StandardTrie<'_, F> =
+            Trie::new_with_root(&s.poseidon_cache, &s.inverse_poseidon_cache, root_scalar);
 
         let found = trie.lookup_aux(key_scalar).unwrap();
 
         s.intern_maybe_opaque_comm(found)
     }
 
+    fn evaluate_lem_simple(&self, s: &LEMStore<F>, args: &[LEMPtr<F>]) -> LEMPtr<F> {
+        let root_ptr = &args[0];
+        let key_ptr = &args[1];
+
+        // TODO: Check tags.
+        let root_scalar = *s.hash_ptr(root_ptr).unwrap().value();
+        let key_scalar = *s.hash_ptr(key_ptr).unwrap().value();
+        let trie: StandardTrie<'_, F> =
+            Trie::new_with_root(&s.poseidon_cache, &s.inverse_poseidon_cache, root_scalar);
+
+        LEMPtr::comm(trie.lookup_aux(key_scalar).unwrap())
+    }
+
     fn has_circuit(&self) -> bool {
         true
     }
+}
+
+fn synthesize_lookup_aux<F: LurkField, CS: ConstraintSystem<F>>(
+    cs: &mut CS,
+    root_ptr: &AllocatedPtr<F>,
+    key_ptr: &AllocatedPtr<F>,
+    not_dummy: &Boolean,
+    poseidon_cache: &PoseidonCache<F>,
+    inverse_poseidon_cache: &InversePoseidonCache<F>,
+) -> Result<AllocatedNum<F>, SynthesisError> {
+    // TODO: Check tags.
+    let supplied_root_value = root_ptr.hash();
+    let root_value = supplied_root_value.get_value();
+    let key_val = key_ptr.hash();
+    let trie: StandardTrie<'_, F> = if not_dummy.get_value() == Some(true) {
+        Trie::new_with_root(
+            poseidon_cache,
+            inverse_poseidon_cache,
+            root_value.ok_or(SynthesisError::AssignmentMissing)?,
+        )
+    } else {
+        Trie::new(poseidon_cache, inverse_poseidon_cache)
+    };
+
+    let allocated_root_value =
+        AllocatedNum::alloc(&mut cs.namespace(|| "allocated_root_value"), || {
+            Ok(trie.root)
+        })?;
+
+    implies_equal(
+        &mut cs.namespace(|| "enforce_root"),
+        not_dummy,
+        supplied_root_value,
+        &allocated_root_value,
+    );
+
+    trie.synthesize_lookup(
+        cs,
+        &poseidon_cache.constants,
+        &allocated_root_value,
+        key_val,
+    )
 }
 
 impl<F: LurkField> CoCircuit<F> for LookupCoprocessor<F> {
@@ -162,30 +242,14 @@ impl<F: LurkField> CoCircuit<F> for LookupCoprocessor<F> {
         let root_ptr = &args[0];
         let key_ptr = &args[1];
 
-        // TODO: Check tags.
-        let supplied_root_value = root_ptr.hash();
-        let root_value = supplied_root_value.get_value();
-        let key_val = key_ptr.hash();
-        let trie: StandardTrie<'_, F> = if not_dummy.get_value() == Some(true) {
-            Trie::new_with_root(s, root_value.ok_or(SynthesisError::AssignmentMissing)?)
-        } else {
-            Trie::new(s)
-        };
-
-        let allocated_root_value =
-            AllocatedNum::alloc(&mut cs.namespace(|| "allocated_root_value"), || {
-                Ok(trie.root)
-            })?;
-
-        implies_equal(
-            &mut cs.namespace(|| "enforce_root"),
+        let result_commitment_val = synthesize_lookup_aux(
+            cs,
+            root_ptr,
+            key_ptr,
             not_dummy,
-            supplied_root_value,
-            &allocated_root_value,
-        );
-
-        let result_commitment_val =
-            trie.synthesize_lookup(cs, s, &allocated_root_value, key_val)?;
+            &s.poseidon_cache,
+            &s.inverse_poseidon_cache,
+        )?;
 
         let result_commitment = AllocatedPtr::alloc_tag(
             &mut cs.namespace(|| "result_commitment"),
@@ -194,6 +258,36 @@ impl<F: LurkField> CoCircuit<F> for LookupCoprocessor<F> {
         )?;
 
         Ok((result_commitment, input_env.clone(), input_cont.clone()))
+    }
+
+    fn synthesize_lem_simple<CS: ConstraintSystem<F>>(
+        &self,
+        cs: &mut CS,
+        g: &lurk::lem::circuit::GlobalAllocator<F>,
+        s: &LEMStore<F>,
+        not_dummy: &Boolean,
+        args: &[AllocatedPtr<F>],
+    ) -> Result<AllocatedPtr<F>, SynthesisError> {
+        let root_ptr = &args[0];
+        let key_ptr = &args[1];
+
+        let result_commitment_val = synthesize_lookup_aux(
+            cs,
+            root_ptr,
+            key_ptr,
+            not_dummy,
+            &s.poseidon_cache,
+            &s.inverse_poseidon_cache,
+        )?;
+
+        let comm_tag = g
+            .get_allocated_const(ExprTag::Comm.to_field())
+            .expect("Comm tag should have been allocated");
+
+        Ok(AllocatedPtr::from_parts(
+            comm_tag.clone(),
+            result_commitment_val,
+        ))
     }
 }
 
@@ -214,16 +308,77 @@ impl<F: LurkField> Coprocessor<F> for InsertCoprocessor<F> {
         let root_scalar = *s.hash_expr(&root_ptr).unwrap().value();
         let key_scalar = *s.hash_expr(&key_ptr).unwrap().value();
         let val_scalar = *s.hash_expr(&val_ptr).unwrap().value();
-        let mut trie: StandardTrie<'_, F> = Trie::new_with_root(s, root_scalar);
+        let mut trie: StandardTrie<'_, F> =
+            Trie::new_with_root(&s.poseidon_cache, &s.inverse_poseidon_cache, root_scalar);
         trie.insert(key_scalar, val_scalar).unwrap();
 
         let new_root = trie.root;
         s.intern_num(Num::Scalar(new_root))
     }
 
+    fn evaluate_lem_simple(&self, s: &LEMStore<F>, args: &[LEMPtr<F>]) -> LEMPtr<F> {
+        let root_ptr = &args[0];
+        let key_ptr = &args[1];
+        let val_ptr = &args[2];
+        let root_scalar = *s.hash_ptr(root_ptr).unwrap().value();
+        let key_scalar = *s.hash_ptr(key_ptr).unwrap().value();
+        let val_scalar = *s.hash_ptr(val_ptr).unwrap().value();
+        let mut trie: StandardTrie<'_, F> =
+            Trie::new_with_root(&s.poseidon_cache, &s.inverse_poseidon_cache, root_scalar);
+        trie.insert(key_scalar, val_scalar).unwrap();
+
+        LEMPtr::num(trie.root)
+    }
+
     fn has_circuit(&self) -> bool {
         true
     }
+}
+
+fn synthesize_insert_aux<F: LurkField, CS: ConstraintSystem<F>>(
+    cs: &mut CS,
+    root_ptr: &AllocatedPtr<F>,
+    key_ptr: &AllocatedPtr<F>,
+    val_ptr: &AllocatedPtr<F>,
+    not_dummy: &Boolean,
+    poseidon_cache: &PoseidonCache<F>,
+    inverse_poseidon_cache: &InversePoseidonCache<F>,
+) -> Result<AllocatedNum<F>, SynthesisError> {
+    // TODO: Check tags.
+    let supplied_root_value = root_ptr.hash();
+    let root_value = supplied_root_value.get_value();
+    let key_val = key_ptr.hash();
+    let new_val = val_ptr.hash();
+    let trie: StandardTrie<'_, F> = if not_dummy.get_value() == Some(true) {
+        Trie::new_with_root(
+            poseidon_cache,
+            inverse_poseidon_cache,
+            root_value.ok_or(SynthesisError::AssignmentMissing)?,
+        )
+    } else {
+        Trie::new(poseidon_cache, inverse_poseidon_cache)
+    };
+
+    let allocated_root_value =
+        AllocatedNum::alloc(&mut cs.namespace(|| "allocated_root_value"), || {
+            Ok(trie.root)
+        })?;
+
+    implies_equal(
+        &mut cs.namespace(|| "enforce_root"),
+        not_dummy,
+        supplied_root_value,
+        &allocated_root_value,
+    );
+
+    trie.synthesize_insert(
+        cs,
+        &poseidon_cache.constants,
+        &allocated_root_value,
+        key_val,
+        new_val.clone(),
+    )
+    .map_err(|_e| SynthesisError::Unsatisfiable)
 }
 
 impl<F: LurkField> CoCircuit<F> for InsertCoprocessor<F> {
@@ -247,32 +402,15 @@ impl<F: LurkField> CoCircuit<F> for InsertCoprocessor<F> {
 
         assert_eq!(self.arity(), args.len());
 
-        // TODO: Check tags.
-        let supplied_root_value = root_ptr.hash();
-        let root_value = supplied_root_value.get_value();
-        let key_val = key_ptr.hash();
-        let new_val = val_ptr.hash();
-        let trie: StandardTrie<'_, F> = if not_dummy.get_value() == Some(true) {
-            Trie::new_with_root(s, root_value.ok_or(SynthesisError::AssignmentMissing)?)
-        } else {
-            Trie::new(s)
-        };
-
-        let allocated_root_value =
-            AllocatedNum::alloc(&mut cs.namespace(|| "allocated_root_value"), || {
-                Ok(trie.root)
-            })?;
-
-        implies_equal(
-            &mut cs.namespace(|| "enforce_root"),
+        let new_root_val = synthesize_insert_aux(
+            cs,
+            root_ptr,
+            key_ptr,
+            val_ptr,
             not_dummy,
-            supplied_root_value,
-            &allocated_root_value,
-        );
-
-        let new_root_val = trie
-            .synthesize_insert(cs, s, &allocated_root_value, key_val, new_val.clone())
-            .map_err(|_e| SynthesisError::Unsatisfiable)?;
+            &s.poseidon_cache,
+            &s.inverse_poseidon_cache,
+        )?;
 
         let new_allocated_trie = AllocatedPtr::alloc_tag(
             &mut cs.namespace(|| "new_commitment"),
@@ -282,6 +420,34 @@ impl<F: LurkField> CoCircuit<F> for InsertCoprocessor<F> {
         )?;
 
         Ok((new_allocated_trie, input_env.clone(), input_cont.clone()))
+    }
+
+    fn synthesize_lem_simple<CS: ConstraintSystem<F>>(
+        &self,
+        cs: &mut CS,
+        g: &lurk::lem::circuit::GlobalAllocator<F>,
+        s: &LEMStore<F>,
+        not_dummy: &Boolean,
+        args: &[AllocatedPtr<F>],
+    ) -> Result<AllocatedPtr<F>, SynthesisError> {
+        let root_ptr = &args[0];
+        let key_ptr = &args[1];
+        let val_ptr = &args[2];
+
+        let new_root_val = synthesize_insert_aux(
+            cs,
+            root_ptr,
+            key_ptr,
+            val_ptr,
+            not_dummy,
+            &s.poseidon_cache,
+            &s.inverse_poseidon_cache,
+        )?;
+
+        let num_tag = g
+            .get_allocated_const(ExprTag::Num.to_field())
+            .expect("Num tag should have been allocated");
+        Ok(AllocatedPtr::from_parts(num_tag.clone(), new_root_val))
     }
 }
 
@@ -304,6 +470,25 @@ pub fn install<F: LurkField>(
 
     let name: Symbol = ".lurk.trie".into();
     let mut package = Package::new(name.into());
+    ["new", "lookup", "insert"].into_iter().for_each(|name| {
+        package.intern(name);
+    });
+    state.borrow_mut().add_package(package);
+}
+
+/// Add the `Trie`-associated functions to a `Lang` with standard bindings.
+// TODO: define standard patterns for such modularity.
+pub fn install_lem<F: LurkField>(
+    s: &LEMStore<F>,
+    state: &Rc<RefCell<State>>,
+    lang: &mut Lang<F, TrieCoproc<F>>,
+) {
+    lang.add_coprocessor_lem(".lurk.trie.new", NewCoprocessor::default(), s);
+    lang.add_coprocessor_lem(".lurk.trie.lookup", LookupCoprocessor::default(), s);
+    lang.add_coprocessor_lem(".lurk.trie.insert", InsertCoprocessor::default(), s);
+
+    let trie_package_name: Symbol = ".lurk.trie".into();
+    let mut package = Package::new(trie_package_name.into());
     ["new", "lookup", "insert"].into_iter().for_each(|name| {
         package.intern(name);
     });
@@ -484,22 +669,30 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
 
     /// Creates a new `Trie`, saving preimage data in `store`.
     /// HEIGHT must be exactly that required to minimally store all elements of `F`.
-    pub fn new(store: &'a Store<F>) -> Self {
-        Self::new_aux(store, None)
+    pub fn new(
+        poseidon_cache: &'a PoseidonCache<F>,
+        inverse_poseidon_cache: &'a InversePoseidonCache<F>,
+    ) -> Self {
+        Self::new_aux(poseidon_cache, inverse_poseidon_cache, None)
     }
 
     /// Creates a new `Trie`, saving preimage data in `store`.
     /// Height must be at least that required to store `size` elements.
-    pub fn new_with_capacity(store: &'a Store<F>, size: usize) -> Self {
-        Self::new_aux(store, Some(size))
+    pub fn new_with_capacity(
+        poseidon_cache: &'a PoseidonCache<F>,
+        inverse_poseidon_cache: &'a InversePoseidonCache<F>,
+        size: usize,
+    ) -> Self {
+        Self::new_aux(poseidon_cache, inverse_poseidon_cache, Some(size))
     }
 
-    fn new_aux(store: &'a Store<F>, size: Option<usize>) -> Self {
+    fn new_aux(
+        poseidon_cache: &'a PoseidonCache<F>,
+        inverse_poseidon_cache: &'a InversePoseidonCache<F>,
+        size: Option<usize>,
+    ) -> Self {
         // ARITY must be a power of two.
         assert_eq!(1, ARITY.count_ones());
-
-        let poseidon_cache = &store.poseidon_cache;
-        let inverse_poseidon_cache = &store.inverse_poseidon_cache;
 
         // This will panic if ARITY is unsupporteed.
         let _ = HashArity::from(ARITY);
@@ -541,8 +734,12 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
     }
 
     /// Create a new `Trie` with specified root.
-    fn new_with_root(store: &'a Store<F>, root: F) -> Self {
-        let mut new = Self::new(store);
+    fn new_with_root(
+        poseidon_cache: &'a PoseidonCache<F>,
+        inverse_poseidon_cache: &'a InversePoseidonCache<F>,
+        root: F,
+    ) -> Self {
+        let mut new = Self::new(poseidon_cache, inverse_poseidon_cache);
 
         new.root = root;
 
@@ -620,14 +817,14 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
     fn synthesize_lookup<CS: ConstraintSystem<F>>(
         &self,
         cs: &mut CS,
-        s: &Store<F>,
+        hash_constants: &HashConstants<F>,
         allocated_root: &AllocatedNum<F>,
         key: &AllocatedNum<F>,
     ) -> Result<AllocatedNum<F>, SynthesisError> {
         let path = Self::synthesize_path(&mut cs.namespace(|| "path"), key)?;
 
         let val = self
-            .synthesize_lookup_at_path(cs, s, allocated_root, &path)?
+            .synthesize_lookup_at_path(cs, hash_constants, allocated_root, &path)?
             .0;
 
         Ok(val)
@@ -636,7 +833,7 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
     fn synthesize_lookup_at_path<CS: ConstraintSystem<F>>(
         &self,
         cs: &mut CS,
-        s: &Store<F>,
+        hash_constants: &HashConstants<F>,
         allocated_root: &AllocatedNum<F>,
         path: &[Vec<Boolean>],
     ) -> Result<(AllocatedNum<F>, Vec<Vec<AllocatedNum<F>>>), SynthesisError> {
@@ -672,7 +869,7 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
 
                     preimage_path.push(allocated_preimage.clone());
 
-                    let hashed = s.poseidon_constants().constants(ARITY.into()).hash(
+                    let hashed = hash_constants.constants(ARITY.into()).hash(
                         &mut cs.namespace(|| format!("poseidon_hash_{i}")),
                         allocated_preimage.clone(),
                         None,
@@ -779,7 +976,7 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
     pub fn synthesize_insert<CS: ConstraintSystem<F>>(
         &self,
         cs: &mut CS,
-        s: &Store<F>,
+        hash_constants: &HashConstants<F>,
         allocated_root: &AllocatedNum<F>,
         key: &AllocatedNum<F>,
         value: AllocatedNum<F>,
@@ -787,7 +984,7 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
         let path = Self::synthesize_path(&mut cs.namespace(|| "path"), key)?;
         self.synthesize_insert_at_path(
             &mut cs.namespace(|| "insert_aux"),
-            s,
+            hash_constants,
             allocated_root,
             &path,
             value,
@@ -797,7 +994,7 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
     fn synthesize_insert_at_path<CS: ConstraintSystem<F>>(
         &self,
         cs: &mut CS,
-        s: &Store<F>,
+        hash_constants: &HashConstants<F>,
         allocated_root: &AllocatedNum<F>,
         path: &[Vec<Boolean>],
         value: AllocatedNum<F>,
@@ -805,7 +1002,7 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
         let preimage_path = self
             .synthesize_lookup_at_path(
                 &mut cs.namespace(|| "found_value"),
-                s,
+                hash_constants,
                 allocated_root,
                 path,
             )?
@@ -813,7 +1010,7 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
 
         Self::synthesize_modify_value_at_path(
             &mut cs.namespace(|| "new_root_value"),
-            s,
+            hash_constants,
             path,
             &preimage_path,
             value,
@@ -822,7 +1019,7 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
 
     fn synthesize_modify_value_at_path<CS: ConstraintSystem<F>>(
         cs: &mut CS,
-        s: &Store<F>,
+        hash_constants: &HashConstants<F>,
         path: &[Vec<Boolean>],
         preimage_path: &[Vec<AllocatedNum<F>>],
         mut value: AllocatedNum<F>,
@@ -846,7 +1043,7 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
                 })
                 .collect::<Result<Vec<_>, SynthesisError>>()?;
 
-            value = s.poseidon_constants().constants(ARITY.into()).hash(
+            value = hash_constants.constants(ARITY.into()).hash(
                 &mut cs.namespace(|| format!("poseidon_hash_{i}")),
                 new_preimage,
                 None,
@@ -879,12 +1076,24 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Default
 mod test {
     use super::*;
     use ff::PrimeField;
+    use once_cell::sync::OnceCell;
     use pasta_curves::pallas::Scalar as Fr;
+
+    static POSEIDON_CACHE: OnceCell<PoseidonCache<Fr>> = OnceCell::new();
+    static INVERSE_POSEIDON_CACHE: OnceCell<InversePoseidonCache<Fr>> = OnceCell::new();
+
+    fn poseidon_cache() -> &'static PoseidonCache<Fr> {
+        POSEIDON_CACHE.get_or_init(PoseidonCache::default)
+    }
+
+    fn inverse_poseidon_cache() -> &'static InversePoseidonCache<Fr> {
+        INVERSE_POSEIDON_CACHE.get_or_init(InversePoseidonCache::default)
+    }
 
     #[test]
     fn test_empty_roots() {
-        let s = &mut Store::new();
-        let t: Trie<'_, Fr, 8, 3> = Trie::new_with_capacity(s, 512);
+        let t: Trie<'_, Fr, 8, 3> =
+            Trie::new_with_capacity(poseidon_cache(), inverse_poseidon_cache(), 512);
         assert_eq!(Fr::zero(), Trie::<'_, Fr, 8, 3>::empty_element());
         assert_eq!(Fr::zero(), t.empty_root_for_height(0));
         assert_eq!(
@@ -919,24 +1128,27 @@ mod test {
 
     #[test]
     fn test_sizes() {
-        let s = &mut Store::new();
         {
-            let t: Trie<'_, Fr, 8, 1> = Trie::new_with_capacity(s, 8);
+            let t: Trie<'_, Fr, 8, 1> =
+                Trie::new_with_capacity(poseidon_cache(), inverse_poseidon_cache(), 8);
             assert_eq!(8, t.leaves());
         }
 
         {
-            let t: Trie<'_, Fr, 8, 2> = Trie::new_with_capacity(s, 64);
+            let t: Trie<'_, Fr, 8, 2> =
+                Trie::new_with_capacity(poseidon_cache(), inverse_poseidon_cache(), 64);
             assert_eq!(64, t.leaves());
         }
 
         {
-            let t: Trie<'_, Fr, 8, 3> = Trie::new_with_capacity(s, 512);
+            let t: Trie<'_, Fr, 8, 3> =
+                Trie::new_with_capacity(poseidon_cache(), inverse_poseidon_cache(), 512);
             assert_eq!(512, t.leaves());
         }
 
         {
-            let t: Trie<'_, Fr, 8, 4> = Trie::new_with_capacity(s, 4096);
+            let t: Trie<'_, Fr, 8, 4> =
+                Trie::new_with_capacity(poseidon_cache(), inverse_poseidon_cache(), 4096);
             assert_eq!(1, t.row_size(0));
             assert_eq!(8, t.row_size(1));
             assert_eq!(64, t.row_size(2));
@@ -959,9 +1171,9 @@ mod test {
 
     #[test]
     fn test_hashes() {
-        let s = &mut Store::new();
         {
-            let mut t0: Trie<'_, Fr, 8, 1> = Trie::new_with_capacity(s, 8);
+            let mut t0: Trie<'_, Fr, 8, 1> =
+                Trie::new_with_capacity(poseidon_cache(), inverse_poseidon_cache(), 8);
             assert_eq!(
                 scalar_from_u64s([
                     0xa81830c13a876b1c,
@@ -974,7 +1186,8 @@ mod test {
             assert_eq!(t0.empty_root(), t0.root());
         }
         {
-            let mut t1: Trie<'_, Fr, 8, 2> = Trie::new_with_capacity(s, 64);
+            let mut t1: Trie<'_, Fr, 8, 2> =
+                Trie::new_with_capacity(poseidon_cache(), inverse_poseidon_cache(), 64);
             assert_eq!(
                 scalar_from_u64s([
                     0x33ff39660bc554aa,
@@ -987,7 +1200,8 @@ mod test {
             assert_eq!(t1.empty_root(), t1.root());
         }
         {
-            let mut t2: Trie<'_, Fr, 8, 3> = Trie::new_with_capacity(s, 512);
+            let mut t2: Trie<'_, Fr, 8, 3> =
+                Trie::new_with_capacity(poseidon_cache(), inverse_poseidon_cache(), 512);
             assert_eq!(
                 scalar_from_u64s([
                     0xa52e7d0bbbee086b,
@@ -1000,7 +1214,8 @@ mod test {
             assert_eq!(t2.empty_root(), t2.root());
         }
         {
-            let mut t3: Trie<'_, Fr, 8, 4> = Trie::new_with_capacity(s, 4096);
+            let mut t3: Trie<'_, Fr, 8, 4> =
+                Trie::new_with_capacity(poseidon_cache(), inverse_poseidon_cache(), 4096);
             assert_eq!(
                 scalar_from_u64s([
                     0xd95987b58e6c5852,
@@ -1021,9 +1236,9 @@ mod test {
 
     #[test]
     fn test_lookup() {
-        let s = &mut Store::new();
         {
-            let t3: Trie<'_, Fr, 8, 3> = Trie::new_with_capacity(s, 512);
+            let t3: Trie<'_, Fr, 8, 3> =
+                Trie::new_with_capacity(poseidon_cache(), inverse_poseidon_cache(), 512);
 
             let found = t3.lookup(Fr::from_u64(500)).unwrap();
             assert_eq!(None, found);
@@ -1031,9 +1246,9 @@ mod test {
     }
     #[test]
     fn test_lookup_proof() {
-        let s = &mut Store::new();
         {
-            let t3: Trie<'_, Fr, 8, 3> = Trie::new_with_capacity(s, 512);
+            let t3: Trie<'_, Fr, 8, 3> =
+                Trie::new_with_capacity(poseidon_cache(), inverse_poseidon_cache(), 512);
             let root = t3.root();
             let key = Fr::from_u64(500);
             let proof = t3.prove_lookup(key).unwrap();
@@ -1047,10 +1262,9 @@ mod test {
     #[test]
     fn test_insert() {
         // TODO: Use prop tests.
-
-        let s = &mut Store::new();
         {
-            let mut t3: Trie<'_, Fr, 8, 3> = Trie::new_with_capacity(s, 512);
+            let mut t3: Trie<'_, Fr, 8, 3> =
+                Trie::new_with_capacity(poseidon_cache(), inverse_poseidon_cache(), 512);
             let key = Fr::from_u64(500);
             let val = Fr::from_u64(123);
 
@@ -1083,9 +1297,9 @@ mod test {
 
     #[test]
     fn test_insert_proof() {
-        let s = &mut Store::new();
         {
-            let mut t3: Trie<'_, Fr, 8, 3> = Trie::new_with_capacity(s, 512);
+            let mut t3: Trie<'_, Fr, 8, 3> =
+                Trie::new_with_capacity(poseidon_cache(), inverse_poseidon_cache(), 512);
             let key = Fr::from_u64(500);
             let val = Fr::from_u64(123);
 

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -778,6 +778,7 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
         path
     }
 
+    /// Synthesizes path as chunks of little-endian bits
     fn synthesize_path<CS: ConstraintSystem<F>>(
         cs: &mut CS,
         key: &AllocatedNum<F>,
@@ -786,6 +787,7 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
         bits.reverse();
 
         let (arity_bits, bits_needed) = Self::path_bit_dimensions();
+        // each chunk is reversed due to little-endian encoding
         let path = bits[bits.len() - bits_needed..]
             .chunks(arity_bits)
             .map(|chunk| chunk.iter().cloned().rev().collect())
@@ -793,10 +795,10 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
         Ok(path)
     }
 
-    // Returns a value corresponding to the commitment associated with `key`, if any.
-    // Note that this depends on the impossibility of discovering a value for which the commitment is zero. We could
-    // alternately return the empty element (`F::zero()`) for missing values, but instead return an `Option` to more
-    // clearly signal intent -- since the encoding of 'missing' values as `Fr::zero()` is significant.
+    /// Returns a value corresponding to the commitment associated with `key`, if any.
+    /// Note that this depends on the impossibility of discovering a value for which the commitment is zero. We could
+    /// alternately return the empty element (`F::zero()`) for missing values, but instead return an `Option` to more
+    /// clearly signal intent -- since the encoding of 'missing' values as `Fr::zero()` is significant.
     pub fn lookup(&self, key: F) -> Result<Option<F>, Error<F>> {
         self.lookup_aux(key)
             .map(|payload| (payload != Self::empty_element()).then_some(payload))

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -788,7 +788,7 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
         let (arity_bits, bits_needed) = Self::path_bit_dimensions();
         let path = bits[bits.len() - bits_needed..]
             .chunks(arity_bits)
-            .map(|chunk| chunk.to_owned().into_iter().rev().collect())
+            .map(|chunk| chunk.iter().cloned().rev().collect())
             .collect();
         Ok(path)
     }

--- a/src/lem/store.rs
+++ b/src/lem/store.rs
@@ -1,7 +1,9 @@
 use anyhow::{bail, Result};
 use arc_swap::ArcSwap;
-use elsa::sync::{FrozenMap, FrozenVec};
-use elsa::sync_index_set::FrozenIndexSet;
+use elsa::{
+    sync::{FrozenMap, FrozenVec},
+    sync_index_set::FrozenIndexSet,
+};
 use indexmap::IndexSet;
 use nom::{sequence::preceded, Parser};
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
@@ -9,7 +11,7 @@ use std::{cell::RefCell, rc::Rc, sync::Arc};
 
 use crate::{
     field::{FWrap, LurkField},
-    hash::PoseidonCache,
+    hash::{InversePoseidonCache, PoseidonCache},
     lem::Tag,
     parser::{syntax, Error, Span},
     state::{lurk_sym, user_sym, State},
@@ -56,6 +58,7 @@ pub struct Store<F: LurkField> {
     ptr_symbol_cache: FrozenMap<Ptr<F>, Box<Symbol>>,
 
     pub poseidon_cache: PoseidonCache<F>,
+    pub inverse_poseidon_cache: InversePoseidonCache<F>,
 
     dehydrated: ArcSwap<FrozenVec<Box<Ptr<F>>>>,
     z_cache: FrozenMap<Ptr<F>, Box<ZPtr<F>>>,

--- a/src/lem/tests/eval_tests.rs
+++ b/src/lem/tests/eval_tests.rs
@@ -1,3 +1,5 @@
+use std::{cell::RefCell, rc::Rc};
+
 use pasta_curves::pallas::Scalar as Fr;
 
 use crate::{
@@ -27,11 +29,57 @@ fn test_aux<C: Coprocessor<Fr>>(
     lang: &Option<&Lang<Fr, C>>,
 ) {
     let ptr = s.read_with_default_state(expr).unwrap();
+    do_test_aux(
+        s,
+        &ptr,
+        expected_result,
+        expected_env,
+        expected_cont,
+        expected_emitted,
+        expected_iterations,
+        lang,
+    );
+}
 
+fn test_aux_with_state<C: Coprocessor<Fr>>(
+    s: &Store<Fr>,
+    state: Rc<RefCell<State>>,
+    expr: &str,
+    expected_result: Option<Ptr<Fr>>,
+    expected_env: Option<Ptr<Fr>>,
+    expected_cont: Option<Ptr<Fr>>,
+    expected_emitted: Option<Vec<Ptr<Fr>>>,
+    expected_iterations: usize,
+    lang: &Option<&Lang<Fr, C>>,
+) {
+    let ptr = s.read(state, expr).unwrap();
+    do_test_aux(
+        s,
+        &ptr,
+        expected_result,
+        expected_env,
+        expected_cont,
+        expected_emitted,
+        expected_iterations,
+        lang,
+    );
+}
+
+#[inline]
+fn do_test_aux<C: Coprocessor<Fr>>(
+    s: &Store<Fr>,
+    ptr: &Ptr<Fr>,
+    expected_result: Option<Ptr<Fr>>,
+    expected_env: Option<Ptr<Fr>>,
+    expected_cont: Option<Ptr<Fr>>,
+    expected_emitted: Option<Vec<Ptr<Fr>>>,
+    expected_iterations: usize,
+    lang: &Option<&Lang<Fr, C>>,
+) {
     if let Some(lang) = lang {
-        test_aux2(
+        do_test(
             s,
-            &ptr,
+            ptr,
             expected_result,
             expected_env,
             expected_cont,
@@ -41,9 +89,9 @@ fn test_aux<C: Coprocessor<Fr>>(
         )
     } else {
         let lang = Lang::<Fr, Coproc<Fr>>::new();
-        test_aux2(
+        do_test(
             s,
-            &ptr,
+            ptr,
             expected_result,
             expected_env,
             expected_cont,
@@ -54,7 +102,7 @@ fn test_aux<C: Coprocessor<Fr>>(
     }
 }
 
-fn test_aux2<C: Coprocessor<Fr>>(
+fn do_test<C: Coprocessor<Fr>>(
     s: &Store<Fr>,
     expr: &Ptr<Fr>,
     expected_result: Option<Ptr<Fr>>,
@@ -1576,21 +1624,21 @@ fn hide_opaque_open_available() {
 
     {
         let expr = s.list(vec![open, comm]);
-        test_aux2::<Coproc<Fr>>(s, &expr, Some(x), None, None, None, 2, &lang);
+        do_test::<Coproc<Fr>>(s, &expr, Some(x), None, None, None, 2, &lang);
     }
 
     {
         let secret = s.intern_lurk_symbol("secret");
         let expr = s.list(vec![secret, comm]);
         let sec = Ptr::num_u64(123);
-        test_aux2::<Coproc<Fr>>(s, &expr, Some(sec), None, None, None, 2, &lang);
+        do_test::<Coproc<Fr>>(s, &expr, Some(sec), None, None, None, 2, &lang);
     }
 
     {
         // We can open a commitment identified by its corresponding `Num`.
         let comm_num = Ptr::num(c);
         let expr2 = s.list(vec![open, comm_num]);
-        test_aux2::<Coproc<Fr>>(s, &expr2, Some(x), None, None, None, 2, &lang);
+        do_test::<Coproc<Fr>>(s, &expr2, Some(x), None, None, None, 2, &lang);
     }
 }
 
@@ -1611,7 +1659,7 @@ fn hide_opaque_open_unavailable() {
     let expr = s2.list(vec![open, comm]);
     let lang = Lang::new();
 
-    test_aux2::<Coproc<Fr>>(s2, &expr, Some(x), None, None, None, 2, &lang);
+    do_test::<Coproc<Fr>>(s2, &expr, Some(x), None, None, None, 2, &lang);
 }
 
 #[test]
@@ -2788,4 +2836,122 @@ fn test_dumb_lang() {
     test_aux(s, expr4, None, None, Some(error), None, 4, &Some(&lang));
     test_aux(s, expr5, None, None, Some(error), None, 2, &Some(&lang));
     test_aux(s, expr6, None, None, Some(error), None, 2, &Some(&lang));
+}
+
+#[test]
+fn test_trie_lang() {
+    use crate::coprocessor::trie::{install_lem, TrieCoproc};
+
+    let s = &Store::<Fr>::default();
+    let state = State::init_lurk_state().rccell();
+    let mut lang = Lang::<Fr, TrieCoproc<Fr>>::new();
+
+    install_lem(s, &state, &mut lang);
+
+    let expr = "(let ((trie (.lurk.trie.new)))
+                      trie)";
+    let res = s
+        .read_with_default_state(
+            "0x1cc5b90039db85fd519af975afa1de9d2b92960a585a546637b653b115bc3b53",
+        )
+        .unwrap();
+
+    test_aux_with_state(
+        s,
+        state.clone(),
+        expr,
+        Some(res),
+        None,
+        None,
+        None,
+        5,
+        &Some(&lang),
+    );
+
+    let expr2 =
+        "(.lurk.trie.lookup 0x1cc5b90039db85fd519af975afa1de9d2b92960a585a546637b653b115bc3b53 123)";
+    let res2 = Ptr::comm(Fr::zero());
+
+    test_aux_with_state(
+        s,
+        state.clone(),
+        expr2,
+        Some(res2),
+        None,
+        None,
+        None,
+        3,
+        &Some(&lang),
+    );
+
+    let expr3 =
+        "(.lurk.trie.insert 0x1cc5b90039db85fd519af975afa1de9d2b92960a585a546637b653b115bc3b53 123 456)";
+    let res3 = s
+        .read_with_default_state(
+            "0x1b22dc5a394231c34e4529af674dc56a736fbd07508acfd1d12c0e67c8b4de27",
+        )
+        .unwrap();
+
+    test_aux_with_state(
+        s,
+        state.clone(),
+        expr3,
+        Some(res3),
+        None,
+        None,
+        None,
+        4,
+        &Some(&lang),
+    );
+
+    let expr4 =
+        "(.lurk.trie.lookup 0x1b22dc5a394231c34e4529af674dc56a736fbd07508acfd1d12c0e67c8b4de27 123)";
+    let res4 = Ptr::comm(Fr::from(456));
+
+    test_aux_with_state(
+        s,
+        state.clone(),
+        expr4,
+        Some(res4),
+        None,
+        None,
+        None,
+        3,
+        &Some(&lang),
+    );
+
+    let s = &Store::<Fr>::default();
+    let expr5 = "(let ((trie (.lurk.trie.new))
+                       (found (.lurk.trie.lookup trie 123)))
+                      found)";
+    let res5 = Ptr::comm(Fr::zero());
+
+    test_aux_with_state(
+        s,
+        state.clone(),
+        expr5,
+        Some(res5),
+        None,
+        None,
+        None,
+        10,
+        &Some(&lang),
+    );
+
+    let expr6 = "(let ((trie (.lurk.trie.insert (.lurk.trie.new) 123 456))
+                       (found (.lurk.trie.lookup trie 123)))
+                      found)";
+    let res6 = Ptr::comm(Fr::from(456));
+
+    test_aux_with_state(
+        s,
+        state.clone(),
+        expr6,
+        Some(res6),
+        None,
+        None,
+        None,
+        14,
+        &Some(&lang),
+    );
 }

--- a/src/proof/tests/nova_tests_lem.rs
+++ b/src/proof/tests/nova_tests_lem.rs
@@ -3272,6 +3272,140 @@ fn test_dumb_lang() {
     );
 }
 
+#[test]
+fn test_trie_lang() {
+    use crate::coprocessor::trie::{install_lem, TrieCoproc};
+
+    let s = &Store::<Fr>::default();
+    let state = State::init_lurk_state().rccell();
+    let mut lang = Lang::<Fr, TrieCoproc<Fr>>::new();
+
+    install_lem(s, &state, &mut lang);
+
+    let lang = Arc::new(lang);
+
+    let terminal = Ptr::null(Tag::Cont(Terminal));
+
+    // let expr = "(let ((trie (.lurk.trie.new)))
+    //                   trie)";
+    // let expr = s.read(state.clone(), expr).unwrap();
+    // let res = s
+    //     .read_with_default_state(
+    //         "0x1cc5b90039db85fd519af975afa1de9d2b92960a585a546637b653b115bc3b53",
+    //     )
+    //     .unwrap();
+    // nova_test_full_aux2::<_, _, C1LEM<'_, _, TrieCoproc<_>>>(
+    //     s,
+    //     expr,
+    //     Some(res),
+    //     None,
+    //     Some(terminal),
+    //     None,
+    //     5,
+    //     DEFAULT_REDUCTION_COUNT,
+    //     false,
+    //     None,
+    //     lang.clone(),
+    // );
+
+    // let expr2 =
+    //     "(.lurk.trie.lookup 0x1cc5b90039db85fd519af975afa1de9d2b92960a585a546637b653b115bc3b53 123)";
+    // let expr2 = s.read(state.clone(), expr2).unwrap();
+    // let res2 = Ptr::comm(Fr::zero());
+    // nova_test_full_aux2::<_, _, C1LEM<'_, _, TrieCoproc<_>>>(
+    //     s,
+    //     expr2,
+    //     Some(res2),
+    //     None,
+    //     Some(terminal),
+    //     None,
+    //     3,
+    //     DEFAULT_REDUCTION_COUNT,
+    //     false,
+    //     None,
+    //     lang.clone(),
+    // );
+
+    // let expr3 =
+    //     "(.lurk.trie.insert 0x1cc5b90039db85fd519af975afa1de9d2b92960a585a546637b653b115bc3b53 123 456)";
+    // let expr3 = s.read(state.clone(), expr3).unwrap();
+    // let res3 = s
+    //     .read_with_default_state(
+    //         "0x1b22dc5a394231c34e4529af674dc56a736fbd07508acfd1d12c0e67c8b4de27",
+    //     )
+    //     .unwrap();
+    // nova_test_full_aux2::<_, _, C1LEM<'_, _, TrieCoproc<_>>>(
+    //     s,
+    //     expr3,
+    //     Some(res3),
+    //     None,
+    //     Some(terminal),
+    //     None,
+    //     4,
+    //     DEFAULT_REDUCTION_COUNT,
+    //     false,
+    //     None,
+    //     lang.clone(),
+    // );
+
+    // let expr4 =
+    //     "(.lurk.trie.lookup 0x1b22dc5a394231c34e4529af674dc56a736fbd07508acfd1d12c0e67c8b4de27 123)";
+    // let expr4 = s.read(state.clone(), expr4).unwrap();
+    // let res4 = Ptr::comm(Fr::from(456));
+    // nova_test_full_aux2::<_, _, C1LEM<'_, _, TrieCoproc<_>>>(
+    //     s,
+    //     expr4,
+    //     Some(res4),
+    //     None,
+    //     Some(terminal),
+    //     None,
+    //     3,
+    //     DEFAULT_REDUCTION_COUNT,
+    //     false,
+    //     None,
+    //     lang.clone(),
+    // );
+
+    // let s = &Store::<Fr>::default();
+    // let expr5 = "(let ((trie (.lurk.trie.new))
+    //                    (found (.lurk.trie.lookup trie 123)))
+    //                   found)";
+    // let expr5 = s.read(state.clone(), expr5).unwrap();
+    // let res5 = Ptr::comm(Fr::zero());
+    // nova_test_full_aux2::<_, _, C1LEM<'_, _, TrieCoproc<_>>>(
+    //     s,
+    //     expr5,
+    //     Some(res5),
+    //     None,
+    //     Some(terminal),
+    //     None,
+    //     10,
+    //     DEFAULT_REDUCTION_COUNT,
+    //     false,
+    //     None,
+    //     lang.clone(),
+    // );
+
+    let expr6 = "(let ((trie (.lurk.trie.insert (.lurk.trie.new) 123 456))
+                       (found (.lurk.trie.lookup trie 123)))
+                      found)";
+    let expr6 = s.read(state.clone(), expr6).unwrap();
+    let res6 = Ptr::comm(Fr::from(456));
+    nova_test_full_aux2::<_, _, C1LEM<'_, _, TrieCoproc<_>>>(
+        s,
+        expr6,
+        Some(res6),
+        None,
+        Some(terminal),
+        None,
+        14,
+        DEFAULT_REDUCTION_COUNT,
+        false,
+        None,
+        lang.clone(),
+    );
+}
+
 // This is related to issue #426
 #[test]
 fn test_prove_lambda_body_nil() {

--- a/src/proof/tests/nova_tests_lem.rs
+++ b/src/proof/tests/nova_tests_lem.rs
@@ -3286,105 +3286,105 @@ fn test_trie_lang() {
 
     let terminal = Ptr::null(Tag::Cont(Terminal));
 
-    // let expr = "(let ((trie (.lurk.trie.new)))
-    //                   trie)";
-    // let expr = s.read(state.clone(), expr).unwrap();
-    // let res = s
-    //     .read_with_default_state(
-    //         "0x1cc5b90039db85fd519af975afa1de9d2b92960a585a546637b653b115bc3b53",
-    //     )
-    //     .unwrap();
-    // nova_test_full_aux2::<_, _, C1LEM<'_, _, TrieCoproc<_>>>(
-    //     s,
-    //     expr,
-    //     Some(res),
-    //     None,
-    //     Some(terminal),
-    //     None,
-    //     5,
-    //     DEFAULT_REDUCTION_COUNT,
-    //     false,
-    //     None,
-    //     lang.clone(),
-    // );
+    let expr = "(let ((trie (.lurk.trie.new)))
+                      trie)";
+    let expr = s.read(state.clone(), expr).unwrap();
+    let res = s
+        .read_with_default_state(
+            "0x1cc5b90039db85fd519af975afa1de9d2b92960a585a546637b653b115bc3b53",
+        )
+        .unwrap();
+    nova_test_full_aux2::<_, _, C1LEM<'_, _, TrieCoproc<_>>>(
+        s,
+        expr,
+        Some(res),
+        None,
+        Some(terminal),
+        None,
+        5,
+        DEFAULT_REDUCTION_COUNT,
+        false,
+        None,
+        lang.clone(),
+    );
 
-    // let expr2 =
-    //     "(.lurk.trie.lookup 0x1cc5b90039db85fd519af975afa1de9d2b92960a585a546637b653b115bc3b53 123)";
-    // let expr2 = s.read(state.clone(), expr2).unwrap();
-    // let res2 = Ptr::comm(Fr::zero());
-    // nova_test_full_aux2::<_, _, C1LEM<'_, _, TrieCoproc<_>>>(
-    //     s,
-    //     expr2,
-    //     Some(res2),
-    //     None,
-    //     Some(terminal),
-    //     None,
-    //     3,
-    //     DEFAULT_REDUCTION_COUNT,
-    //     false,
-    //     None,
-    //     lang.clone(),
-    // );
+    let expr2 =
+        "(.lurk.trie.lookup 0x1cc5b90039db85fd519af975afa1de9d2b92960a585a546637b653b115bc3b53 123)";
+    let expr2 = s.read(state.clone(), expr2).unwrap();
+    let res2 = Ptr::comm(Fr::zero());
+    nova_test_full_aux2::<_, _, C1LEM<'_, _, TrieCoproc<_>>>(
+        s,
+        expr2,
+        Some(res2),
+        None,
+        Some(terminal),
+        None,
+        3,
+        DEFAULT_REDUCTION_COUNT,
+        false,
+        None,
+        lang.clone(),
+    );
 
-    // let expr3 =
-    //     "(.lurk.trie.insert 0x1cc5b90039db85fd519af975afa1de9d2b92960a585a546637b653b115bc3b53 123 456)";
-    // let expr3 = s.read(state.clone(), expr3).unwrap();
-    // let res3 = s
-    //     .read_with_default_state(
-    //         "0x1b22dc5a394231c34e4529af674dc56a736fbd07508acfd1d12c0e67c8b4de27",
-    //     )
-    //     .unwrap();
-    // nova_test_full_aux2::<_, _, C1LEM<'_, _, TrieCoproc<_>>>(
-    //     s,
-    //     expr3,
-    //     Some(res3),
-    //     None,
-    //     Some(terminal),
-    //     None,
-    //     4,
-    //     DEFAULT_REDUCTION_COUNT,
-    //     false,
-    //     None,
-    //     lang.clone(),
-    // );
+    let expr3 =
+        "(.lurk.trie.insert 0x1cc5b90039db85fd519af975afa1de9d2b92960a585a546637b653b115bc3b53 123 456)";
+    let expr3 = s.read(state.clone(), expr3).unwrap();
+    let res3 = s
+        .read_with_default_state(
+            "0x1b22dc5a394231c34e4529af674dc56a736fbd07508acfd1d12c0e67c8b4de27",
+        )
+        .unwrap();
+    nova_test_full_aux2::<_, _, C1LEM<'_, _, TrieCoproc<_>>>(
+        s,
+        expr3,
+        Some(res3),
+        None,
+        Some(terminal),
+        None,
+        4,
+        DEFAULT_REDUCTION_COUNT,
+        false,
+        None,
+        lang.clone(),
+    );
 
-    // let expr4 =
-    //     "(.lurk.trie.lookup 0x1b22dc5a394231c34e4529af674dc56a736fbd07508acfd1d12c0e67c8b4de27 123)";
-    // let expr4 = s.read(state.clone(), expr4).unwrap();
-    // let res4 = Ptr::comm(Fr::from(456));
-    // nova_test_full_aux2::<_, _, C1LEM<'_, _, TrieCoproc<_>>>(
-    //     s,
-    //     expr4,
-    //     Some(res4),
-    //     None,
-    //     Some(terminal),
-    //     None,
-    //     3,
-    //     DEFAULT_REDUCTION_COUNT,
-    //     false,
-    //     None,
-    //     lang.clone(),
-    // );
+    let expr4 =
+        "(.lurk.trie.lookup 0x1b22dc5a394231c34e4529af674dc56a736fbd07508acfd1d12c0e67c8b4de27 123)";
+    let expr4 = s.read(state.clone(), expr4).unwrap();
+    let res4 = Ptr::comm(Fr::from(456));
+    nova_test_full_aux2::<_, _, C1LEM<'_, _, TrieCoproc<_>>>(
+        s,
+        expr4,
+        Some(res4),
+        None,
+        Some(terminal),
+        None,
+        3,
+        DEFAULT_REDUCTION_COUNT,
+        false,
+        None,
+        lang.clone(),
+    );
 
-    // let s = &Store::<Fr>::default();
-    // let expr5 = "(let ((trie (.lurk.trie.new))
-    //                    (found (.lurk.trie.lookup trie 123)))
-    //                   found)";
-    // let expr5 = s.read(state.clone(), expr5).unwrap();
-    // let res5 = Ptr::comm(Fr::zero());
-    // nova_test_full_aux2::<_, _, C1LEM<'_, _, TrieCoproc<_>>>(
-    //     s,
-    //     expr5,
-    //     Some(res5),
-    //     None,
-    //     Some(terminal),
-    //     None,
-    //     10,
-    //     DEFAULT_REDUCTION_COUNT,
-    //     false,
-    //     None,
-    //     lang.clone(),
-    // );
+    let s = &Store::<Fr>::default();
+    let expr5 = "(let ((trie (.lurk.trie.new))
+                       (found (.lurk.trie.lookup trie 123)))
+                      found)";
+    let expr5 = s.read(state.clone(), expr5).unwrap();
+    let res5 = Ptr::comm(Fr::zero());
+    nova_test_full_aux2::<_, _, C1LEM<'_, _, TrieCoproc<_>>>(
+        s,
+        expr5,
+        Some(res5),
+        None,
+        Some(terminal),
+        None,
+        10,
+        DEFAULT_REDUCTION_COUNT,
+        false,
+        None,
+        lang.clone(),
+    );
 
     let expr6 = "(let ((trie (.lurk.trie.insert (.lurk.trie.new) 123 456))
                        (found (.lurk.trie.lookup trie 123)))

--- a/src/proof/tests/nova_tests_lurk.rs
+++ b/src/proof/tests/nova_tests_lurk.rs
@@ -3417,20 +3417,6 @@ fn test_trie_lang_circuit() {
         lang.clone(),
     );
 
-    nova_test_full_aux2::<_, _, C1Lurk<'_, _, TrieCoproc<_>>>(
-        s,
-        expr,
-        Some(res),
-        None,
-        Some(terminal),
-        None,
-        4,
-        DEFAULT_REDUCTION_COUNT,
-        false,
-        None,
-        lang.clone(),
-    );
-
     let expr4 =
             s.read_with_state(state, "(.lurk.trie.lookup 0x1b22dc5a394231c34e4529af674dc56a736fbd07508acfd1d12c0e67c8b4de27 123)").unwrap();
     let res4 = s.intern_opaque_comm(Fr::from(456));


### PR DESCRIPTION
This PR adds the implementations for the Trie coprocessor for LEM.

It also adds a missing test for the Trie coprocessor in Alpha and fixes a bug in the lookup circuit.