### PR TITLE
chore: remove dead code from multiple modules (easy)

### DIFF
--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -144,13 +144,6 @@ impl Status {
         }
     }
 
-    pub fn is_incomplete(&self) -> bool {
-        match self {
-            Self::Incomplete => true,
-            Self::Terminal | Self::Error => false,
-        }
-    }
-
     pub fn to_cont<F: LurkField>(&self, s: &Store<F>) -> Option<ContPtr<F>> {
         match self {
             Self::Terminal => Some(s.intern_cont_terminal()),

--- a/src/hash_witness.rs
+++ b/src/hash_witness.rs
@@ -396,12 +396,6 @@ where
     }
 }
 
-impl<Name: HashName, T, const L: usize, F: LurkField> HashWitness<Name, T, L, F> {
-    pub fn length() -> usize {
-        L
-    }
-}
-
 pub type ConsWitness<F> = HashWitness<ConsName, Cons<F>, MAX_CONSES_PER_REDUCTION, F>;
 pub type ContWitness<F> = HashWitness<ContName, Cont<F>, MAX_CONTS_PER_REDUCTION, F>;
 
@@ -492,23 +486,8 @@ impl<
         self.slots.iter().map(|x| x.1).collect()
     }
 
-    pub fn all_names(&self) -> Vec<Name> {
-        self.slots.iter().map(|x| x.0).collect()
-    }
-
-    pub fn stubs_used(&self) -> Vec<Stub<T>> {
-        self.all_stubs()
-            .into_iter()
-            .filter(|c| !c.is_dummy())
-            .collect()
-    }
-
     pub fn stubs_used_count(&self) -> usize {
         self.all_stubs().iter().filter(|c| !c.is_dummy()).count()
-    }
-
-    pub fn total_stub(&self) -> usize {
-        self.all_stubs().len()
     }
 }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -1285,20 +1285,6 @@ impl<F: LurkField> Store<F> {
         self.get_z_cont(ptr, &mut None).ok().map(|x| x.0)
     }
 
-    pub fn hash_string(&self, s: &str) -> ZExprPtr<F> {
-        let ptr = self.intern_string(s);
-        self.get_z_expr(&ptr, &mut None)
-            .expect("known string can't be opaque")
-            .0
-    }
-
-    pub fn hash_symbol(&self, s: &Symbol) -> ZExprPtr<F> {
-        let ptr = self.intern_symbol(s);
-        self.get_z_expr(&ptr, &mut None)
-            .expect("known symbol can't be opaque")
-            .0
-    }
-
     pub fn car_cdr(&self, ptr: &Ptr<F>) -> Result<(Ptr<F>, Ptr<F>), Error> {
         match ptr.tag {
             ExprTag::Nil => Ok((lurk_sym_ptr!(self, nil), lurk_sym_ptr!(self, nil))),
@@ -1343,19 +1329,6 @@ impl<F: LurkField> Store<F> {
                 "one or more values missing when comparing Ptrs for equality".into(),
             )),
         }
-    }
-
-    pub fn cons_eq(&self, a: &Ptr<F>, b: &Ptr<F>) -> bool {
-        assert_eq!(ExprTag::Cons, a.tag);
-        assert_eq!(ExprTag::Cons, b.tag);
-
-        let a_opaque = a.is_opaque();
-        let b_opaque = b.is_opaque();
-
-        if !a_opaque && !b_opaque {
-            return a == b;
-        }
-        self.hash_expr(a) == self.hash_expr(b)
     }
 
     /// Fill the cache for Scalars. Only Ptrs which have been interned since last hydration will be hashed, so it is

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -200,20 +200,6 @@ impl Symbol {
         res
     }
 
-    // TODO: needs some kind of whitespace escaping
-    pub fn fmt_to_string_raw(&self) -> String {
-        let mut res = String::from("~(");
-        let mut iter = self.path.iter().peekable();
-        while let Some(next) = iter.next() {
-            res.push_str(next);
-            match iter.peek() {
-                Some(_) => res.push(' '),
-                None => res.push(')'),
-            }
-        }
-        res
-    }
-
     pub fn prints_as_absolute(&self) -> bool {
         if self.path.is_empty() {
             false

--- a/src/z_data/z_store.rs
+++ b/src/z_data/z_store.rs
@@ -48,25 +48,6 @@ impl<F: LurkField> ZStore<F> {
         }
     }
 
-    /// Converts an entire store to a `ZStore`
-    /// WARNING: This will leak secrets used for opaque data in
-    /// `Store::comm_store`. Not for use with hiding commitments
-    pub fn to_z_store(store: &Store<F>) -> Self {
-        store.hydrate_scalar_cache();
-        let mut zstore = ZStore::new();
-        for zptr in store.z_expr_ptr_map.keys_cloned() {
-            let ptr = store.z_expr_ptr_map.get(&zptr).unwrap();
-            let zexpr = store.to_z_expr(ptr);
-            zstore.expr_map.insert(zptr, zexpr);
-        }
-        for zptr in store.z_cont_ptr_map.keys_cloned() {
-            let ptr = store.z_cont_ptr_map.get(&zptr).unwrap();
-            let zcont = store.to_z_cont(ptr);
-            zstore.cont_map.insert(zptr, zcont);
-        }
-        zstore
-    }
-
     /// Creates a new `ZStore` and adds all `ZExprPtrs` reachable from the hashed `expr`
     /// Inserts child pointers into `ZStore` with `to_z_store_with_ptr`,
     /// then inserts top level pointer
@@ -76,15 +57,6 @@ impl<F: LurkField> ZStore<F> {
             Ok((new, z_ptr)) => (new, Some(z_ptr)),
             _ => (ZStore::new(), None),
         }
-    }
-
-    /// Converts a Lurk expression to a `ZExpr` and stores it in the `ZStore`, returning
-    /// the resulting `ZExprPtr`
-    pub fn insert_expr(&mut self, store: &Store<F>, expr: &Ptr<F>) -> Option<ZExprPtr<F>> {
-        let z_ptr = store.hash_expr(expr)?;
-        let z_expr = ZExpr::from_ptr(store, expr);
-        self.expr_map.insert(z_ptr, z_expr);
-        Some(z_ptr)
     }
 
     /// Returns the `ZExpr` immediately corresponding to the `ZExprPtr`, where "immediate" means


### PR DESCRIPTION
- Removed redundant and unused functions across multiple files including `hash_witness.rs`, `z_data/z_store.rs`, `eval/mod.rs`, and `symbol.rs`.

Remaining unused items are in the following categories:
- in a module we don't want to touch today (#804), and where removal needs some thought, e.g. `parse_code`, `parse_space`, `parse_line_comment`, `assert_all_paths_taken`, `construct`, `construct_strcons`,
- small utilities which removal wouldn't be significant, e.g. `is_evaluation`, `is_root_symbol`, `push_tag`, `push_symbol`, `push_default`, `to_z_expr`, `is_coprocessor`
- related to underused functionality we know we'll want to extend the use of: 
    - supernova (`supernova_circuit_params`, `supernova_aux_params`, `supernova_public_params`), 
    - opaque pointers (`intern_maybe_opaque_fun`, `intern_maybe_opaque_sym`, `hidden`, `get_opaque_ptr`, `new_opaque_pr`, ...) 
    - public parameter caching (`circuit_cache_key`, `with_public_params`)
    
Closes #214 