### PR TITLE
Eliminate hashing shims for hardcoded tags across the LEM codebase

### DIFF
--- a/src/cli/zstore.rs
+++ b/src/cli/zstore.rs
@@ -7,9 +7,7 @@ use crate::{
     lem::{
         pointers::{Ptr, ZChildren, ZPtr},
         store::Store,
-        Tag,
     },
-    tag::ContTag::{Dummy, Error, Outermost, Terminal},
 };
 
 use super::field_data::HasFieldModulus;
@@ -68,13 +66,7 @@ pub(crate) fn populate_z_store<F: LurkField>(
         } else {
             let z_ptr = match ptr {
                 Ptr::Atom(tag, f) => {
-                    let z_ptr = match tag {
-                        Tag::Cont(Outermost | Error | Dummy | Terminal) => {
-                            // temporary shim for compatibility with Lurk Alpha
-                            ZPtr::from_parts(*tag, store.poseidon_cache.hash8(&[F::ZERO; 8]))
-                        }
-                        _ => ZPtr::from_parts(*tag, *f),
-                    };
+                    let z_ptr = ZPtr::from_parts(*tag, *f);
                     z_store.dag.insert(z_ptr, ZChildren::Atom);
                     z_ptr
                 }

--- a/src/lem/interpreter.rs
+++ b/src/lem/interpreter.rs
@@ -123,8 +123,8 @@ pub struct Frame<F: LurkField> {
 
 impl<F: LurkField> Frame<F> {
     pub fn blank(func: &Func, pc: usize) -> Frame<F> {
-        let input = vec![Ptr::null(Tag::Expr(Nil)); func.input_params.len()];
-        let output = vec![Ptr::null(Tag::Expr(Nil)); func.output_size];
+        let input = vec![Ptr::zero(Tag::Expr(Nil)); func.input_params.len()];
+        let output = vec![Ptr::zero(Tag::Expr(Nil)); func.output_size];
         let hints = Hints::blank(func);
         Frame {
             input,
@@ -196,8 +196,20 @@ impl Block {
                 Op::Copy(tgt, src) => {
                     bindings.insert(tgt.clone(), bindings.get_cloned(src)?);
                 }
-                Op::Null(tgt, tag) => {
-                    bindings.insert_ptr(tgt.clone(), Ptr::null(*tag));
+                Op::Zero(tgt, tag) => {
+                    bindings.insert_ptr(tgt.clone(), Ptr::zero(*tag));
+                }
+                Op::Hash3Zeros(tgt, tag) => {
+                    bindings.insert_ptr(tgt.clone(), Ptr::Atom(*tag, store.hash3zeros));
+                }
+                Op::Hash4Zeros(tgt, tag) => {
+                    bindings.insert_ptr(tgt.clone(), Ptr::Atom(*tag, store.hash4zeros));
+                }
+                Op::Hash6Zeros(tgt, tag) => {
+                    bindings.insert_ptr(tgt.clone(), Ptr::Atom(*tag, store.hash6zeros));
+                }
+                Op::Hash8Zeros(tgt, tag) => {
+                    bindings.insert_ptr(tgt.clone(), Ptr::Atom(*tag, store.hash8zeros));
                 }
                 Op::Lit(tgt, lit) => {
                     bindings.insert_ptr(tgt.clone(), lit.to_ptr(store));

--- a/src/lem/macros.rs
+++ b/src/lem/macros.rs
@@ -46,7 +46,19 @@ macro_rules! tag {
 #[macro_export]
 macro_rules! op {
     ( let $tgt:ident : $kind:ident::$tag:ident ) => {
-        $crate::lem::Op::Null($crate::var!($tgt), $crate::tag!($kind::$tag))
+        $crate::lem::Op::Zero($crate::var!($tgt), $crate::tag!($kind::$tag))
+    };
+    ( let $tgt:ident : $kind:ident::$tag:ident = HASH_3_ZEROS ) => {
+        $crate::lem::Op::Hash3Zeros($crate::var!($tgt), $crate::tag!($kind::$tag))
+    };
+    ( let $tgt:ident : $kind:ident::$tag:ident = HASH_4_ZEROS ) => {
+        $crate::lem::Op::Hash4Zeros($crate::var!($tgt), $crate::tag!($kind::$tag))
+    };
+    ( let $tgt:ident : $kind:ident::$tag:ident = HASH_6_ZEROS ) => {
+        $crate::lem::Op::Hash6Zeros($crate::var!($tgt), $crate::tag!($kind::$tag))
+    };
+    ( let $tgt:ident : $kind:ident::$tag:ident = HASH_8_ZEROS ) => {
+        $crate::lem::Op::Hash8Zeros($crate::var!($tgt), $crate::tag!($kind::$tag))
     };
     ( let $tgt:ident = $constr:ident($str:literal) ) => {
         $crate::lem::Op::Lit(
@@ -285,6 +297,46 @@ macro_rules! block {
             {
                 $($limbs)*
                 $crate::op!(let $tgt: $kind::$tag)
+            },
+            $($tail)*
+        )
+    };
+    (@seq {$($limbs:expr)*}, let $tgt:ident : $kind:ident::$tag:ident = HASH_3_ZEROS; $($tail:tt)*) => {
+        $crate::block! (
+            @seq
+            {
+                $($limbs)*
+                $crate::op!(let $tgt: $kind::$tag = HASH_3_ZEROS)
+            },
+            $($tail)*
+        )
+    };
+    (@seq {$($limbs:expr)*}, let $tgt:ident : $kind:ident::$tag:ident = HASH_4_ZEROS; $($tail:tt)*) => {
+        $crate::block! (
+            @seq
+            {
+                $($limbs)*
+                $crate::op!(let $tgt: $kind::$tag = HASH_4_ZEROS)
+            },
+            $($tail)*
+        )
+    };
+    (@seq {$($limbs:expr)*}, let $tgt:ident : $kind:ident::$tag:ident = HASH_6_ZEROS; $($tail:tt)*) => {
+        $crate::block! (
+            @seq
+            {
+                $($limbs)*
+                $crate::op!(let $tgt: $kind::$tag = HASH_6_ZEROS)
+            },
+            $($tail)*
+        )
+    };
+    (@seq {$($limbs:expr)*}, let $tgt:ident : $kind:ident::$tag:ident = HASH_8_ZEROS; $($tail:tt)*) => {
+        $crate::block! (
+            @seq
+            {
+                $($limbs)*
+                $crate::op!(let $tgt: $kind::$tag = HASH_8_ZEROS)
             },
             $($tail)*
         )
@@ -648,7 +700,7 @@ mod tests {
     #[test]
     fn test_macros() {
         let lemops = [
-            Op::Null(mptr("foo"), Tag::Expr(Num)),
+            Op::Zero(mptr("foo"), Tag::Expr(Num)),
             Op::Cons2(mptr("foo"), Tag::Expr(Char), [mptr("bar"), mptr("baz")]),
             Op::Cons3(
                 mptr("foo"),
@@ -733,7 +785,7 @@ mod tests {
                     (
                         Tag::Expr(Str),
                         Block {
-                            ops: vec![Op::Null(mptr("foo"), Tag::Expr(Num))],
+                            ops: vec![Op::Zero(mptr("foo"), Tag::Expr(Num))],
                             ctrl: Ctrl::Return(vec![mptr("foo"), mptr("foo"), mptr("foo")]),
                         }
                     ),
@@ -741,8 +793,8 @@ mod tests {
                         Tag::Expr(Char),
                         Block {
                             ops: vec![
-                                Op::Null(mptr("foo"), Tag::Expr(Num)),
-                                Op::Null(mptr("goo"), Tag::Expr(Char))
+                                Op::Zero(mptr("foo"), Tag::Expr(Num)),
+                                Op::Zero(mptr("goo"), Tag::Expr(Char))
                             ],
                             ctrl: Ctrl::Return(vec![mptr("foo"), mptr("goo"), mptr("goo")]),
                         }
@@ -781,15 +833,15 @@ mod tests {
                         lurk_sym("cons"),
                         Block {
                             ops: vec![
-                                Op::Null(mptr("foo"), Tag::Expr(Num)),
-                                Op::Null(mptr("goo"), Tag::Expr(Char))
+                                Op::Zero(mptr("foo"), Tag::Expr(Num)),
+                                Op::Zero(mptr("goo"), Tag::Expr(Char))
                             ],
                             ctrl: Ctrl::Return(vec![mptr("foo"), mptr("goo"), mptr("goo")]),
                         }
                     )
                 ],
                 Block {
-                    ops: vec![Op::Null(mptr("xoo"), Tag::Expr(Str))],
+                    ops: vec![Op::Zero(mptr("xoo"), Tag::Expr(Str))],
                     ctrl: Ctrl::Return(vec![mptr("xoo"), mptr("xoo"), mptr("xoo")]),
                 }
             )

--- a/src/lem/pointers.rs
+++ b/src/lem/pointers.rs
@@ -72,11 +72,11 @@ impl<F: LurkField> Ptr<F> {
     }
 
     #[inline]
-    pub fn null(tag: Tag) -> Self {
+    pub fn zero(tag: Tag) -> Self {
         Ptr::Atom(tag, F::ZERO)
     }
 
-    pub fn is_null(&self) -> bool {
+    pub fn is_zero(&self) -> bool {
         match self {
             Ptr::Atom(_, f) => f == &F::ZERO,
             _ => false,
@@ -89,7 +89,7 @@ impl<F: LurkField> Ptr<F> {
 
     #[inline]
     pub fn dummy() -> Self {
-        Self::null(Tag::Expr(Nil))
+        Self::zero(Tag::Expr(Nil))
     }
 
     #[inline]

--- a/src/lem/tests/eval_tests.rs
+++ b/src/lem/tests/eval_tests.rs
@@ -12,10 +12,7 @@ use crate::{
         Tag,
     },
     state::State,
-    tag::{
-        ContTag::{Error, Terminal},
-        Op,
-    },
+    tag::Op,
 };
 
 fn test_aux<C: Coprocessor<Fr>>(
@@ -132,7 +129,7 @@ fn do_test<C: Coprocessor<Fr>>(
     if let Some(expected_cont) = expected_cont {
         assert_eq!(expected_cont, new_cont);
     } else {
-        assert_eq!(Ptr::null(Tag::Cont(Terminal)), new_cont);
+        assert_eq!(s.cont_terminal(), new_cont);
     }
     if let Some(expected_emitted) = expected_emitted {
         assert_eq!(expected_emitted.len(), emitted.len());
@@ -162,7 +159,7 @@ fn evaluate_cons() {
     let car = Ptr::num_u64(1);
     let cdr = Ptr::num_u64(2);
     let expected = s.cons(car, cdr);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -181,7 +178,7 @@ fn emit_output() {
     let expr = "(emit 123)";
     let expected = Ptr::num_u64(123);
     let emitted = vec![expected];
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -200,7 +197,7 @@ fn evaluate_lambda() {
     let expr = "((lambda (x) x) 123)";
 
     let expected = Ptr::num_u64(123);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -219,7 +216,7 @@ fn evaluate_empty_args_lambda() {
     let expr = "((lambda () 123))";
 
     let expected = Ptr::num_u64(123);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -238,7 +235,7 @@ fn evaluate_lambda2() {
     let expr = "((lambda (y) ((lambda (x) y) 321)) 123)";
 
     let expected = Ptr::num_u64(123);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -257,7 +254,7 @@ fn evaluate_lambda3() {
     let expr = "((lambda (y) ((lambda (x) ((lambda (z) z) x)) y)) 123)";
 
     let expected = Ptr::num_u64(123);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -278,7 +275,7 @@ fn evaluate_lambda4() {
             "((lambda (y) ((lambda (x) ((lambda (z) z) x)) 888)) 999)";
 
     let expected = Ptr::num_u64(888);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -299,7 +296,7 @@ fn evaluate_lambda5() {
             "(((lambda (fn) (lambda (x) (fn x))) (lambda (y) y)) 999)";
 
     let expected = Ptr::num_u64(999);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -318,7 +315,7 @@ fn evaluate_sum() {
     let expr = "(+ 2 (+ 3 4))";
 
     let expected = Ptr::num_u64(9);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -337,7 +334,7 @@ fn evaluate_diff() {
     let expr = "(- 9 5)";
 
     let expected = Ptr::num_u64(4);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -356,7 +353,7 @@ fn evaluate_product() {
     let expr = "(* 9 5)";
 
     let expected = Ptr::num_u64(45);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -375,7 +372,7 @@ fn evaluate_quotient() {
     let expr = "(/ 21 7)";
 
     let expected = Ptr::num_u64(3);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -393,7 +390,7 @@ fn evaluate_quotient_divide_by_zero() {
     let s = &Store::<Fr>::default();
     let expr = "(/ 21 0)";
 
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 3, &None);
 }
 
@@ -405,7 +402,7 @@ fn evaluate_num_equal() {
         let expr = "(= 5 5)";
 
         let expected = s.intern_lurk_symbol("t");
-        let terminal = Ptr::null(Tag::Cont(Terminal));
+        let terminal = s.cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
             expr,
@@ -421,7 +418,7 @@ fn evaluate_num_equal() {
         let expr = "(= 5 6)";
 
         let expected = s.intern_nil();
-        let terminal = Ptr::null(Tag::Cont(Terminal));
+        let terminal = s.cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
             expr,
@@ -441,7 +438,7 @@ fn evaluate_adder1() {
     let expr = "(((lambda (x) (lambda (y) (+ x y))) 2) 3)";
 
     let expected = Ptr::num_u64(5);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -462,7 +459,7 @@ fn evaluate_adder2() {
                    ((make-adder 2) 3))";
 
     let expected = Ptr::num_u64(5);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -481,7 +478,7 @@ fn evaluate_let_simple() {
     let expr = "(let ((a 1)) a)";
 
     let expected = Ptr::num_u64(1);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -500,7 +497,7 @@ fn evaluate_empty_let_bug() {
     let expr = "(let () (+ 1 2))";
 
     let expected = Ptr::num_u64(3);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -521,7 +518,7 @@ fn evaluate_let() {
                    (+ a b))";
 
     let expected = Ptr::num_u64(3);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -539,7 +536,7 @@ fn evaluate_let_empty_error() {
     let s = &Store::<Fr>::default();
     let expr = "(let)";
 
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 1, &None);
 }
 
@@ -548,7 +545,7 @@ fn evaluate_let_empty_body_error() {
     let s = &Store::<Fr>::default();
     let expr = "(let ((a 1)))";
 
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 1, &None);
 }
 
@@ -557,7 +554,7 @@ fn evaluate_letrec_empty_error() {
     let s = &Store::<Fr>::default();
     let expr = "(letrec)";
 
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 1, &None);
 }
 
@@ -566,7 +563,7 @@ fn evaluate_letrec_empty_body_error() {
     let s = &Store::<Fr>::default();
     let expr = "(letrec ((a 1)))";
 
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 1, &None);
 }
 
@@ -576,7 +573,7 @@ fn evaluate_letrec_body_nil() {
     let expr = "(eq nil (let () nil))";
 
     let expected = s.intern_lurk_symbol("t");
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -595,7 +592,7 @@ fn evaluate_let_parallel_binding() {
     let expr = "(let ((a 1) (b a)) b)";
 
     let expected = Ptr::num_u64(1);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -618,7 +615,7 @@ fn evaluate_arithmetic_let() {
 
     let expected = Ptr::num_u64(3);
     let new_env = s.intern_nil();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -649,7 +646,7 @@ fn evaluate_fundamental_conditional() {
                        (((iff 5) 6) true))";
 
         let expected = Ptr::num_u64(5);
-        let terminal = Ptr::null(Tag::Cont(Terminal));
+        let terminal = s.cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
             expr,
@@ -676,7 +673,7 @@ fn evaluate_fundamental_conditional() {
                        (((iff 5) 6) false))";
 
         let expected = Ptr::num_u64(6);
-        let terminal = Ptr::null(Tag::Cont(Terminal));
+        let terminal = s.cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
             expr,
@@ -697,7 +694,7 @@ fn evaluate_if() {
         let expr = "(if t 5 6)";
 
         let expected = Ptr::num_u64(5);
-        let terminal = Ptr::null(Tag::Cont(Terminal));
+        let terminal = s.cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
             expr,
@@ -714,7 +711,7 @@ fn evaluate_if() {
         let expr = "(if nil 5 6)";
 
         let expected = Ptr::num_u64(6);
-        let terminal = Ptr::null(Tag::Cont(Terminal));
+        let terminal = s.cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
             expr,
@@ -735,7 +732,7 @@ fn evaluate_fully_evaluates() {
         let expr = "(if t (+ 5 5) 6)";
 
         let expected = Ptr::num_u64(10);
-        let terminal = Ptr::null(Tag::Cont(Terminal));
+        let terminal = s.cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
             expr,
@@ -760,7 +757,7 @@ fn evaluate_recursion1() {
                    ((exp 5) 3))";
 
     let expected = Ptr::num_u64(125);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -785,7 +782,7 @@ fn evaluate_recursion2() {
                    (((exp 5) 5) 1))";
 
     let expected = Ptr::num_u64(3125);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -808,7 +805,7 @@ fn evaluate_recursion_multiarg() {
                           (exp 5 3))";
 
     let expected = Ptr::num_u64(125);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -834,7 +831,7 @@ fn evaluate_recursion_optimized() {
                     ((exp 5) 3))";
 
     let expected = Ptr::num_u64(125);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -859,7 +856,7 @@ fn evaluate_tail_recursion() {
                           (((exp 5) 3) 1))";
 
     let expected = Ptr::num_u64(125);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -887,7 +884,7 @@ fn evaluate_tail_recursion_somewhat_optimized() {
                    (((exp 5) 3) 1))";
 
     let expected = Ptr::num_u64(125);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -908,7 +905,7 @@ fn evaluate_multiple_letrec_bindings() {
                    (+ (square 3) (double 2)))";
 
     let expected = Ptr::num_u64(13);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -929,7 +926,7 @@ fn evaluate_multiple_letrec_bindings_referencing() {
                    (+ (double 3) (double-inc 2)))";
 
     let expected = Ptr::num_u64(11);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -961,7 +958,7 @@ fn evaluate_multiple_letrec_bindings_recursive() {
                       (exp3 4 2)))";
 
     let expected = Ptr::num_u64(33);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -977,7 +974,7 @@ fn evaluate_multiple_letrec_bindings_recursive() {
 #[test]
 fn nested_let_closure_regression() {
     let s = &Store::<Fr>::default();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     let expected = Ptr::num_u64(6);
 
     {
@@ -1023,7 +1020,7 @@ fn evaluate_eq() {
         let expr = "(eq 'a 'a)";
 
         let expected = s.intern_lurk_symbol("t");
-        let terminal = Ptr::null(Tag::Cont(Terminal));
+        let terminal = s.cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
             expr,
@@ -1040,7 +1037,7 @@ fn evaluate_eq() {
         let expr = "(eq 1 1)";
 
         let expected = s.intern_lurk_symbol("t");
-        let terminal = Ptr::null(Tag::Cont(Terminal));
+        let terminal = s.cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
             expr,
@@ -1057,7 +1054,7 @@ fn evaluate_eq() {
         let expr = "(eq 'a 1)";
 
         let expected = s.intern_nil();
-        let terminal = Ptr::null(Tag::Cont(Terminal));
+        let terminal = s.cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
             expr,
@@ -1075,7 +1072,7 @@ fn evaluate_eq() {
         let expr = "(eq 1 'a)";
 
         let expected = s.intern_nil();
-        let terminal = Ptr::null(Tag::Cont(Terminal));
+        let terminal = s.cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
             expr,
@@ -1092,7 +1089,7 @@ fn evaluate_eq() {
 #[test]
 fn evaluate_zero_arg_lambda() {
     let s = &Store::<Fr>::default();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     {
         let expr = "((lambda () 123))";
 
@@ -1153,14 +1150,14 @@ fn evaluate_zero_arg_lambda_variants() {
         let s = &Store::<Fr>::default();
         let expr = "((lambda () 123) 1)";
 
-        let error = Ptr::null(Tag::Cont(Error));
+        let error = s.cont_error();
         test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 3, &None);
     }
     {
         let s = &Store::<Fr>::default();
         let expr = "(123)";
 
-        let error = Ptr::null(Tag::Cont(Error));
+        let error = s.cont_error();
         test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 1, &None);
     }
 }
@@ -1196,7 +1193,7 @@ fn evaluate_make_tree() {
         let expected = s
             .read_with_default_state("(((h . g) . (f . e)) . ((d . c) . (b . a)))")
             .unwrap();
-        let terminal = Ptr::null(Tag::Cont(Terminal));
+        let terminal = s.cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
             expr,
@@ -1242,7 +1239,7 @@ fn evaluate_map_tree_bug() {
          (map-tree (lambda (x) (+ 1 x)) '((1 . 2) . (3 . 4))))";
 
         let expected = s.read_with_default_state("((2 . 3) . (4 . 5))").unwrap();
-        let terminal = Ptr::null(Tag::Cont(Terminal));
+        let terminal = s.cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
             expr,
@@ -1269,7 +1266,7 @@ fn evaluate_map_tree_numequal_bug() {
                                                   (map-tree f (cdr tree)))))))
                        (map-tree (lambda (x) (+ 1 x)) '((1 . 2) . (3 . 4))))";
         let expected = s.intern_nil();
-        let error = Ptr::null(Tag::Cont(Error));
+        let error = s.cont_error();
         test_aux::<Coproc<Fr>>(s, expr, Some(expected), None, Some(error), None, 169, &None);
     }
 }
@@ -1295,7 +1292,7 @@ fn env_lost_bug() {
   (foo '()))
 ";
         let expected = s.intern_nil();
-        let terminal = Ptr::null(Tag::Cont(Terminal));
+        let terminal = s.cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
             expr,
@@ -1320,7 +1317,7 @@ fn dont_discard_rest_env() {
                                  (l (lambda (x) (+ z x))))
                          (l 9)))";
         let expected = Ptr::num_u64(18);
-        let terminal = Ptr::null(Tag::Cont(Terminal));
+        let terminal = s.cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
             expr,
@@ -1344,8 +1341,8 @@ fn test_str_car_cdr_cons() {
     let pple = s.read(state, r#" "pple" "#).unwrap();
     let empty = s.intern_string("");
     let nil = s.intern_nil();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
-    let error = Ptr::null(Tag::Cont(Error));
+    let terminal = s.cont_terminal();
+    let error = s.cont_error();
 
     test_aux::<Coproc<Fr>>(
         s,
@@ -1443,7 +1440,7 @@ fn test_str_car_cdr_cons() {
 #[test]
 fn test_one_arg_cons_error() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<Coproc<Fr>>(s, r#"(cons "")"#, None, None, Some(error), None, 1, &None);
 }
 
@@ -1451,7 +1448,7 @@ fn test_one_arg_cons_error() {
 fn test_car_nil() {
     let s = &Store::<Fr>::default();
     let expected = s.intern_nil();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         r#"(car nil)"#,
@@ -1468,7 +1465,7 @@ fn test_car_nil() {
 fn test_cdr_nil() {
     let s = &Store::<Fr>::default();
     let expected = s.intern_nil();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         r#"(cdr nil)"#,
@@ -1484,7 +1481,7 @@ fn test_cdr_nil() {
 #[test]
 fn test_car_cdr_invalid_tag_error_sym() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<Coproc<Fr>>(s, r#"(car 'car)"#, None, None, Some(error), None, 2, &None);
     test_aux::<Coproc<Fr>>(s, r#"(cdr 'car)"#, None, None, Some(error), None, 2, &None);
 }
@@ -1492,7 +1489,7 @@ fn test_car_cdr_invalid_tag_error_sym() {
 #[test]
 fn test_car_cdr_invalid_tag_error_char() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<Coproc<Fr>>(s, r"(car #\a)", None, None, Some(error), None, 2, &None);
     test_aux::<Coproc<Fr>>(s, r"(cdr #\a)", None, None, Some(error), None, 2, &None);
 }
@@ -1500,7 +1497,7 @@ fn test_car_cdr_invalid_tag_error_char() {
 #[test]
 fn test_car_cdr_invalid_tag_error_num() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<Coproc<Fr>>(s, r#"(car 42)"#, None, None, Some(error), None, 2, &None);
     test_aux::<Coproc<Fr>>(s, r#"(cdr 42)"#, None, None, Some(error), None, 2, &None);
 }
@@ -1508,7 +1505,7 @@ fn test_car_cdr_invalid_tag_error_num() {
 #[test]
 fn test_car_cdr_invalid_tag_error_lambda() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<Coproc<Fr>>(
         s,
         r#"(car (lambda (x) x))"#,
@@ -1702,7 +1699,7 @@ fn commit_nil() {
 fn commit_error() {
     let s = &Store::<Fr>::default();
     let expr = "(commit 123 456)";
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 1, &None);
 }
 
@@ -1710,7 +1707,7 @@ fn commit_error() {
 fn open_error() {
     let s = &Store::<Fr>::default();
     let expr = "(open 123 456)";
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 1, &None);
 }
 
@@ -1718,7 +1715,7 @@ fn open_error() {
 fn secret_error() {
     let s = &Store::<Fr>::default();
     let expr = "(secret 123 456)";
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 1, &None);
 }
 
@@ -1726,7 +1723,7 @@ fn secret_error() {
 fn num_error() {
     let s = &Store::<Fr>::default();
     let expr = "(num 123 456)";
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 1, &None);
 }
 
@@ -1734,7 +1731,7 @@ fn num_error() {
 fn comm_error() {
     let s = &Store::<Fr>::default();
     let expr = "(comm 123 456)";
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 1, &None);
 }
 
@@ -1742,7 +1739,7 @@ fn comm_error() {
 fn char_error() {
     let s = &Store::<Fr>::default();
     let expr = "(char 123 456)";
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 1, &None);
 }
 
@@ -1751,7 +1748,7 @@ fn prove_commit_secret() {
     let s = &Store::<Fr>::default();
     let expr = "(secret (commit 123))";
     let expected = Ptr::num_u64(0);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -1769,7 +1766,7 @@ fn num() {
     let s = &Store::<Fr>::default();
     let expr = "(num 123)";
     let expected = Ptr::num_u64(123);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -1787,7 +1784,7 @@ fn num_char() {
     let s = &Store::<Fr>::default();
     let expr = r"(num #\a)";
     let expected = Ptr::num_u64(97);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -1805,7 +1802,7 @@ fn char_num() {
     let s = &Store::<Fr>::default();
     let expr = r#"(char 97)"#;
     let expected_a = s.read_with_default_state(r"#\a").unwrap();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -1823,7 +1820,7 @@ fn char_coercion() {
     let s = &Store::<Fr>::default();
     let expr = r#"(char (- 0 4294967200))"#;
     let expected_a = s.read_with_default_state(r"#\a").unwrap();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -1840,7 +1837,7 @@ fn char_coercion() {
 fn commit_num() {
     let s = &Store::<Fr>::default();
     let expr = "(num (commit 123))";
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(s, expr, None, None, Some(terminal), None, 4, &None);
 }
 
@@ -1849,7 +1846,7 @@ fn hide_open_comm_num() {
     let s = &Store::<Fr>::default();
     let expr = "(open (comm (num (hide 123 456))))";
     let expected = Ptr::num_u64(456);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -1867,7 +1864,7 @@ fn hide_secret_comm_num() {
     let s = &Store::<Fr>::default();
     let expr = "(secret (comm (num (hide 123 456))))";
     let expected = Ptr::num_u64(123);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -1885,7 +1882,7 @@ fn commit_open_comm_num() {
     let s = &Store::<Fr>::default();
     let expr = "(open (comm (num (commit 123))))";
     let expected = Ptr::num_u64(123);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -1903,7 +1900,7 @@ fn commit_secret_comm_num() {
     let s = &Store::<Fr>::default();
     let expr = "(secret (comm (num (commit 123))))";
     let expected = Ptr::num_u64(0);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -1921,7 +1918,7 @@ fn commit_num_open() {
     let s = &Store::<Fr>::default();
     let expr = "(open (num (commit 123)))";
     let expected = Ptr::num_u64(123);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
         expr,
@@ -1940,7 +1937,7 @@ fn num_invalid_tag() {
     let expr = "(num (quote x))";
     let expr1 = "(num \"asdf\")";
     let expr2 = "(num '(1))";
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 2, &None);
     test_aux::<Coproc<Fr>>(s, expr1, None, None, Some(error), None, 2, &None);
     test_aux::<Coproc<Fr>>(s, expr2, None, None, Some(error), None, 2, &None);
@@ -1952,7 +1949,7 @@ fn comm_invalid_tag() {
     let expr = "(comm (quote x))";
     let expr1 = "(comm \"asdf\")";
     let expr2 = "(comm '(1))";
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 2, &None);
     test_aux::<Coproc<Fr>>(s, expr1, None, None, Some(error), None, 2, &None);
     test_aux::<Coproc<Fr>>(s, expr2, None, None, Some(error), None, 2, &None);
@@ -1964,7 +1961,7 @@ fn char_invalid_tag() {
     let expr = "(char (quote x))";
     let expr1 = "(char \"asdf\")";
     let expr2 = "(char '(1))";
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 2, &None);
     test_aux::<Coproc<Fr>>(s, expr1, None, None, Some(error), None, 2, &None);
     test_aux::<Coproc<Fr>>(s, expr2, None, None, Some(error), None, 2, &None);
@@ -1975,7 +1972,7 @@ fn terminal_sym() {
     let s = &Store::<Fr>::default();
     let expr = "(quote x)";
     let x = s.intern_user_symbol("x");
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(s, expr, Some(x), None, Some(terminal), None, 1, &None);
 }
 
@@ -1991,7 +1988,7 @@ fn open_opaque_commit() {
 fn open_wrong_type() {
     let s = &Store::<Fr>::default();
     let expr = "(open 'asdf)";
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 2, &None);
 }
 
@@ -1999,7 +1996,7 @@ fn open_wrong_type() {
 fn secret_wrong_type() {
     let s = &Store::<Fr>::default();
     let expr = "(secret 'asdf)";
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 2, &None);
 }
 
@@ -2027,7 +2024,7 @@ fn relational_aux(s: &Store<Fr>, op: &str, a: &str, b: &str, res: bool) {
     } else {
         s.intern_nil()
     };
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<Coproc<Fr>>(
         s,
@@ -2159,7 +2156,7 @@ fn test_relational() {
 fn test_relational_edge_case_identity() {
     let s = &Store::<Fr>::default();
     let t = s.intern_lurk_symbol("t");
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     // Normally, a value cannot be less than the result of incrementing it.
     // However, the most positive field element (when viewed as signed)
@@ -2188,7 +2185,7 @@ fn test_relational_edge_case_identity() {
 fn test_num_syntax_implications() {
     let s = &Store::<Fr>::default();
     let t = s.intern_lurk_symbol("t");
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     {
         let expr = "(let ((most-positive -1/2)
@@ -2254,7 +2251,7 @@ fn test_quoted_symbols() {
                           (|Foo \\| Bar| (lambda (x) (* x x))))
                       (|Foo \\| Bar| |foo bar|))";
     let res = Ptr::num_u64(81);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 13, &None);
 }
@@ -2266,7 +2263,7 @@ fn test_eval() {
     let expr2 = "(* 5 (eval '(+ 1 a) '((a . 3))))"; // two-arg eval, optional second arg is env.
     let res = Ptr::num_u64(9);
     let res2 = Ptr::num_u64(20);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 17, &None);
     test_aux::<Coproc<Fr>>(s, expr2, Some(res2), None, Some(terminal), None, 9, &None);
@@ -2278,8 +2275,8 @@ fn test_eval_env_regression() {
     let expr = "(let ((a 1)) (eval 'a))";
     let expr2 = "(let ((a 1)) (eval 'a (current-env)))";
     let res = Ptr::num_u64(1);
-    let error = Ptr::null(Tag::Cont(Error));
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let error = s.cont_error();
+    let terminal = s.cont_terminal();
 
     test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 5, &None);
     test_aux::<Coproc<Fr>>(s, expr2, Some(res), None, Some(terminal), None, 6, &None);
@@ -2291,7 +2288,7 @@ fn test_u64_self_evaluating() {
 
     let expr = "123u64";
     let res = Ptr::u64(123);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 1, &None);
 }
@@ -2304,7 +2301,7 @@ fn test_u64_mul() {
     let expr2 = "(* 18446744073709551615u64 2u64)";
     let expr3 = "(* (- 0u64 1u64) 2u64)";
     let res = Ptr::u64(18446744073709551614);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 7, &None);
     test_aux::<Coproc<Fr>>(s, expr2, Some(res), None, Some(terminal), None, 3, &None);
@@ -2318,7 +2315,7 @@ fn test_u64_add() {
     let expr = "(+ 18446744073709551615u64 2u64)";
     let expr2 = "(+ (- 0u64 1u64) 2u64)";
     let res = Ptr::u64(1);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 3, &None);
     test_aux::<Coproc<Fr>>(s, expr2, Some(res), None, Some(terminal), None, 6, &None);
@@ -2334,7 +2331,7 @@ fn test_u64_sub() {
     let res = Ptr::u64(1);
     let res2 = Ptr::u64(18446744073709551615);
     let res3 = Ptr::u64(0);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 3, &None);
     test_aux::<Coproc<Fr>>(s, expr2, Some(res2), None, Some(terminal), None, 3, &None);
@@ -2353,8 +2350,8 @@ fn test_u64_div() {
 
     let expr3 = "(/ 100u64 0u64)";
 
-    let terminal = Ptr::null(Tag::Cont(Terminal));
-    let error = Ptr::null(Tag::Cont(Error));
+    let terminal = s.cont_terminal();
+    let error = s.cont_error();
 
     test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 3, &None);
     test_aux::<Coproc<Fr>>(s, expr2, Some(res2), None, Some(terminal), None, 3, &None);
@@ -2373,8 +2370,8 @@ fn test_u64_mod() {
 
     let expr3 = "(% 100u64 0u64)";
 
-    let terminal = Ptr::null(Tag::Cont(Terminal));
-    let error = Ptr::null(Tag::Cont(Error));
+    let terminal = s.cont_terminal();
+    let error = s.cont_error();
 
     test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 3, &None);
     test_aux::<Coproc<Fr>>(s, expr2, Some(res2), None, Some(terminal), None, 3, &None);
@@ -2389,7 +2386,7 @@ fn test_num_mod() {
     let expr2 = "(% 100 3u64)";
     let expr3 = "(% 100u64 3)";
 
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
 
     test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 3, &None);
     test_aux::<Coproc<Fr>>(s, expr2, None, None, Some(error), None, 3, &None);
@@ -2418,7 +2415,7 @@ fn test_u64_comp() {
 
     let t = s.intern_lurk_symbol("t");
     let nil = s.intern_nil();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<Coproc<Fr>>(s, expr, Some(t), None, Some(terminal), None, 3, &None);
     test_aux::<Coproc<Fr>>(s, expr2, Some(nil), None, Some(terminal), None, 3, &None);
@@ -2453,8 +2450,8 @@ fn test_u64_conversion() {
     let res2 = Ptr::num_u64(2);
     let res3 = Ptr::u64(2);
     let res5 = Ptr::u64(123);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
-    let error = Ptr::null(Tag::Cont(Error));
+    let terminal = s.cont_terminal();
+    let error = s.cont_error();
 
     test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 3, &None);
     test_aux::<Coproc<Fr>>(s, expr2, Some(res), None, Some(terminal), None, 2, &None);
@@ -2469,7 +2466,7 @@ fn test_u64_conversion() {
 #[test]
 fn test_numeric_type_error() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
 
     let test = |op| {
         let expr = &format!("({op} 0 'a)");
@@ -2499,7 +2496,7 @@ fn test_u64_num_comparison() {
     let expr2 = "(= 1 2u64)";
     let t = s.intern_lurk_symbol("t");
     let nil = s.intern_nil();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<Coproc<Fr>>(s, expr, Some(t), None, Some(terminal), None, 3, &None);
     test_aux::<Coproc<Fr>>(s, expr2, Some(nil), None, Some(terminal), None, 3, &None);
@@ -2513,7 +2510,7 @@ fn test_u64_num_cons() {
     let expr2 = "(cons 1u64 1)";
     let res = s.read_with_default_state("(1 . 1u64)").unwrap();
     let res2 = s.read_with_default_state("(1u64 . 1)").unwrap();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 3, &None);
     test_aux::<Coproc<Fr>>(s, expr2, Some(res2), None, Some(terminal), None, 3, &None);
@@ -2524,7 +2521,7 @@ fn test_hide_u64_secret() {
     let s = &Store::<Fr>::default();
 
     let expr = "(hide 0u64 123)";
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
 
     test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 3, &None);
 }
@@ -2540,7 +2537,7 @@ fn test_keyword() {
     let res2 = s.intern_lurk_symbol("t");
     let res3 = s.intern_nil();
 
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 1, &None);
     test_aux::<Coproc<Fr>>(s, expr2, Some(res2), None, Some(terminal), None, 3, &None);
@@ -2615,7 +2612,7 @@ fn test_fold_cons_regression() {
                                          acc))))
                       (fold (lambda (x y) (+ x y)) 0 '(1 2 3)))";
     let res = Ptr::num_u64(6);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 152, &None);
 }
@@ -2625,7 +2622,7 @@ fn test_lambda_args_regression() {
     let s = &Store::<Fr>::default();
 
     let expr = "(cons (lambda (x y) nil) nil)";
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<Coproc<Fr>>(s, expr, None, None, Some(terminal), None, 3, &None);
 }
@@ -2634,7 +2631,7 @@ fn test_lambda_args_regression() {
 fn test_eval_bad_form() {
     let s = &Store::<Fr>::default();
     let expr = "(* 5 (eval '(+ 1 a) '((0 . 3))))"; // two-arg eval, optional second arg is env.
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
 
     test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 8, &None);
 }
@@ -2642,7 +2639,7 @@ fn test_eval_bad_form() {
 #[test]
 fn test_eval_quote_error() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
 
     test_aux::<Coproc<Fr>>(s, "(1)", None, None, Some(error), None, 1, &None);
     test_aux::<Coproc<Fr>>(s, "(quote . 1)", None, None, Some(error), None, 1, &None);
@@ -2654,7 +2651,7 @@ fn test_eval_quote_error() {
 fn test_eval_dotted_syntax_error() {
     let s = &Store::<Fr>::default();
     let expr = "(let ((a (lambda (x) (+ x 1)))) (a . 1))";
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
 
     test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, 3, &None);
 }
@@ -2662,7 +2659,7 @@ fn test_eval_dotted_syntax_error() {
 #[allow(dead_code)]
 fn op_syntax_error<T: Op + Copy>() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     let test = |op: T| {
         let name = op.symbol_name();
 
@@ -2714,7 +2711,7 @@ fn test_eval_binop_syntax_error() {
 #[test]
 fn test_eval_lambda_body_syntax() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
 
     test_aux::<Coproc<Fr>>(s, "((lambda ()))", None, None, Some(error), None, 2, &None);
     test_aux::<Coproc<Fr>>(
@@ -2752,7 +2749,7 @@ fn test_eval_lambda_body_syntax() {
 #[test]
 fn test_eval_non_symbol_binding_error() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
 
     let test = |x| {
         let expr = format!("(let (({x} 123)) {x})");
@@ -2809,8 +2806,8 @@ fn test_dumb_lang() {
     let error6 = Ptr::char('x');
     let error7 = Ptr::char('y');
 
-    let error = Ptr::null(Tag::Cont(Error));
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let error = s.cont_error();
+    let terminal = s.cont_terminal();
 
     test_aux(
         s,

--- a/src/lem/tests/misc.rs
+++ b/src/lem/tests/misc.rs
@@ -6,7 +6,7 @@ use crate::{
     eval::lang::{DummyCoprocessor, Lang},
     field::LurkField,
     func,
-    lem::{pointers::Ptr, slot::SlotsCounter, store::Store, Func, Tag},
+    lem::{pointers::Ptr, slot::SlotsCounter, store::Store, Func},
 };
 
 /// Helper function for testing circuit synthesis.
@@ -16,10 +16,9 @@ use crate::{
 ///   provided expressions.
 ///   - `expected_slots` gives the number of expected slots for each type of hash.
 fn synthesize_test_helper(func: &Func, inputs: Vec<Ptr<Fr>>, expected_num_slots: SlotsCounter) {
-    use crate::tag::ContTag::Outermost;
     let store = &Store::default();
     let nil = store.intern_nil();
-    let outermost = Ptr::null(Tag::Cont(Outermost));
+    let outermost = store.cont_outermost();
 
     assert_eq!(func.slot, expected_num_slots);
 

--- a/src/proof/tests/nova_tests_lem.rs
+++ b/src/proof/tests/nova_tests_lem.rs
@@ -8,10 +8,7 @@ use crate::{
     proof::nova::C1LEM,
     state::user_sym,
     state::State,
-    tag::{
-        ContTag::{Error, Terminal},
-        ExprTag, Op, Op1, Op2,
-    },
+    tag::{ExprTag, Op, Op1, Op2},
 };
 
 use super::{nova_test_full_aux, nova_test_full_aux2, test_aux, DEFAULT_REDUCTION_COUNT};
@@ -22,7 +19,7 @@ type M1<'a, Fr> = C1LEM<'a, Fr, Coproc<Fr>>;
 fn test_prove_binop() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(3);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(+ 1 2)",
@@ -42,7 +39,7 @@ fn test_prove_binop() {
 fn test_prove_binop_fail() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(2);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(+ 1 2)",
@@ -60,7 +57,7 @@ fn test_prove_binop_fail() {
 fn test_prove_arithmetic_let() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(3);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(let ((a 5)
@@ -81,7 +78,7 @@ fn test_prove_arithmetic_let() {
 fn test_prove_eq() {
     let s = &Store::<Fr>::default();
     let expected = s.intern_lurk_symbol("t");
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     nova_test_full_aux::<_, _, M1<'_, _>>(
         s,
         "(eq 5 5)",
@@ -102,7 +99,7 @@ fn test_prove_eq() {
 fn test_prove_num_equal() {
     let s = &Store::<Fr>::default();
     let expected = s.intern_lurk_symbol("t");
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(= 5 5)",
@@ -115,7 +112,7 @@ fn test_prove_num_equal() {
     );
 
     let expected = s.intern_nil();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(= 5 6)",
@@ -132,7 +129,7 @@ fn test_prove_num_equal() {
 fn test_prove_invalid_num_equal() {
     let s = &Store::<Fr>::default();
     let expected = s.intern_nil();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(= 5 nil)",
@@ -162,7 +159,7 @@ fn test_prove_equal() {
     let s = &Store::<Fr>::default();
     let nil = s.intern_nil();
     let t = s.intern_lurk_symbol("t");
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -200,7 +197,7 @@ fn test_prove_equal() {
 #[test]
 fn test_prove_quote_end_is_nil_error() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(quote (1) (2))",
@@ -217,7 +214,7 @@ fn test_prove_quote_end_is_nil_error() {
 fn test_prove_if() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(5);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(if t 5 6)",
@@ -230,7 +227,7 @@ fn test_prove_if() {
     );
 
     let expected = Ptr::num_u64(6);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(if nil 5 6)",
@@ -247,7 +244,7 @@ fn test_prove_if() {
 fn test_prove_if_end_is_nil_error() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(5);
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(if nil 5 6 7)",
@@ -265,7 +262,7 @@ fn test_prove_if_end_is_nil_error() {
 fn test_prove_if_fully_evaluates() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(10);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(if t (+ 5 5) 6)",
@@ -283,7 +280,7 @@ fn test_prove_if_fully_evaluates() {
 fn test_prove_recursion1() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(25);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(letrec ((exp (lambda (base)
@@ -306,7 +303,7 @@ fn test_prove_recursion1() {
 fn test_prove_recursion2() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(25);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(letrec ((exp (lambda (base)
@@ -328,7 +325,7 @@ fn test_prove_recursion2() {
 fn test_prove_unop_regression_aux(chunk_count: usize) {
     let s = &Store::<Fr>::default();
     let expected = s.intern_lurk_symbol("t");
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     nova_test_full_aux::<_, _, M1<'_, _>>(
         s,
         "(atom 123)",
@@ -404,7 +401,7 @@ fn test_prove_unop_regression() {
 fn test_prove_emit_output() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(123);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(emit 123)",
@@ -422,7 +419,7 @@ fn test_prove_emit_output() {
 fn test_prove_evaluate() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(99);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "((lambda (x) x) 99)",
@@ -440,7 +437,7 @@ fn test_prove_evaluate() {
 fn test_prove_evaluate2() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(99);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "((lambda (y)
@@ -460,7 +457,7 @@ fn test_prove_evaluate2() {
 fn test_prove_evaluate3() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(999);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "((lambda (y)
@@ -483,7 +480,7 @@ fn test_prove_evaluate3() {
 fn test_prove_evaluate4() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(888);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "((lambda (y)
@@ -507,7 +504,7 @@ fn test_prove_evaluate4() {
 fn test_prove_evaluate5() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(999);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(((lambda (fn)
@@ -528,7 +525,7 @@ fn test_prove_evaluate5() {
 fn test_prove_evaluate_sum() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(9);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(+ 2 (+ 3 4))",
@@ -545,7 +542,7 @@ fn test_prove_evaluate_sum() {
 fn test_prove_binop_rest_is_nil() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(9);
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(- 9 8 7)",
@@ -570,7 +567,7 @@ fn test_prove_binop_rest_is_nil() {
 
 fn op_syntax_error<T: Op + Copy>() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     let test = |op: T| {
         let name = op.symbol_name();
 
@@ -619,7 +616,7 @@ fn test_prove_binop_syntax_error() {
 fn test_prove_diff() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(4);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(- 9 5)",
@@ -637,7 +634,7 @@ fn test_prove_diff() {
 fn test_prove_product() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(45);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(* 9 5)",
@@ -655,7 +652,7 @@ fn test_prove_product() {
 fn test_prove_quotient() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(7);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(/ 21 3)",
@@ -672,7 +669,7 @@ fn test_prove_quotient() {
 fn test_prove_error_div_by_zero() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(0);
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(/ 21 0)",
@@ -689,7 +686,7 @@ fn test_prove_error_div_by_zero() {
 fn test_prove_error_invalid_type_and_not_cons() {
     let s = &Store::<Fr>::default();
     let expected = s.intern_nil();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(/ 21 nil)",
@@ -707,7 +704,7 @@ fn test_prove_error_invalid_type_and_not_cons() {
 fn test_prove_adder() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(5);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(((lambda (x)
@@ -728,7 +725,7 @@ fn test_prove_adder() {
 fn test_prove_current_env_simple() {
     let s = &Store::<Fr>::default();
     let expected = s.intern_nil();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(current-env)",
@@ -745,7 +742,7 @@ fn test_prove_current_env_simple() {
 fn test_prove_current_env_rest_is_nil_error() {
     let s = &Store::<Fr>::default();
     let expected = s.read_with_default_state("(current-env a)").unwrap();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(current-env a)",
@@ -763,7 +760,7 @@ fn test_prove_current_env_rest_is_nil_error() {
 fn test_prove_let_simple() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(1);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(let ((a 1))
@@ -780,7 +777,7 @@ fn test_prove_let_simple() {
 #[test]
 fn test_prove_let_end_is_nil_error() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(let ((a 1 2)) a)",
@@ -796,7 +793,7 @@ fn test_prove_let_end_is_nil_error() {
 #[test]
 fn test_prove_letrec_end_is_nil_error() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(letrec ((a 1 2)) a)",
@@ -812,7 +809,7 @@ fn test_prove_letrec_end_is_nil_error() {
 #[test]
 fn test_prove_lambda_empty_error() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "((lambda (x)) 0)",
@@ -828,28 +825,28 @@ fn test_prove_lambda_empty_error() {
 #[test]
 fn test_prove_let_empty_error() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(s, "(let)", None, None, Some(error), None, 1, &None);
 }
 
 #[test]
 fn test_prove_let_empty_body_error() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(s, "(let ((a 1)))", None, None, Some(error), None, 1, &None);
 }
 
 #[test]
 fn test_prove_letrec_empty_error() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(s, "(letrec)", None, None, Some(error), None, 1, &None);
 }
 
 #[test]
 fn test_prove_letrec_empty_body_error() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(letrec ((a 1)))",
@@ -866,7 +863,7 @@ fn test_prove_letrec_empty_body_error() {
 fn test_prove_let_body_nil() {
     let s = &Store::<Fr>::default();
     let expected = s.intern_lurk_symbol("t");
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(eq nil (let () nil))",
@@ -882,7 +879,7 @@ fn test_prove_let_body_nil() {
 #[test]
 fn test_prove_let_rest_body_is_nil_error() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(let ((a 1)) a 1)",
@@ -898,7 +895,7 @@ fn test_prove_let_rest_body_is_nil_error() {
 #[test]
 fn test_prove_letrec_rest_body_is_nil_error() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(letrec ((a 1)) a 1)",
@@ -916,7 +913,7 @@ fn test_prove_letrec_rest_body_is_nil_error() {
 fn test_prove_let_null_bindings() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(3);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(let () (+ 1 2))",
@@ -933,7 +930,7 @@ fn test_prove_let_null_bindings() {
 fn test_prove_letrec_null_bindings() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(3);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(letrec () (+ 1 2))",
@@ -951,7 +948,7 @@ fn test_prove_letrec_null_bindings() {
 fn test_prove_let() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(6);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(let ((a 1)
@@ -972,7 +969,7 @@ fn test_prove_let() {
 fn test_prove_arithmetic() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(20);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "((((lambda (x)
@@ -997,7 +994,7 @@ fn test_prove_arithmetic() {
 fn test_prove_comparison() {
     let s = &Store::<Fr>::default();
     let expected = s.intern_lurk_symbol("t");
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(let ((x 2)
@@ -1019,7 +1016,7 @@ fn test_prove_comparison() {
 fn test_prove_conditional() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(5);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(let ((true (lambda (a)
@@ -1048,7 +1045,7 @@ fn test_prove_conditional() {
 fn test_prove_conditional2() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(6);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(let ((true (lambda (a)
@@ -1077,7 +1074,7 @@ fn test_prove_conditional2() {
 fn test_prove_fundamental_conditional_bug() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(5);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(let ((true (lambda (a)
@@ -1103,7 +1100,7 @@ fn test_prove_fundamental_conditional_bug() {
 fn test_prove_fully_evaluates() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(10);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(if t (+ 5 5) 6)",
@@ -1121,7 +1118,7 @@ fn test_prove_fully_evaluates() {
 fn test_prove_recursion() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(25);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(letrec ((exp (lambda (base)
@@ -1144,7 +1141,7 @@ fn test_prove_recursion() {
 fn test_prove_recursion_multiarg() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(25);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(letrec ((exp (lambda (base exponent)
@@ -1166,7 +1163,7 @@ fn test_prove_recursion_multiarg() {
 fn test_prove_recursion_optimized() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(25);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(let ((exp (lambda (base)
@@ -1191,7 +1188,7 @@ fn test_prove_recursion_optimized() {
 fn test_prove_tail_recursion() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(25);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(letrec ((exp (lambda (base)
@@ -1215,7 +1212,7 @@ fn test_prove_tail_recursion() {
 fn test_prove_tail_recursion_somewhat_optimized() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(25);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(letrec ((exp (lambda (base)
@@ -1240,7 +1237,7 @@ fn test_prove_tail_recursion_somewhat_optimized() {
 fn test_prove_no_mutual_recursion() {
     let s = &Store::<Fr>::default();
     let expected = s.intern_lurk_symbol("t");
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(letrec ((even (lambda (n)
@@ -1265,7 +1262,7 @@ fn test_prove_no_mutual_recursion() {
 #[ignore]
 fn test_prove_no_mutual_recursion_error() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(letrec ((even (lambda (n)
@@ -1291,7 +1288,7 @@ fn test_prove_no_mutual_recursion_error() {
 fn test_prove_cons1() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(1);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(car (cons 1 2))",
@@ -1307,28 +1304,28 @@ fn test_prove_cons1() {
 #[test]
 fn test_prove_car_end_is_nil_error() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(s, "(car (1 2) 3)", None, None, Some(error), None, 1, &None);
 }
 
 #[test]
 fn test_prove_cdr_end_is_nil_error() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(s, "(cdr (1 2) 3)", None, None, Some(error), None, 1, &None);
 }
 
 #[test]
 fn test_prove_atom_end_is_nil_error() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(s, "(atom 123 4)", None, None, Some(error), None, 1, &None);
 }
 
 #[test]
 fn test_prove_emit_end_is_nil_error() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(s, "(emit 123 4)", None, None, Some(error), None, 1, &None);
 }
 
@@ -1336,7 +1333,7 @@ fn test_prove_emit_end_is_nil_error() {
 fn test_prove_cons2() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(2);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(cdr (cons 1 2))",
@@ -1353,7 +1350,7 @@ fn test_prove_cons2() {
 fn test_prove_zero_arg_lambda1() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(123);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "((lambda () 123))",
@@ -1370,7 +1367,7 @@ fn test_prove_zero_arg_lambda1() {
 fn test_prove_zero_arg_lambda2() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(10);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(let ((x 9) (f (lambda () (+ x 1)))) (f))",
@@ -1391,9 +1388,9 @@ fn test_prove_zero_arg_lambda3() {
         let num = Ptr::num_u64(123);
         let body = s.list(vec![num]);
         let env = s.intern_nil();
-        s.intern_3_ptrs(Tag::Expr(ExprTag::Fun), arg, body, env)
+        s.intern_fun(arg, body, env)
     };
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     nova_test_full_aux::<_, _, M1<'_, _>>(
         s,
         "((lambda (x) 123))",
@@ -1412,7 +1409,7 @@ fn test_prove_zero_arg_lambda3() {
 #[test]
 fn test_prove_zero_arg_lambda4() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "((lambda () 123) 1)",
@@ -1429,7 +1426,7 @@ fn test_prove_zero_arg_lambda4() {
 fn test_prove_zero_arg_lambda5() {
     let s = &Store::<Fr>::default();
     let expected = s.read_with_default_state("(123)").unwrap();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(123)",
@@ -1446,7 +1443,7 @@ fn test_prove_zero_arg_lambda5() {
 fn test_prove_zero_arg_lambda6() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(123);
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "((emit 123))",
@@ -1462,7 +1459,7 @@ fn test_prove_zero_arg_lambda6() {
 #[test]
 fn test_prove_nested_let_closure_regression() {
     let s = &Store::<Fr>::default();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     let expected = Ptr::num_u64(6);
     let expr = "(let ((data-function (lambda () 123))
                       (x 6)
@@ -1485,7 +1482,7 @@ fn test_prove_nested_let_closure_regression() {
 fn test_prove_minimal_tail_call() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(123);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(letrec
@@ -1508,7 +1505,7 @@ fn test_prove_minimal_tail_call() {
 fn test_prove_cons_in_function1() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(2);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(((lambda (a)
@@ -1530,7 +1527,7 @@ fn test_prove_cons_in_function1() {
 fn test_prove_cons_in_function2() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(3);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(((lambda (a)
@@ -1552,7 +1549,7 @@ fn test_prove_cons_in_function2() {
 fn test_prove_multiarg_eval_bug() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(2);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(car (cdr '(1 2 3 4)))",
@@ -1570,7 +1567,7 @@ fn test_prove_multiarg_eval_bug() {
 fn test_prove_multiple_letrec_bindings() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(123);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(letrec
@@ -1594,7 +1591,7 @@ fn test_prove_multiple_letrec_bindings() {
 fn test_prove_tail_call2() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(123);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(letrec
@@ -1618,7 +1615,7 @@ fn test_prove_tail_call2() {
 fn test_prove_multiple_letrecstar_bindings() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(13);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(letrec ((double (lambda (x) (* 2 x)))
@@ -1638,7 +1635,7 @@ fn test_prove_multiple_letrecstar_bindings() {
 fn test_prove_multiple_letrecstar_bindings_referencing() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(11);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(letrec ((double (lambda (x) (* 2 x)))
@@ -1658,7 +1655,7 @@ fn test_prove_multiple_letrecstar_bindings_referencing() {
 fn test_prove_multiple_letrecstar_bindings_recursive() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(33);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(letrec ((exp (lambda (base exponent)
@@ -1689,7 +1686,7 @@ fn test_prove_multiple_letrecstar_bindings_recursive() {
 fn test_prove_dont_discard_rest_env() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(18);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(let ((z 9))
@@ -1711,7 +1708,7 @@ fn test_prove_dont_discard_rest_env() {
 fn test_prove_fibonacci() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(1);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     nova_test_full_aux::<_, _, M1<'_, _>>(
         s,
         "(letrec ((next (lambda (a b n target)
@@ -1740,7 +1737,7 @@ fn test_prove_fibonacci() {
 // fn test_prove_fibonacci_100() {
 //     let s = &Store::<Fr>::default();
 //     let expected = s.read_with_default_state("354224848179261915075").unwrap();
-//     let terminal = Ptr::null(Tag::Cont(Terminal));
+//     let terminal = s.cont_terminal();
 //     nova_test_full_aux::<Coproc<Fr>>::(
 //         s,
 //         "(letrec ((next (lambda (a b n target)
@@ -1765,7 +1762,7 @@ fn test_prove_fibonacci() {
 #[test]
 fn test_prove_terminal_continuation_regression() {
     let s = &Store::<Fr>::default();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(letrec ((a (lambda (x) (cons 2 2))))
@@ -1783,7 +1780,7 @@ fn test_prove_terminal_continuation_regression() {
 #[ignore]
 fn test_prove_chained_functional_commitment() {
     let s = &Store::<Fr>::default();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(letrec ((secret 12345)
@@ -1804,7 +1801,7 @@ fn test_prove_chained_functional_commitment() {
 fn test_prove_begin_empty() {
     let s = &Store::<Fr>::default();
     let expected = s.intern_nil();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(begin)",
@@ -1839,7 +1836,7 @@ fn test_prove_begin_emit() {
 fn test_prove_str_car() {
     let s = &Store::<Fr>::default();
     let expected_a = s.read_with_default_state(r"#\a").unwrap();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         r#"(car "apple")"#,
@@ -1856,7 +1853,7 @@ fn test_prove_str_car() {
 fn test_prove_str_cdr() {
     let s = &Store::<Fr>::default();
     let expected_pple = s.read_with_default_state(r#" "pple" "#).unwrap();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         r#"(cdr "apple")"#,
@@ -1873,7 +1870,7 @@ fn test_prove_str_cdr() {
 fn test_prove_str_car_empty() {
     let s = &Store::<Fr>::default();
     let expected_nil = s.intern_nil();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         r#"(car "")"#,
@@ -1890,7 +1887,7 @@ fn test_prove_str_car_empty() {
 fn test_prove_str_cdr_empty() {
     let s = &Store::<Fr>::default();
     let expected_empty_str = s.intern_string("");
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         r#"(cdr "")"#,
@@ -1907,7 +1904,7 @@ fn test_prove_str_cdr_empty() {
 fn test_prove_strcons() {
     let s = &Store::<Fr>::default();
     let expected_apple = s.read_with_default_state(r#" "apple" "#).unwrap();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         r#"(strcons #\a "pple")"#,
@@ -1923,7 +1920,7 @@ fn test_prove_strcons() {
 #[test]
 fn test_prove_str_cons_error() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(
         s,
         r"(strcons #\a 123)",
@@ -1939,7 +1936,7 @@ fn test_prove_str_cons_error() {
 #[test]
 fn test_prove_one_arg_cons_error() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(s, r#"(cons "")"#, None, None, Some(error), None, 1, &None);
 }
 
@@ -1947,7 +1944,7 @@ fn test_prove_one_arg_cons_error() {
 fn test_prove_car_nil() {
     let s = &Store::<Fr>::default();
     let expected = s.intern_nil();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         r#"(car nil)"#,
@@ -1964,7 +1961,7 @@ fn test_prove_car_nil() {
 fn test_prove_cdr_nil() {
     let s = &Store::<Fr>::default();
     let expected = s.intern_nil();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         r#"(cdr nil)"#,
@@ -1980,7 +1977,7 @@ fn test_prove_cdr_nil() {
 #[test]
 fn test_prove_car_cdr_invalid_tag_error_sym() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(s, r#"(car car)"#, None, None, Some(error), None, 2, &None);
     test_aux::<_, _, M1<'_, _>>(s, r#"(cdr car)"#, None, None, Some(error), None, 2, &None);
 }
@@ -1988,7 +1985,7 @@ fn test_prove_car_cdr_invalid_tag_error_sym() {
 #[test]
 fn test_prove_car_cdr_invalid_tag_error_char() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(s, r"(car #\a)", None, None, Some(error), None, 2, &None);
     test_aux::<_, _, M1<'_, _>>(s, r"(cdr #\a)", None, None, Some(error), None, 2, &None);
 }
@@ -1996,7 +1993,7 @@ fn test_prove_car_cdr_invalid_tag_error_char() {
 #[test]
 fn test_prove_car_cdr_invalid_tag_error_num() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(s, r#"(car 42)"#, None, None, Some(error), None, 2, &None);
     test_aux::<_, _, M1<'_, _>>(s, r#"(cdr 42)"#, None, None, Some(error), None, 2, &None);
 }
@@ -2006,7 +2003,7 @@ fn test_prove_car_cdr_of_cons() {
     let s = &Store::<Fr>::default();
     let res1 = Ptr::num_u64(1);
     let res2 = Ptr::num_u64(2);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         r#"(car (cons 1 2))"#,
@@ -2032,7 +2029,7 @@ fn test_prove_car_cdr_of_cons() {
 #[test]
 fn test_prove_car_cdr_invalid_tag_error_lambda() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(
         s,
         r#"(car (lambda (x) x))"#,
@@ -2060,7 +2057,7 @@ fn test_prove_hide_open() {
     let s = &Store::<Fr>::default();
     let expr = "(open (hide 123 456))";
     let expected = Ptr::num_u64(456);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         expr,
@@ -2077,7 +2074,7 @@ fn test_prove_hide_open() {
 fn test_prove_hide_wrong_secret_type() {
     let s = &Store::<Fr>::default();
     let expr = "(hide 'x 456)";
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(s, expr, None, None, Some(error), None, 3, &None);
 }
 
@@ -2086,7 +2083,7 @@ fn test_prove_hide_secret() {
     let s = &Store::<Fr>::default();
     let expr = "(secret (hide 123 456))";
     let expected = Ptr::num_u64(123);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         expr,
@@ -2104,7 +2101,7 @@ fn test_prove_hide_open_sym() {
     let s = &Store::<Fr>::default();
     let expr = "(open (hide 123 'x))";
     let x = s.intern_user_symbol("x");
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(s, expr, Some(x), None, Some(terminal), None, 5, &None);
 }
 
@@ -2113,7 +2110,7 @@ fn test_prove_commit_open_sym() {
     let s = &Store::<Fr>::default();
     let expr = "(open (commit 'x))";
     let x = s.intern_user_symbol("x");
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(s, expr, Some(x), None, Some(terminal), None, 4, &None);
 }
 
@@ -2122,7 +2119,7 @@ fn test_prove_commit_open() {
     let s = &Store::<Fr>::default();
     let expr = "(open (commit 123))";
     let expected = Ptr::num_u64(123);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         expr,
@@ -2139,7 +2136,7 @@ fn test_prove_commit_open() {
 fn test_prove_commit_error() {
     let s = &Store::<Fr>::default();
     let expr = "(commit 123 456)";
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(s, expr, None, None, Some(error), None, 1, &None);
 }
 
@@ -2147,7 +2144,7 @@ fn test_prove_commit_error() {
 fn test_prove_open_error() {
     let s = &Store::<Fr>::default();
     let expr = "(open 123 456)";
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(s, expr, None, None, Some(error), None, 1, &None);
 }
 
@@ -2155,7 +2152,7 @@ fn test_prove_open_error() {
 fn test_prove_open_wrong_type() {
     let s = &Store::<Fr>::default();
     let expr = "(open 'asdf)";
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(s, expr, None, None, Some(error), None, 2, &None);
 }
 
@@ -2163,7 +2160,7 @@ fn test_prove_open_wrong_type() {
 fn test_prove_secret_wrong_type() {
     let s = &Store::<Fr>::default();
     let expr = "(secret 'asdf)";
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(s, expr, None, None, Some(error), None, 2, &None);
 }
 
@@ -2172,7 +2169,7 @@ fn test_prove_commit_secret() {
     let s = &Store::<Fr>::default();
     let expr = "(secret (commit 123))";
     let expected = Ptr::num_u64(0);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         expr,
@@ -2190,7 +2187,7 @@ fn test_prove_num() {
     let s = &Store::<Fr>::default();
     let expr = "(num 123)";
     let expected = Ptr::num_u64(123);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         expr,
@@ -2208,7 +2205,7 @@ fn test_prove_num_char() {
     let s = &Store::<Fr>::default();
     let expr = r"(num #\a)";
     let expected = Ptr::num_u64(97);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         expr,
@@ -2226,7 +2223,7 @@ fn test_prove_char_num() {
     let s = &Store::<Fr>::default();
     let expr = r#"(char 97)"#;
     let expected_a = s.read_with_default_state(r"#\a").unwrap();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         expr,
@@ -2246,7 +2243,7 @@ fn test_prove_char_coercion() {
     let expr2 = r#"(char (- 0 4294967199))"#;
     let expected_a = s.read_with_default_state(r"#\a").unwrap();
     let expected_b = s.read_with_default_state(r"#\b").unwrap();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         expr,
@@ -2273,7 +2270,7 @@ fn test_prove_char_coercion() {
 fn test_prove_commit_num() {
     let s = &Store::<Fr>::default();
     let expr = "(num (commit 123))";
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(s, expr, None, None, Some(terminal), None, 4, &None);
 }
 
@@ -2282,7 +2279,7 @@ fn test_prove_hide_open_comm_num() {
     let s = &Store::<Fr>::default();
     let expr = "(open (comm (num (hide 123 456))))";
     let expected = Ptr::num_u64(456);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         expr,
@@ -2300,7 +2297,7 @@ fn test_prove_hide_secret_comm_num() {
     let s = &Store::<Fr>::default();
     let expr = "(secret (comm (num (hide 123 456))))";
     let expected = Ptr::num_u64(123);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         expr,
@@ -2318,7 +2315,7 @@ fn test_prove_commit_open_comm_num() {
     let s = &Store::<Fr>::default();
     let expr = "(open (comm (num (commit 123))))";
     let expected = Ptr::num_u64(123);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         expr,
@@ -2336,7 +2333,7 @@ fn test_prove_commit_secret_comm_num() {
     let s = &Store::<Fr>::default();
     let expr = "(secret (comm (num (commit 123))))";
     let expected = Ptr::num_u64(0);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         expr,
@@ -2354,7 +2351,7 @@ fn test_prove_commit_num_open() {
     let s = &Store::<Fr>::default();
     let expr = "(open (num (commit 123)))";
     let expected = Ptr::num_u64(123);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         expr,
@@ -2373,7 +2370,7 @@ fn test_prove_num_invalid_tag() {
     let expr = "(num (quote x))";
     let expr1 = "(num \"asdf\")";
     let expr2 = "(num '(1))";
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(s, expr, None, None, Some(error), None, 2, &None);
     test_aux::<_, _, M1<'_, _>>(s, expr1, None, None, Some(error), None, 2, &None);
     test_aux::<_, _, M1<'_, _>>(s, expr2, None, None, Some(error), None, 2, &None);
@@ -2385,7 +2382,7 @@ fn test_prove_comm_invalid_tag() {
     let expr = "(comm (quote x))";
     let expr1 = "(comm \"asdf\")";
     let expr2 = "(comm '(1))";
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(s, expr, None, None, Some(error), None, 2, &None);
     test_aux::<_, _, M1<'_, _>>(s, expr1, None, None, Some(error), None, 2, &None);
     test_aux::<_, _, M1<'_, _>>(s, expr2, None, None, Some(error), None, 2, &None);
@@ -2397,7 +2394,7 @@ fn test_prove_char_invalid_tag() {
     let expr = "(char (quote x))";
     let expr1 = "(char \"asdf\")";
     let expr2 = "(char '(1))";
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(s, expr, None, None, Some(error), None, 2, &None);
     test_aux::<_, _, M1<'_, _>>(s, expr1, None, None, Some(error), None, 2, &None);
     test_aux::<_, _, M1<'_, _>>(s, expr2, None, None, Some(error), None, 2, &None);
@@ -2408,7 +2405,7 @@ fn test_prove_terminal_sym() {
     let s = &Store::<Fr>::default();
     let expr = "(quote x)";
     let x = s.intern_user_symbol("x");
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(s, expr, Some(x), None, Some(terminal), None, 1, &None);
 }
 
@@ -2445,8 +2442,8 @@ fn test_str_car_cdr_cons() {
     let pple = s.read_with_default_state(r#" "pple" "#).unwrap();
     let empty = s.intern_string("");
     let nil = s.intern_nil();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
-    let error = Ptr::null(Tag::Cont(Error));
+    let terminal = s.cont_terminal();
+    let error = s.cont_error();
 
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -2551,7 +2548,7 @@ fn relational_aux(s: &Store<Fr>, op: &str, a: &str, b: &str, res: bool) {
     } else {
         s.intern_nil()
     };
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -2688,7 +2685,7 @@ fn test_relational_edge_case_identity() {
                       (most-negative (+ 1 most-positive)))
                   (< most-negative most-positive))";
     let t = s.intern_lurk_symbol("t");
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, Some(t), None, Some(terminal), None, 19, &None);
 }
@@ -2700,7 +2697,7 @@ fn test_prove_test_eval() {
     let expr2 = "(* 5 (eval '(+ 1 a) '((a . 3))))"; // two-arg eval, optional second arg is env.
     let res = Ptr::num_u64(9);
     let res2 = Ptr::num_u64(20);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, Some(res), None, Some(terminal), None, 17, &None);
     test_aux::<_, _, M1<'_, _>>(s, expr2, Some(res2), None, Some(terminal), None, 9, &None);
@@ -2717,7 +2714,7 @@ fn test_prove_test_keyword() {
     let res2 = s.intern_lurk_symbol("t");
     let res3 = s.intern_nil();
 
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, Some(res), None, Some(terminal), None, 1, &None);
     test_aux::<_, _, M1<'_, _>>(s, expr2, Some(res2), None, Some(terminal), None, 3, &None);
@@ -2735,7 +2732,7 @@ fn test_prove_functional_commitment() {
                       (inc (lambda (x) (+ x 1))))
                   ((open f) inc))";
     let res = Ptr::num_u64(10);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, Some(res), None, Some(terminal), None, 25, &None);
 }
@@ -2756,7 +2753,7 @@ fn test_prove_complicated_functional_commitment() {
 
                   ((open f) in))";
     let res = Ptr::num_u64(6);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, Some(res), None, Some(terminal), None, 108, &None);
 }
@@ -2770,7 +2767,7 @@ fn test_prove_test_fold_cons_regression() {
                                      acc))))
                   (fold (lambda (x y) (+ x y)) 0 '(1 2 3)))";
     let res = Ptr::num_u64(6);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, Some(res), None, Some(terminal), None, 152, &None);
 }
@@ -2780,7 +2777,7 @@ fn test_prove_test_lambda_args_regression() {
     let s = &Store::<Fr>::default();
 
     let expr = "(cons (lambda (x y) nil) nil)";
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, None, None, Some(terminal), None, 3, &None);
 }
@@ -2790,7 +2787,7 @@ fn test_prove_reduce_sym_contradiction_regression() {
     let s = &Store::<Fr>::default();
 
     let expr = "(eval 'a '(nil))";
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, None, None, Some(error), None, 4, &None);
 }
@@ -2806,7 +2803,7 @@ fn test_prove_test_self_eval_env_not_nil() {
     // this solution makes the circuit a bit smaller
     let expr = "(let ((a 1)) t)";
 
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(s, expr, None, None, Some(terminal), None, 3, &None);
 }
 
@@ -2817,7 +2814,7 @@ fn test_prove_test_self_eval_nil() {
     // nil doesn't have SYM tag
     let expr = "nil";
 
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(s, expr, None, None, Some(terminal), None, 1, &None);
 }
 
@@ -2827,7 +2824,7 @@ fn test_prove_test_env_not_nil_and_binding_nil() {
 
     let expr = "(let ((a 1) (b 2)) c)";
 
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(s, expr, None, None, Some(error), None, 7, &None);
 }
 
@@ -2835,7 +2832,7 @@ fn test_prove_test_env_not_nil_and_binding_nil() {
 fn test_prove_test_eval_bad_form() {
     let s = &Store::<Fr>::default();
     let expr = "(* 5 (eval '(+ 1 a) '((0 . 3))))"; // two-arg eval, optional second arg is env. This tests for error on malformed env.
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, None, None, Some(error), None, 8, &None);
 }
@@ -2846,7 +2843,7 @@ fn test_prove_test_u64_self_evaluating() {
 
     let expr = "123u64";
     let res = Ptr::u64(123);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, Some(res), None, Some(terminal), None, 1, &None);
 }
@@ -2861,7 +2858,7 @@ fn test_prove_test_u64_mul() {
     let expr4 = "(u64 18446744073709551617)";
     let res = Ptr::u64(18446744073709551614);
     let res2 = Ptr::u64(1);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, Some(res), None, Some(terminal), None, 7, &None);
     test_aux::<_, _, M1<'_, _>>(s, expr2, Some(res), None, Some(terminal), None, 3, &None);
@@ -2876,7 +2873,7 @@ fn test_prove_test_u64_add() {
     let expr = "(+ 18446744073709551615u64 2u64)";
     let expr2 = "(+ (- 0u64 1u64) 2u64)";
     let res = Ptr::u64(1);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, Some(res), None, Some(terminal), None, 3, &None);
     test_aux::<_, _, M1<'_, _>>(s, expr2, Some(res), None, Some(terminal), None, 6, &None);
@@ -2892,7 +2889,7 @@ fn test_prove_test_u64_sub() {
     let res = Ptr::u64(1);
     let res2 = Ptr::u64(18446744073709551615);
     let res3 = Ptr::u64(0);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, Some(res), None, Some(terminal), None, 3, &None);
     test_aux::<_, _, M1<'_, _>>(s, expr2, Some(res2), None, Some(terminal), None, 3, &None);
@@ -2911,8 +2908,8 @@ fn test_prove_test_u64_div() {
 
     let expr3 = "(/ 100u64 0u64)";
 
-    let terminal = Ptr::null(Tag::Cont(Terminal));
-    let error = Ptr::null(Tag::Cont(Error));
+    let terminal = s.cont_terminal();
+    let error = s.cont_error();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, Some(res), None, Some(terminal), None, 3, &None);
     test_aux::<_, _, M1<'_, _>>(s, expr2, Some(res2), None, Some(terminal), None, 3, &None);
@@ -2931,8 +2928,8 @@ fn test_prove_test_u64_mod() {
 
     let expr3 = "(% 100u64 0u64)";
 
-    let terminal = Ptr::null(Tag::Cont(Terminal));
-    let error = Ptr::null(Tag::Cont(Error));
+    let terminal = s.cont_terminal();
+    let error = s.cont_error();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, Some(res), None, Some(terminal), None, 3, &None);
     test_aux::<_, _, M1<'_, _>>(s, expr2, Some(res2), None, Some(terminal), None, 3, &None);
@@ -2947,7 +2944,7 @@ fn test_prove_test_num_mod() {
     let expr2 = "(% 100 3u64)";
     let expr3 = "(% 100u64 3)";
 
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, None, None, Some(error), None, 3, &None);
     test_aux::<_, _, M1<'_, _>>(s, expr2, None, None, Some(error), None, 3, &None);
@@ -2973,7 +2970,7 @@ fn test_prove_test_u64_comp() {
 
     let t = s.intern_lurk_symbol("t");
     let nil = s.intern_nil();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, Some(t), None, Some(terminal), None, 3, &None);
     test_aux::<_, _, M1<'_, _>>(s, expr2, Some(nil), None, Some(terminal), None, 3, &None);
@@ -3000,7 +2997,7 @@ fn test_prove_test_u64_conversion() {
     let res = Ptr::num_u64(1);
     let res2 = Ptr::num_u64(2);
     let res3 = Ptr::u64(2);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, Some(res), None, Some(terminal), None, 3, &None);
     test_aux::<_, _, M1<'_, _>>(s, expr2, Some(res), None, Some(terminal), None, 2, &None);
@@ -3016,7 +3013,7 @@ fn test_prove_test_u64_num_comparison() {
     let expr2 = "(= 1 2u64)";
     let t = s.intern_lurk_symbol("t");
     let nil = s.intern_nil();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, Some(t), None, Some(terminal), None, 3, &None);
     test_aux::<_, _, M1<'_, _>>(s, expr2, Some(nil), None, Some(terminal), None, 3, &None);
@@ -3030,7 +3027,7 @@ fn test_prove_test_u64_num_cons() {
     let expr2 = "(cons 1u64 1)";
     let res = s.read_with_default_state("(1 . 1u64)").unwrap();
     let res2 = s.read_with_default_state("(1u64 . 1)").unwrap();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, Some(res), None, Some(terminal), None, 3, &None);
     test_aux::<_, _, M1<'_, _>>(s, expr2, Some(res2), None, Some(terminal), None, 3, &None);
@@ -3041,7 +3038,7 @@ fn test_prove_test_hide_u64_secret() {
     let s = &Store::<Fr>::default();
 
     let expr = "(hide 0u64 123)";
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, None, None, Some(error), None, 3, &None);
 }
@@ -3051,7 +3048,7 @@ fn test_prove_test_mod_by_zero_error() {
     let s = &Store::<Fr>::default();
 
     let expr = "(% 0 0)";
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, None, None, Some(error), None, 3, &None);
 }
@@ -3060,7 +3057,7 @@ fn test_prove_test_mod_by_zero_error() {
 fn test_prove_dotted_syntax_error() {
     let s = &Store::<Fr>::default();
     let expr = "(let ((a (lambda (x) (+ x 1)))) (a . 1))";
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, None, None, Some(error), None, 3, &None);
 }
@@ -3075,7 +3072,7 @@ fn test_prove_call_literal_fun() {
     let input = Ptr::num_u64(9);
     let expr = s.list(vec![fun, input]);
     let res = Ptr::num_u64(10);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     let lang: Arc<Lang<Fr, Coproc<Fr>>> = Arc::new(Lang::new());
 
     nova_test_full_aux2::<_, _, M1<'_, _>>(
@@ -3096,7 +3093,7 @@ fn test_prove_call_literal_fun() {
 #[test]
 fn test_prove_lambda_body_syntax() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
 
     test_aux::<_, _, M1<'_, _>>(s, "((lambda ()))", None, None, Some(error), None, 2, &None);
     test_aux::<_, _, M1<'_, _>>(
@@ -3135,7 +3132,7 @@ fn test_prove_lambda_body_syntax() {
 #[ignore]
 fn test_prove_non_symbol_binding_error() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
 
     let test = |x| {
         let expr = format!("(let (({x} 123)) {x})");
@@ -3157,7 +3154,7 @@ fn test_prove_non_symbol_binding_error() {
 #[test]
 fn test_prove_head_with_sym_mimicking_value() {
     let s = &Store::<Fr>::default();
-    let error = Ptr::null(Tag::Cont(Error));
+    let error = s.cont_error();
 
     let hash_num = |s: &Store<Fr>, state: Rc<RefCell<State>>, name| {
         let sym = s.read(state, name).unwrap();
@@ -3241,8 +3238,8 @@ fn test_dumb_lang() {
     let error6 = Ptr::char('x');
     let error7 = Ptr::char('y');
 
-    let error = Ptr::null(Tag::Cont(Error));
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let error = s.cont_error();
+    let terminal = s.cont_terminal();
     let lang = Arc::new(lang);
 
     test_aux::<_, _, C1LEM<'_, _, DumbCoproc<_>>>(
@@ -3339,7 +3336,7 @@ fn test_trie_lang() {
 
     let lang = Arc::new(lang);
 
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
 
     let expr = "(let ((trie (.lurk.trie.new)))
                       trie)";
@@ -3466,7 +3463,7 @@ fn test_trie_lang() {
 fn test_prove_lambda_body_nil() {
     let s = &Store::<Fr>::default();
     let expected = s.intern_nil();
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "((lambda (x) nil) 0)",
@@ -3484,7 +3481,7 @@ fn test_prove_lambda_body_nil() {
 fn test_letrec_let_nesting() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(2);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(letrec ((x (let ((z 0)) 1))) 2)",
@@ -3500,7 +3497,7 @@ fn test_letrec_let_nesting() {
 fn test_let_sequencing() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(1);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(let ((x 0) (y x)) 1)",
@@ -3516,7 +3513,7 @@ fn test_let_sequencing() {
 fn test_letrec_sequencing() {
     let s = &Store::<Fr>::default();
     let expected = Ptr::num_u64(3);
-    let terminal = Ptr::null(Tag::Cont(Terminal));
+    let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(letrec ((x 0) (y (letrec ((inner 1)) 2))) 3)",


### PR DESCRIPTION
Changes:
* Expand LEM's expressiveness to produce that kind of data in the model
* Adjust the Store accordingly, providing the appropriate API to create such pointers directly

Performance:
* The store benchmarks are a bit worse because initiating a default Store now has the extra cost of computing a few poseidon hashes
* But hydration is better because the hardcoded tag check shim is gone
* No significant changes to evaluation or proving

Note: I tried an approach with `OnceCell`s. It made the store interning and hydration benchmarks have no change wrt `master`, but it backfired with a 2% slowdown in evaluation, which is worse than paying a small cost on the store startup.

```text
end2end_benchmark/end2end_go_base_nova/_10_0
                        time:   [1.1098 s 1.1130 s 1.1157 s]
                        change: [+0.1501% +0.4740% +0.7700%] (p = 0.01 < 0.05)
                        Change within noise threshold.

store_benchmark/store_go_base_bls12/_10_16
                        time:   [156.42 µs 156.48 µs 156.56 µs]
                        change: [+4.8783% +4.9844% +5.0762%] (p = 0.00 < 0.05)
                        Performance has regressed.
store_benchmark/store_go_base_pallas/_10_16
                        time:   [158.86 µs 158.93 µs 159.01 µs]
                        change: [+4.5726% +4.6446% +4.7182%] (p = 0.00 < 0.05)
                        Performance has regressed.
store_benchmark/store_go_base_bls12/_10_160
                        time:   [159.15 µs 159.23 µs 159.33 µs]
                        change: [+3.9374% +4.0413% +4.1424%] (p = 0.00 < 0.05)
                        Performance has regressed.
store_benchmark/store_go_base_pallas/_10_160
                        time:   [157.71 µs 157.79 µs 157.89 µs]
                        change: [+4.0536% +4.1132% +4.1800%] (p = 0.00 < 0.05)
                        Performance has regressed.

hydration_benchmark/hydration_go_base_bls12/_10_16
                        time:   [103.96 ns 103.97 ns 103.98 ns]
                        change: [-3.7004% -3.5877% -3.4693%] (p = 0.00 < 0.05)
                        Performance has improved.
hydration_benchmark/hydration_go_base_pallas/_10_16
                        time:   [103.97 ns 103.97 ns 103.98 ns]
                        change: [-3.6144% -3.5865% -3.5611%] (p = 0.00 < 0.05)
                        Performance has improved.
hydration_benchmark/hydration_go_base_bls12/_10_160
                        time:   [103.03 ns 103.08 ns 103.12 ns]
                        change: [-4.0741% -3.9706% -3.8657%] (p = 0.00 < 0.05)
                        Performance has improved.
hydration_benchmark/hydration_go_base_pallas/_10_160
                        time:   [103.66 ns 103.68 ns 103.70 ns]
                        change: [-3.5395% -3.5072% -3.4763%] (p = 0.00 < 0.05)
                        Performance has improved.

eval_benchmark/eval_go_base_bls12/_10_16
                        time:   [8.0917 ms 8.0943 ms 8.0970 ms]
                        change: [-0.6780% -0.6198% -0.5642%] (p = 0.00 < 0.05)
                        Change within noise threshold.
eval_benchmark/eval_go_base_pallas/_10_16
                        time:   [8.1685 ms 8.1724 ms 8.1765 ms]
                        change: [+0.1633% +0.2267% +0.2902%] (p = 0.00 < 0.05)
                        Change within noise threshold.
eval_benchmark/eval_go_base_bls12/_10_160
                        time:   [81.775 ms 81.827 ms 81.888 ms]
                        change: [-0.4352% -0.2755% -0.1315%] (p = 0.00 < 0.05)
                        Change within noise threshold.
eval_benchmark/eval_go_base_pallas/_10_160
                        time:   [82.448 ms 82.532 ms 82.611 ms]
                        change: [+0.0092% +0.1232% +0.2417%] (p = 0.04 < 0.05)
                        Change within noise threshold.
```

Closes #796