### PR TITLE
chore: Downgrade minimum Rust version to 1.71.1 (easy)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "Turing-Complete Zero Knowledge"
 edition = "2021"
 repository = "https://github.com/lurk-lab/lurk-rs"
-rust-version = "1.72.0"
+rust-version = "1.71.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
- Downgraded the minimum Rust language version utilizable in the project.
- our MSRV was temporarily increased due to an erroneous increase in the dev branch of bellpepper. This was fixed in https://github.com/lurk-lab/bellpepper/pull/35