### PR TITLE
fix: provide correct params to LEM version of fibonacci bench

### DIFF
--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -259,7 +259,7 @@ fn fib_bench(c: &mut Criterion) {
             let lem_params = ProveParams {
                 folding_steps: *folding_steps,
                 reduction_count: *reduction_count,
-                version: Version::ALPHA,
+                version: Version::LEM,
             };
             lem::prove(lem_params, &mut group, &state);
         }


### PR DESCRIPTION
- Updated the `ProveParams` version from `ALPHA` to `LEM` in the Fibonacci benchmarking file.
- Fixes #800