### PR TITLE
use non-deprecated getters for WitnessCS

### DIFF
--- a/src/proof/tests/mod.rs
+++ b/src/proof/tests/mod.rs
@@ -200,8 +200,8 @@ where
         let cs_inputs = cs.scalar_inputs();
         let cs_aux = cs.scalar_aux();
 
-        let wcs_inputs = wcs.scalar_inputs();
-        let wcs_aux = wcs.scalar_aux();
+        let wcs_inputs = wcs.input_assignment();
+        let wcs_aux = wcs.aux_assignment();
 
         assert_eq!(None, mismatch(&cs_inputs, &wcs_inputs));
         assert_eq!(None, mismatch(&cs_aux, &wcs_aux));

--- a/src/proof/tests/mod.rs
+++ b/src/proof/tests/mod.rs
@@ -203,8 +203,8 @@ where
         let wcs_inputs = wcs.input_assignment();
         let wcs_aux = wcs.aux_assignment();
 
-        assert_eq!(None, mismatch(&cs_inputs, &wcs_inputs));
-        assert_eq!(None, mismatch(&cs_aux, &wcs_aux));
+        assert_eq!(None, mismatch(&cs_inputs, wcs_inputs));
+        assert_eq!(None, mismatch(&cs_aux, wcs_aux));
 
         previous_frame = Some(multiframe);
 


### PR DESCRIPTION
There is a [deprecated warning](https://github.com/lurk-lab/arecibo/actions/runs/6716208822/job/18313683952?pr=89#step:7:811) in the result of the [check-lurk-compiles](https://github.com/lurk-lab/arecibo/blob/dev/.github/workflows/rust.yml#L39) job in [this pending pr](https://github.com/lurk-lab/arecibo/pull/89) due to a change that was made in bellpepper see: https://github.com/lurk-lab/bellpepper/pull/48

This change uses the new public getters for WitnessCS to resolve the deprecated warnings.