### PR TITLE
Add a demo flag on the load command

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -110,6 +110,10 @@ struct LoadArgs {
     /// Path to circom directory
     #[clap(long, value_parser)]
     circom_dir: Option<Utf8PathBuf>,
+
+    /// Flag to load the file in demo mode
+    #[arg(long)]
+    demo: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -149,6 +153,9 @@ struct LoadCli {
 
     #[clap(long, value_parser)]
     circom_dir: Option<Utf8PathBuf>,
+
+    #[arg(long)]
+    demo: bool,
 }
 
 impl LoadArgs {
@@ -166,6 +173,7 @@ impl LoadArgs {
             proofs_dir: self.proofs_dir,
             commits_dir: self.commits_dir,
             circom_dir: self.circom_dir,
+            demo: self.demo,
         }
     }
 }
@@ -304,7 +312,7 @@ impl ReplCli {
             ( $rc: expr, $limit: expr, $field: path, $backend: expr ) => {{
                 let mut repl = new_repl!(self, $rc, $limit, $field, $backend);
                 if let Some(lurk_file) = &self.load {
-                    repl.load_file(lurk_file)?;
+                    repl.load_file(lurk_file, false)?;
                 }
                 repl.start()
             }};
@@ -344,7 +352,6 @@ impl ReplCli {
         backend.validate_field(field)?;
         match field {
             LanguageField::Pallas => repl!(rc, limit, pallas::Scalar, backend.clone()),
-            // LanguageField::Vesta => repl!(rc, limit, vesta::Scalar, backend),
             LanguageField::Vesta => todo!(),
             LanguageField::BLS12_381 => todo!(),
             LanguageField::BN256 => todo!(),
@@ -358,7 +365,7 @@ impl LoadCli {
         macro_rules! load {
             ( $rc: expr, $limit: expr, $field: path, $backend: expr ) => {{
                 let mut repl = new_repl!(self, $rc, $limit, $field, $backend);
-                repl.load_file(&self.lurk_file)?;
+                repl.load_file(&self.lurk_file, self.demo)?;
                 if self.prove {
                     repl.prove_last_frames()?;
                 }
@@ -400,7 +407,6 @@ impl LoadCli {
         backend.validate_field(field)?;
         match field {
             LanguageField::Pallas => load!(rc, limit, pallas::Scalar, backend.clone()),
-            // LanguageField::Vesta => load!(rc, limit, vesta::Scalar, backend),
             LanguageField::Vesta => todo!(),
             LanguageField::BLS12_381 => todo!(),
             LanguageField::BN256 => todo!(),

--- a/src/cli/repl/meta_cmd.rs
+++ b/src/cli/repl/meta_cmd.rs
@@ -40,7 +40,7 @@ impl MetaCmd<F> {
             match repl.store.fetch_string(&first) {
                 Some(path) => {
                     let joined = repl.pwd_path.join(Utf8Path::new(&path));
-                    repl.load_file(&joined)?
+                    repl.load_file(&joined, false)?
                 }
                 _ => bail!("Argument of `load` must be a string."),
             }

--- a/src/lem/store.rs
+++ b/src/lem/store.rs
@@ -470,11 +470,17 @@ impl<F: LurkField> Store<F> {
         &self,
         state: Rc<RefCell<State>>,
         input: &'a str,
-    ) -> Result<(Span<'a>, Ptr<F>, bool), Error> {
+    ) -> Result<(usize, Span<'a>, Ptr<F>, bool), Error> {
         match preceded(syntax::parse_space, syntax::parse_maybe_meta(state, false))
             .parse(input.into())
         {
-            Ok((i, Some((is_meta, x)))) => Ok((i, self.intern_syntax(x), is_meta)),
+            Ok((i, Some((is_meta, x)))) => {
+                let from_offset = x
+                    .get_pos()
+                    .get_from_offset()
+                    .expect("Parsed syntax should have its Pos set");
+                Ok((from_offset, i, self.intern_syntax(x), is_meta))
+            }
             Ok((_, None)) => Err(Error::NoInput),
             Err(e) => Err(Error::Syntax(format!("{}", e))),
         }

--- a/src/parser/position.rs
+++ b/src/parser/position.rs
@@ -76,4 +76,12 @@ impl Pos {
             upto_column: upto.get_utf8_column(),
         }
     }
+
+    /// Retrieves the `from_offset` attribute, if present
+    pub fn get_from_offset(&self) -> Option<usize> {
+        match self {
+            Self::No => None,
+            Self::Pos { from_offset, .. } => Some(*from_offset),
+        }
+    }
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -36,6 +36,22 @@ pub enum Syntax<F: LurkField> {
     Improper(Pos, Vec<Syntax<F>>, Box<Syntax<F>>),
 }
 
+impl<F: LurkField> Syntax<F> {
+    /// Retrieves the `Pos` attribute
+    pub fn get_pos(&self) -> &Pos {
+        match self {
+            Self::Num(pos, _)
+            | Self::UInt(pos, _)
+            | Self::Symbol(pos, _)
+            | Self::String(pos, _)
+            | Self::Char(pos, _)
+            | Self::Quote(pos, _)
+            | Self::List(pos, _)
+            | Self::Improper(pos, ..) => pos,
+        }
+    }
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 impl<Fr: LurkField> Arbitrary for Syntax<Fr> {
     type Parameters = ();

--- a/tests/lurk-lib-tests.rs
+++ b/tests/lurk-lib-tests.rs
@@ -43,6 +43,6 @@ fn lurk_cli_tests() {
         let joined_new = Utf8PathBuf::from_path_buf(joined.clone()).unwrap();
 
         repl::<S1, ReplState<S1, Coproc<S1>>, _, Coproc<S1>>(Some(joined), Lang::new()).unwrap();
-        let _ = repl_new.load_file(&joined_new);
+        let _ = repl_new.load_file(&joined_new, false);
     }
 }


### PR DESCRIPTION
Adds a `--demo` flag to load files in demo mode.

This is better than the initial idea of a new command because it can reuse all the parameters that the `load` command already accepts.

Closes #757 