### PR TITLE
ci: Fix bugs in `#790`

### DIFF
--- a/.github/workflows/bench-deploy.yml
+++ b/.github/workflows/bench-deploy.yml
@@ -35,7 +35,8 @@ jobs:
       - name: Install criterion
         run: cargo install cargo-criterion
       - name: Run benchmarks
-        run: cd benches && just --dotenv-filename bench.env gpu-bench fibonacci_lem
+        run: just --dotenv-filename bench.env gpu-bench fibonacci_lem
+        working-directory: ${{ github.workspace }}/benches
       # TODO: Prettify labels for easier viewing
       # Compress the benchmark file and metadata for later analysis
       - name: Compress artifacts

--- a/.github/workflows/bench-deploy.yml
+++ b/.github/workflows/bench-deploy.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install criterion
         run: cargo install cargo-criterion
       - name: Run benchmarks
-        run: just --dotenv-filename bench.env gpu-bench fibonacci_lem
+        run: cd benches && just --dotenv-filename bench.env gpu-bench fibonacci_lem
       # TODO: Prettify labels for easier viewing
       # Compress the benchmark file and metadata for later analysis
       - name: Compress artifacts

--- a/.github/workflows/merge-tests.yml
+++ b/.github/workflows/merge-tests.yml
@@ -67,7 +67,7 @@ jobs:
   # TODO: Make this a required status check
   # Run comparative benchmark against master, reject on regression
   gpu-benchmark:
-    if: github.event_name != 'pull_request' || github.event.action == 'enqueued'
+    #if: github.event_name != 'pull_request' || github.event.action == 'enqueued'
     name: Run fibonacci bench on GPU
     runs-on: [self-hosted, gpu-bench]
     steps:
@@ -103,25 +103,29 @@ jobs:
       - name: Run GPU bench on base branch
         run: cd master/benches && just --dotenv-filename bench.env gpu-bench fibonacci_lem
       - name: Copy bench output to PR branch
-        run: cp master/${{ env.BASE_REF }}.json .
+        run: |
+          mkdir -p target
+          cp -r master/target/criterion target
+          cp master/${{ env.BASE_REF }}.json .
       - name: Run GPU bench on PR branch
         run: cd benches && just --dotenv-filename bench.env gpu-bench fibonacci_lem
       # Create a `criterion-table` and write in commit comment
       - name: Run `criterion-table`
         run: cat ${{ github.sha }}.json | criterion-table > BENCHMARKS.md
-      - name: Write bench on commit comment
-        uses: peter-evans/commit-comment@v3
-        with:
-          body-path: BENCHMARKS.md
+      #- name: Write bench on commit comment
+      #  uses: peter-evans/commit-comment@v3
+      #  with:
+      #    body-path: BENCHMARKS.md
       # TODO: Use jq for JSON parsing if needed
       # Check for benchmark regression based on Criterion's configured noise threshold
       - name: Performance regression check
         id: check-regression
         run: |
+          echo $(grep -c 'Regressed' ${{ github.sha }}.json)
           echo "regress_count=$(grep -c 'Regressed' ${{ github.sha }}.json)" >> $GITHUB_OUTPUT
       # Fail job if regression found
       - uses: actions/github-script@v6
-        if: ${{ steps.check-regression.outputs.regress_count }} > 0
+        if: ${{ steps.check-regression.outputs.regress_count > 0 }}
         with:
           script: |
             core.setFailed('Fibonacci bench regression detected')

--- a/.github/workflows/merge-tests.yml
+++ b/.github/workflows/merge-tests.yml
@@ -67,7 +67,7 @@ jobs:
   # TODO: Make this a required status check
   # Run comparative benchmark against master, reject on regression
   gpu-benchmark:
-    #if: github.event_name != 'pull_request' || github.event.action == 'enqueued'
+    if: github.event_name != 'pull_request' || github.event.action == 'enqueued'
     name: Run fibonacci bench on GPU
     runs-on: [self-hosted, gpu-bench]
     steps:
@@ -96,33 +96,34 @@ jobs:
           path: master
       # Copy the script so the base can bench with the same parameters
       - name: Copy source script to base branch
-        run: cd benches && cp justfile bench.env ../master/benches
+        run: cp justfile bench.env ../master/benches
+        working-directory: ${{ github.workspace }}/benches
       - name: Set base ref variable
-        run: cd master && echo "BASE_REF=$(git rev-parse HEAD)" >> $GITHUB_ENV
-      - run: echo ${{ env.BASE_REF }}
+        run: echo "BASE_REF=$(git rev-parse HEAD)" | tee -a $GITHUB_ENV
+        working-directory: ${{ github.workspace }}/master
       - name: Run GPU bench on base branch
-        run: cd master/benches && just --dotenv-filename bench.env gpu-bench fibonacci_lem
+        run: just --dotenv-filename bench.env gpu-bench fibonacci_lem
+        working-directory: ${{ github.workspace }}/master/benches
       - name: Copy bench output to PR branch
         run: |
           mkdir -p target
           cp -r master/target/criterion target
           cp master/${{ env.BASE_REF }}.json .
       - name: Run GPU bench on PR branch
-        run: cd benches && just --dotenv-filename bench.env gpu-bench fibonacci_lem
+        run: just --dotenv-filename bench.env gpu-bench fibonacci_lem
+        working-directory: ${{ github.workspace }}/benches
       # Create a `criterion-table` and write in commit comment
       - name: Run `criterion-table`
         run: cat ${{ github.sha }}.json | criterion-table > BENCHMARKS.md
-      #- name: Write bench on commit comment
-      #  uses: peter-evans/commit-comment@v3
-      #  with:
-      #    body-path: BENCHMARKS.md
+      - name: Write bench on commit comment
+        uses: peter-evans/commit-comment@v3
+        with:
+          body-path: BENCHMARKS.md
       # TODO: Use jq for JSON parsing if needed
       # Check for benchmark regression based on Criterion's configured noise threshold
       - name: Performance regression check
         id: check-regression
-        run: |
-          echo $(grep -c 'Regressed' ${{ github.sha }}.json)
-          echo "regress_count=$(grep -c 'Regressed' ${{ github.sha }}.json)" >> $GITHUB_OUTPUT
+        run: echo "regress_count=$(grep -c 'Regressed' ${{ github.sha }}.json)" | tee -a $GITHUB_OUTPUT
       # Fail job if regression found
       - uses: actions/github-script@v6
         if: ${{ steps.check-regression.outputs.regress_count > 0 }}


### PR DESCRIPTION
Bugs in #790:
- The `merge_group` bench wasn't generating a comparison due to a lack of shared `target/criterion` data
- The `merge_group` bench was always reporting a regression due to a syntax error
- The `bench-deploy` workflow wasn't generating benchmarks correctly as it was running in the wrong directory

Successful runs:
- Regression failure: https://github.com/lurk-lab/ci-lab/actions/runs/6711235126/job/18238175028
- Non-regression success: https://github.com/lurk-lab/ci-lab/actions/runs/6711704879/job/18239666659

NOTE: Do not merge until the `merge_group` bench (enabled on `pull_request` for testing) successfully reports a non-regression and then restores the previous trigger behavior.