### PR TITLE
ci: Parameterize `BenchmarkId` on output type in PR bench comments

### DIFF
--- a/.github/workflows/bench-pr-comment.yml
+++ b/.github/workflows/bench-pr-comment.yml
@@ -32,6 +32,14 @@ jobs:
         run: sudo apt-get install -y pkg-config libssl-dev
       - uses: actions-rs/toolchain@v1
       - uses: Swatinem/rust-cache@v2
+      - name: Load env vars
+        run: |
+          set -a
+          source bench.env
+          set +a
+          echo "LURK_BENCH_OUTPUT=pr-comment" >> $GITHUB_ENV
+          env | grep -E 'LURK|EC_GPU|CUDA'
+        working-directory: ${{ github.workspace }}/benches
       # Run the comparative benchmark and comment output on the PR
       - uses: boa-dev/criterion-compare-action@v3
         with:
@@ -77,6 +85,7 @@ jobs:
           set -a
           source bench.env
           set +a
+          echo "LURK_BENCH_OUTPUT=pr-comment" >> $GITHUB_ENV
           env | grep -E 'LURK|EC_GPU|CUDA'
         working-directory: ${{ github.workspace }}/benches
       # Run the comparative benchmark and comment output on the PR


### PR DESCRIPTION
This PR adds the `LURK_BENCH_OUTPUT` env var, which enables customization of the `fibonacci_lem` `BenchmarkId` for differently formatted output types.

Problem: `boa-dev/criterion-compare-action` PR comment is printing incorrectly: https://github.com/lurk-lab/lurk-rs/pull/825#issuecomment-1789070013. `critcmp` can't compare benchmarks with different `BenchmarkId`'s, and our `fibonacci_lem` benchmark includes the commit hash in the ID.

Solution: Remove the commit hash for the `pr-comment` output type, and keep it for the other types for now.