### PR TITLE
ci: Enable `issue_comment` actions on forked PRs

### DIFF
--- a/.github/workflows/bench-pr-comment.yml
+++ b/.github/workflows/bench-pr-comment.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   cpu-benchmark:
-    name: run end2end benchmark
+    name: run fibonacci benchmark
     runs-on: buildjet-32vcpu-ubuntu-2204
     if:
       github.event.issue.pull_request
@@ -21,17 +21,18 @@ jobs:
       && contains(github.event.comment.body, '!benchmark')
       && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')
     steps:
-      - uses: xt0rted/pull-request-comment-branch@v2
-        id: comment-branch
       - uses: actions/checkout@v4
-        if: success()
-        with:
-          ref: ${{ steps.comment-branch.outputs.head_ref }}
+      - name: Checkout PR branch
+        run: gh pr checkout $PR_NUMBER
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+      # Install dependencies
       - name: Install dependencies
         run: sudo apt-get install -y pkg-config libssl-dev
-      # Set the Rust env vars
       - uses: actions-rs/toolchain@v1
       - uses: Swatinem/rust-cache@v2
+      # Run the comparative benchmark and comment output on the PR
       - uses: boa-dev/criterion-compare-action@v3
         with:
           # Optional. Compare only this benchmark target
@@ -39,8 +40,6 @@ jobs:
           # Needed. The name of the branch to compare with
           branchName: ${{ github.ref_name }}
 
-  # TODO: Check it works with forked PRs when running
-  # `gh pr checkout {{ github.event.issue.number}}` with `env: GH_TOKEN`
   gpu-benchmark:
     name: run fibonacci benchmark on GPU
     runs-on: [self-hosted, gpu-bench]
@@ -50,13 +49,19 @@ jobs:
       && contains(github.event.comment.body, '!gpu-benchmark')
       && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')
     steps:
+      - uses: actions/checkout@v4
+      - name: Checkout PR branch
+        run: gh pr checkout $PR_NUMBER
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
       # Set up GPU
       # Check we have access to the machine's Nvidia drivers
       - run: nvidia-smi
       # The `compute`/`sm` number corresponds to the Nvidia GPU architecture
       # In this case, the self-hosted machine uses the Ampere architecture, but we want this to be configurable
       # See https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
-      # Writes env vars to `bench.env` to be read by `just` command
+      # Writes env vars to `bench.env` to be read by `dotenv` action. This is roundabout but puts all the env vars in one place
       - name: Set env for CUDA compute
         run: echo "CUDA_ARCH=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader | sed 's/\.//g')" >> bench.env
       - name: set env for EC_GPU
@@ -64,24 +69,19 @@ jobs:
       # Check that CUDA is installed with a driver-compatible version
       # This must also be compatible with the GPU architecture, see above link
       - run: nvcc --version
-
-      - uses: xt0rted/pull-request-comment-branch@v2
-        id: comment-branch
-      - uses: actions/checkout@v4
-        if: success()
-        with:
-          ref: ${{ steps.comment-branch.outputs.head_ref }}
+      # Install dependencies
       - uses: actions-rs/toolchain@v1
       - uses: Swatinem/rust-cache@v2
-      # Strict load => panic if .env file not found
       - name: Load env vars
         uses: xom9ikk/dotenv@v2
         with:
           path: bench.env
+          # Strict load => panic if .env file not found
           load-mode: strict
-
+      # Run the comparative benchmark and comment output on the PR
       - uses: boa-dev/criterion-compare-action@v3
         with:
+          # Note: Removing `benchName` causes `criterion` errors: https://github.com/boa-dev/criterion-compare-action#troubleshooting
           # Optional. Compare only this benchmark target
           benchName: "fibonacci_lem"
           # Optional. Features activated in the benchmark


### PR DESCRIPTION
Enables `!benchmark` and `!gpu-benchmark` comments to run on forked PRs.

Successful run: https://github.com/lurk-lab/ci-lab/actions/runs/6701467940/job/18208949422 from https://github.com/lurk-lab/ci-lab/pull/17

Closes #815 