### PR TITLE
Make `Ptr` hashing functions pure

### DIFF
--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -131,8 +131,8 @@ impl<F: LurkField> EvaluationStore for Store<F> {
         self.hydrate_scalar_cache()
     }
 
-    fn ptr_eq(&self, left: &Self::Ptr, right: &Self::Ptr) -> Result<bool, Self::Error> {
-        self.ptr_eq(left, right)
+    fn ptr_eq(&self, left: &Self::Ptr, right: &Self::Ptr) -> bool {
+        self.ptr_eq(left, right).unwrap()
     }
 }
 
@@ -178,8 +178,8 @@ impl<'a, F: LurkField, C: Coprocessor<F> + 'a> MultiFrameTrait<'a, F, C> for Mul
     fn io_to_scalar_vector(
         store: &Self::Store,
         io: &<Self::EvalFrame as FrameLike<Ptr<F>, ContPtr<F>>>::FrameIO,
-    ) -> Result<Vec<F>, Self::StoreError> {
-        io.to_vector(store)
+    ) -> Vec<F> {
+        io.to_vector(store).unwrap()
     }
 
     fn compute_witness(&self, s: &Self::Store) -> WitnessCS<F> {

--- a/src/cli/commitment.rs
+++ b/src/cli/commitment.rs
@@ -35,7 +35,7 @@ impl<F: LurkField> HasFieldModulus for Commitment<F> {
 impl<F: LurkField> Commitment<F> {
     pub(crate) fn new(secret: Option<F>, payload: Ptr<F>, store: &Store<F>) -> Result<Self> {
         let secret = secret.unwrap_or(F::NON_HIDING_COMMITMENT_SECRET);
-        let (hash, z_payload) = store.hide_and_return_z_payload(secret, payload)?;
+        let (hash, z_payload) = store.hide_and_return_z_payload(secret, payload);
         let mut z_store = ZStore::<F>::default();
         populate_z_store(&mut z_store, &payload, store, &mut HashMap::default())?;
         z_store.add_comm(hash, secret, z_payload);

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -315,7 +315,7 @@ impl Repl<F> {
                 &commitment.z_store,
                 &mut Default::default(),
             )?;
-            self.store.hide(*secret, payload)?;
+            self.store.hide(*secret, payload);
             if print_data {
                 println!(
                     "{}",

--- a/src/cli/repl/meta_cmd.rs
+++ b/src/cli/repl/meta_cmd.rs
@@ -144,7 +144,7 @@ impl MetaCmd<F> {
                 .eval_expr(second)
                 .with_context(|| "evaluating second arg")?;
             let (first_io_expr, second_io_expr) = (&first_io[0], &second_io[0]);
-            if !&repl.store.ptr_eq(first_io_expr, second_io_expr)? {
+            if !repl.store.ptr_eq(first_io_expr, second_io_expr) {
                 eprintln!(
                     "`assert-eq` failed. Expected:\n  {} = {}\nGot:\n  {} ≠ {}",
                     first.fmt_to_string(&repl.store, &repl.state.borrow()),

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -347,7 +347,7 @@ pub(crate) mod test {
                 .get_allocated_const(LEMTag::Expr(ExprTag::Num).to_field())
                 .expect("Num tag should have been allocated");
 
-            let err_cont_z_ptr = s.hash_ptr(&s.cont_error()).expect("hash_ptr failed");
+            let err_cont_z_ptr = s.hash_ptr(&s.cont_error());
             let cont_err = g
                 .get_allocated_ptr_from_z_ptr(&err_cont_z_ptr)
                 .expect("Error pointer should have been allocated");

--- a/src/coprocessor/sha256.rs
+++ b/src/coprocessor/sha256.rs
@@ -143,10 +143,7 @@ impl<F: LurkField> Coprocessor<F> for Sha256Coprocessor<F> {
     }
 
     fn evaluate_lem_simple(&self, s: &LEMStore<F>, args: &[LEMPtr<F>]) -> LEMPtr<F> {
-        let z_ptrs = args
-            .iter()
-            .map(|ptr| s.hash_ptr(ptr).unwrap())
-            .collect::<Vec<_>>();
+        let z_ptrs = args.iter().map(|ptr| s.hash_ptr(ptr)).collect::<Vec<_>>();
         LEMPtr::num(compute_sha256(self.n, &z_ptrs))
     }
 }

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -133,7 +133,7 @@ impl<F: LurkField> CoCircuit<F> for NewCoprocessor<F> {
 
         // TODO: Use a custom type.
         let root = LEMPtr::num(trie.root);
-        let root_z_ptr = s.hash_ptr(&root).unwrap();
+        let root_z_ptr = s.hash_ptr(&root);
 
         AllocatedPtr::alloc_constant(cs, root_z_ptr)
     }
@@ -169,8 +169,8 @@ impl<F: LurkField> Coprocessor<F> for LookupCoprocessor<F> {
         let key_ptr = &args[1];
 
         // TODO: Check tags.
-        let root_scalar = *s.hash_ptr(root_ptr).unwrap().value();
-        let key_scalar = *s.hash_ptr(key_ptr).unwrap().value();
+        let root_scalar = *s.hash_ptr(root_ptr).value();
+        let key_scalar = *s.hash_ptr(key_ptr).value();
         let trie: StandardTrie<'_, F> =
             Trie::new_with_root(&s.poseidon_cache, &s.inverse_poseidon_cache, root_scalar);
 
@@ -320,9 +320,9 @@ impl<F: LurkField> Coprocessor<F> for InsertCoprocessor<F> {
         let root_ptr = &args[0];
         let key_ptr = &args[1];
         let val_ptr = &args[2];
-        let root_scalar = *s.hash_ptr(root_ptr).unwrap().value();
-        let key_scalar = *s.hash_ptr(key_ptr).unwrap().value();
-        let val_scalar = *s.hash_ptr(val_ptr).unwrap().value();
+        let root_scalar = *s.hash_ptr(root_ptr).value();
+        let key_scalar = *s.hash_ptr(key_ptr).value();
+        let val_scalar = *s.hash_ptr(val_ptr).value();
         let mut trie: StandardTrie<'_, F> =
             Trie::new_with_root(&s.poseidon_cache, &s.inverse_poseidon_cache, root_scalar);
         trie.insert(key_scalar, val_scalar).unwrap();

--- a/src/eval/lang.rs
+++ b/src/eval/lang.rs
@@ -140,7 +140,7 @@ impl<F: LurkField, C: Coprocessor<F>> Lang<F, C> {
 
         // TODO: this `z_ptr` is not really needed by LEM
         let ptr = store.intern_symbol(&name);
-        let z_ptr = store.hash_ptr(&ptr).unwrap();
+        let z_ptr = store.hash_ptr(&ptr);
         let z_ptr = ZExprPtr::from_parts(lurk::tag::ExprTag::Sym, *z_ptr.value());
 
         self.coprocessors.insert(name, (cproc.into(), z_ptr));

--- a/src/lem/interpreter.rs
+++ b/src/lem/interpreter.rs
@@ -230,7 +230,7 @@ impl Block {
                     let b = bindings.get_ptr(b)?;
                     // In order to compare Ptrs, we *must* resolve the hashes. Otherwise, we risk failing to recognize equality of
                     // compound data with opaque data in either element's transitive closure.
-                    let c = store.hash_ptr(&a)?.value() == store.hash_ptr(&b)?.value();
+                    let c = store.hash_ptr(&a).value() == store.hash_ptr(&b).value();
                     bindings.insert_bool(tgt.clone(), c);
                 }
                 Op::Not(tgt, a) => {
@@ -419,7 +419,7 @@ impl Block {
                     let Ptr::Atom(Tag::Expr(Num), secret) = bindings.get_ptr(sec)? else {
                         bail!("{sec} is not a numeric pointer")
                     };
-                    let tgt_ptr = store.hide(secret, src_ptr)?;
+                    let tgt_ptr = store.hide(secret, src_ptr);
                     hints.commitment.push(Some(SlotData::FPtr(secret, src_ptr)));
                     bindings.insert_ptr(tgt.clone(), tgt_ptr);
                 }

--- a/src/lem/tests/eval_tests.rs
+++ b/src/lem/tests/eval_tests.rs
@@ -121,10 +121,10 @@ fn do_test<C: Coprocessor<Fr>>(
     let new_cont = output[2];
 
     if let Some(expected_result) = expected_result {
-        assert!(s.ptr_eq(&expected_result, &new_expr).unwrap());
+        assert!(s.ptr_eq(&expected_result, &new_expr));
     }
     if let Some(expected_env) = expected_env {
-        assert!(s.ptr_eq(&expected_env, &new_env).unwrap());
+        assert!(s.ptr_eq(&expected_env, &new_env));
     }
     if let Some(expected_cont) = expected_cont {
         assert_eq!(expected_cont, new_cont);
@@ -137,7 +137,7 @@ fn do_test<C: Coprocessor<Fr>>(
         assert!(expected_emitted
             .iter()
             .zip(emitted)
-            .all(|(a, b)| s.ptr_eq(a, &b).unwrap()));
+            .all(|(a, b)| s.ptr_eq(a, &b)));
     }
     assert_eq!(expected_iterations, iterations);
 }
@@ -1612,7 +1612,7 @@ fn hide_opaque_open_available() {
     let expr = s.read_with_default_state("(hide 123 'x)").unwrap();
     let (output, ..) = evaluate_simple::<Fr, Coproc<Fr>>(None, expr, s, 10).unwrap();
 
-    let c = *s.hash_ptr(&output[0]).unwrap().value();
+    let c = *s.hash_ptr(&output[0]).value();
     let comm = Ptr::comm(c);
 
     let open = s.intern_lurk_symbol("open");
@@ -1646,7 +1646,7 @@ fn hide_opaque_open_unavailable() {
     let expr = s.read_with_default_state("(hide 123 'x)").unwrap();
     let (output, ..) = evaluate_simple::<Fr, Coproc<Fr>>(None, expr, s, 10).unwrap();
 
-    let c = *s.hash_ptr(&output[0]).unwrap().value();
+    let c = *s.hash_ptr(&output[0]).value();
 
     let s2 = &Store::<Fr>::default();
     let comm = Ptr::comm(c);
@@ -2581,12 +2581,12 @@ fn test_sym_hash_values() {
     let asdf = s.intern_string("asdf");
     let consed_with_root = s.cons(asdf, root_sym);
 
-    let cons_z_ptr = &s.hash_ptr(&new_expr).unwrap();
-    let sym_z_ptr = &s.hash_ptr(&sym).unwrap();
-    let key_z_ptr = &s.hash_ptr(&key).unwrap();
+    let cons_z_ptr = &s.hash_ptr(&new_expr);
+    let sym_z_ptr = &s.hash_ptr(&sym);
+    let key_z_ptr = &s.hash_ptr(&key);
 
-    let consed_with_root_z_ptr = &s.hash_ptr(&consed_with_root).unwrap();
-    let toplevel_z_ptr = &s.hash_ptr(&toplevel_sym).unwrap();
+    let consed_with_root_z_ptr = &s.hash_ptr(&consed_with_root);
+    let toplevel_z_ptr = &s.hash_ptr(&toplevel_sym);
 
     // Symbol and keyword scalar hash values are the same as
     // those of the name string consed onto the parent symbol.

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -71,7 +71,7 @@ pub trait EvaluationStore {
     fn hydrate_z_cache(&self);
 
     /// hash-equality of the expressions represented by Ptrs
-    fn ptr_eq(&self, left: &Self::Ptr, right: &Self::Ptr) -> Result<bool, Self::Error>;
+    fn ptr_eq(&self, left: &Self::Ptr, right: &Self::Ptr) -> bool;
 }
 
 /// Trait to support multiple `MultiFrame` implementations.
@@ -120,7 +120,7 @@ pub trait MultiFrameTrait<'a, F: LurkField, C: Coprocessor<F> + 'a>:
     fn io_to_scalar_vector(
         store: &Self::Store,
         io: &<Self::EvalFrame as FrameLike<Self::Ptr, Self::ContPtr>>::FrameIO,
-    ) -> Result<Vec<F>, Self::StoreError>;
+    ) -> Vec<F>;
 
     /// Returns true if the supplied instance directly precedes this one in a sequential computation trace.
     fn precedes(&self, maybe_next: &Self) -> bool;

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -307,9 +307,8 @@ where
         lang: &Arc<Lang<F, C>>,
     ) -> Result<(Proof<'a, F, C, M>, Vec<F>, Vec<F>, usize), ProofError> {
         store.hydrate_z_cache();
-        let z0 = M::io_to_scalar_vector(store, frames[0].input()).map_err(|e| e.into())?;
-        let zi =
-            M::io_to_scalar_vector(store, frames.last().unwrap().output()).map_err(|e| e.into())?;
+        let z0 = M::io_to_scalar_vector(store, frames[0].input());
+        let zi = M::io_to_scalar_vector(store, frames.last().unwrap().output());
         let folding_config = Arc::new(FoldingConfig::new_ivc(lang.clone(), self.reduction_count()));
         let circuits = M::from_frames(self.reduction_count(), frames, store, &folding_config);
 
@@ -442,8 +441,7 @@ where
 
                     // This is a CircuitFrame, not an EvalFrame
                     let first_frame = circuit_primary.frames().unwrap().iter().next().unwrap();
-                    let zi =
-                        M::io_to_scalar_vector(store, first_frame.input()).map_err(|e| e.into())?;
+                    let zi = M::io_to_scalar_vector(store, first_frame.input());
                     let zi_allocated: Vec<_> = zi
                         .iter()
                         .enumerate()

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -270,9 +270,8 @@ where
         lang: Arc<Lang<F, C>>,
     ) -> Result<(Proof<'a, F, C, M>, Vec<F>, Vec<F>, usize, usize), ProofError> {
         store.hydrate_z_cache();
-        let z0 = M::io_to_scalar_vector(store, frames[0].input()).map_err(|e| e.into())?;
-        let zi =
-            M::io_to_scalar_vector(store, frames.last().unwrap().output()).map_err(|e| e.into())?;
+        let z0 = M::io_to_scalar_vector(store, frames[0].input());
+        let zi = M::io_to_scalar_vector(store, frames.last().unwrap().output());
         let folding_config = Arc::new(FoldingConfig::new_nivc(lang, self.reduction_count));
 
         let nivc_steps = M::from_frames(self.reduction_count(), frames, store, &folding_config);

--- a/src/proof/tests/mod.rs
+++ b/src/proof/tests/mod.rs
@@ -223,10 +223,10 @@ where
     }
 
     if let Some(expected_result) = expected_result {
-        assert!(s.ptr_eq(&expected_result, output.expr()).unwrap());
+        assert!(s.ptr_eq(&expected_result, output.expr()));
     }
     if let Some(expected_env) = expected_env {
-        assert!(s.ptr_eq(&expected_env, output.env()).unwrap());
+        assert!(s.ptr_eq(&expected_env, output.env()));
     }
     if let Some(expected_cont) = expected_cont {
         assert_eq!(&expected_cont, output.cont());

--- a/src/proof/tests/nova_tests_lem.rs
+++ b/src/proof/tests/nova_tests_lem.rs
@@ -3158,7 +3158,7 @@ fn test_prove_head_with_sym_mimicking_value() {
 
     let hash_num = |s: &Store<Fr>, state: Rc<RefCell<State>>, name| {
         let sym = s.read(state, name).unwrap();
-        let z_ptr = s.hash_ptr(&sym).unwrap();
+        let z_ptr = s.hash_ptr(&sym);
         let hash = *z_ptr.value();
         Num::Scalar(hash)
     };


### PR DESCRIPTION
Pointer hashing functions used to throw errors when the data needed for hashing wouldn't be found in the store. However, this indicates a malformed store, meaning that interning must have gone wrong somewhere else. So a straightforward panic is more adequate.

This simplifies a lot of calls to `Store::hash_ptr`, which were being `unwrap`d or `expect`d in many cases anyway.