### PR TITLE
chore:: Refactor field tests to use pasta_curves instead of blstrs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ itertools = "0.9"
 lurk-macros = { path = "lurk-macros" }
 lurk-metrics = { path = "lurk-metrics" }
 metrics = { workspace = true }
-neptune = { workspace = true, features = ["arity2", "arity4", "arity8", "arity16", "pasta", "bls"] }
+neptune = { workspace = true, features = ["arity2", "arity4", "arity8", "arity16", "pasta"] }
 nom = "7.1.3"
 nom_locate = "4.1.0"
 nova = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ base-x = "0.2.11"
 bellpepper = { workspace = true }
 bellpepper-core = { workspace = true }
 bincode = { workspace = true }
-blstrs = { workspace = true }
 bytecount = "=0.6.4"
 camino = { workspace = true, features = ["serde1"] }
 clap = { workspace = true, features = ["derive"] }
@@ -93,7 +92,7 @@ default = []
 opencl = ["neptune/opencl", "nova/opencl"]
 cuda = ["neptune/cuda", "nova/cuda"]
 # compile without ISA extensions
-portable = ["blstrs/portable", "pasta-msm/portable", "nova/portable"]
+portable = ["pasta-msm/portable", "nova/portable"]
 flamegraph = ["pprof/flamegraph", "pprof/criterion"]
 
 [dev-dependencies]
@@ -123,7 +122,6 @@ base64 = "0.13.1"
 bellpepper = { git = "https://github.com/lurk-lab/bellpepper", branch = "dev" }
 bellpepper-core = { git = "https://github.com/lurk-lab/bellpepper", branch = "dev" }
 bincode = "1.3.3"
-blstrs = { git = "https://github.com/lurk-lab/blstrs", branch = "dev" }
 clap = "4.3.17"
 ff = "0.13"
 metrics = "0.21.1"

--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ bin/lurk
 Set the environment variable `LURK_FIELD` to specify the scalar field of the Lurk language instance:
 - `LURK_FIELD=PALLAS` (default): scalar field of Pallas
 - `LURK_FIELD=VESTA`: scalar field of Vesta
-- `LURK_FIELD=BLS12-381`: scalar field of BLS12-381
 
 ```
 ➜  lurk-rs ✗ bin/lurk

--- a/benches/end2end_lem.rs
+++ b/benches/end2end_lem.rs
@@ -1,7 +1,6 @@
 use criterion::{
     black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, SamplingMode,
 };
-use pasta_curves::pallas::Scalar as Fr;
 use pasta_curves::pallas::Scalar as Fq;
 use std::{cell::RefCell, rc::Rc, sync::Arc, time::Duration};
 
@@ -102,7 +101,6 @@ fn store_benchmark_lem(c: &mut Criterion) {
         .measurement_time(Duration::from_secs(5))
         .sample_size(60);
 
-    let bls12_store = Store::<Fr>::default();
     let pallas_store = Store::<Fq>::default();
 
     let state = State::init_lurk_state().rccell();
@@ -111,14 +109,6 @@ fn store_benchmark_lem(c: &mut Criterion) {
     let sizes = [(10, 16), (10, 160)];
     for size in sizes {
         let parameter_string = format!("_{}_{}", size.0, size.1);
-
-        let bls12_id = BenchmarkId::new("store_go_base_bls12", &parameter_string);
-        group.bench_with_input(bls12_id, &size, |b, &s| {
-            b.iter(|| {
-                let result = go_base::<Fr>(&bls12_store, state.clone(), s.0, s.1);
-                black_box(result)
-            })
-        });
 
         let pasta_id = BenchmarkId::new("store_go_base_pallas", &parameter_string);
         group.bench_with_input(pasta_id, &size, |b, &s| {
@@ -141,7 +131,6 @@ fn hydration_benchmark_lem(c: &mut Criterion) {
         .measurement_time(Duration::from_secs(5))
         .sample_size(60);
 
-    let bls12_store = Store::<Fr>::default();
     let pallas_store = Store::<Fq>::default();
 
     let state = State::init_lurk_state().rccell();
@@ -150,14 +139,6 @@ fn hydration_benchmark_lem(c: &mut Criterion) {
     let sizes = [(10, 16), (10, 160)];
     for size in sizes {
         let parameter_string = format!("_{}_{}", size.0, size.1);
-
-        {
-            let benchmark_id = BenchmarkId::new("hydration_go_base_bls12", &parameter_string);
-            group.bench_with_input(benchmark_id, &size, |b, &s| {
-                let _ptr = go_base::<Fr>(&bls12_store, state.clone(), s.0, s.1);
-                b.iter(|| bls12_store.hydrate_z_cache())
-            });
-        }
 
         {
             let benchmark_id = BenchmarkId::new("hydration_go_base_pallas", &parameter_string);
@@ -181,7 +162,6 @@ fn eval_benchmark_lem(c: &mut Criterion) {
         .sample_size(60);
 
     let limit = 1_000_000_000;
-    let bls12_store = Store::default();
     let pallas_store = Store::default();
 
     let state = State::init_lurk_state().rccell();
@@ -190,15 +170,6 @@ fn eval_benchmark_lem(c: &mut Criterion) {
     let sizes = [(10, 16), (10, 160)];
     for size in sizes {
         let parameter_string = format!("_{}_{}", size.0, size.1);
-
-        {
-            let benchmark_id = BenchmarkId::new("eval_go_base_bls12", &parameter_string);
-            group.bench_with_input(benchmark_id, &size, |b, &s| {
-                let ptr = go_base::<Fr>(&bls12_store, state.clone(), s.0, s.1);
-                b.iter(|| evaluate_simple::<Fr, Coproc<Fr>>(None, ptr, &bls12_store, limit))
-            });
-        }
-
         {
             let benchmark_id = BenchmarkId::new("eval_go_base_pallas", &parameter_string);
             group.bench_with_input(benchmark_id, &size, |b, &s| {
@@ -218,7 +189,6 @@ fn eval_benchmark_lem(c: &mut Criterion) {
 //          .sample_size(60);
 
 //     let limit = 1_000_000_000;
-//     let _lang_bls = Lang::<Fr, Coproc<Fr>>::new();
 //     let _lang_pallas = Lang::<Fq, Coproc<Fq>>::new();
 //     let lang_pallas = Lang::<Fq, Coproc<Fq>>::new();
 

--- a/clutch/src/main.rs
+++ b/clutch/src/main.rs
@@ -17,7 +17,6 @@ fn main() -> Result<()> {
 
     let default_field = LanguageField::Pallas;
     let field = match std::env::var("LURK_FIELD").as_deref() {
-        Ok("BLS12-381") => LanguageField::BLS12_381,
         Ok("PALLAS") => LanguageField::Pallas,
         Ok("VESTA") => LanguageField::Vesta,
         _ => default_field,

--- a/src/cli/circom.rs
+++ b/src/cli/circom.rs
@@ -86,7 +86,6 @@ pub(crate) fn create_circom_gadget(circom_folder: &Utf8PathBuf, name: &str) -> R
         // because circom and lurk have different semantics about which field should be specified
         // (circom wants the base field and lurk the scalar field).
         match lurk_field.as_str() {
-            "BLS12-381" => "bn128",
             "PALLAS" => "vesta",
             "VESTA" => "pallas",
             _ => bail!("unsupported field"),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -353,7 +353,6 @@ impl ReplCli {
         match field {
             LanguageField::Pallas => repl!(rc, limit, pallas::Scalar, backend.clone()),
             LanguageField::Vesta => todo!(),
-            LanguageField::BLS12_381 => todo!(),
             LanguageField::BN256 => todo!(),
             LanguageField::Grumpkin => todo!(),
         }
@@ -408,7 +407,6 @@ impl LoadCli {
         match field {
             LanguageField::Pallas => load!(rc, limit, pallas::Scalar, backend.clone()),
             LanguageField::Vesta => todo!(),
-            LanguageField::BLS12_381 => todo!(),
             LanguageField::BN256 => todo!(),
             LanguageField::Grumpkin => todo!(),
         }

--- a/src/field.rs
+++ b/src/field.rs
@@ -41,8 +41,6 @@ pub enum LanguageField {
     Pallas,
     /// The Vesta field,
     Vesta,
-    /// The BLS12-381 scalar field,
-    BLS12_381,
     /// The BN256 scalar field,
     BN256,
     /// THe Grumpkin scalar field,
@@ -54,7 +52,6 @@ impl std::fmt::Display for LanguageField {
         match self {
             Self::Pallas => write!(f, "Pallas"),
             Self::Vesta => write!(f, "Vesta"),
-            Self::BLS12_381 => write!(f, "BLS12-381"),
             Self::BN256 => write!(f, "BN256"),
             Self::Grumpkin => write!(f, "Grumpkin"),
         }
@@ -357,10 +354,6 @@ pub mod tests {
 
     proptest! {
       #[test]
-      fn prop_bls_repr_bytes_consistency(f1 in any::<FWrap<Fr>>()) {
-        repr_bytes_consistency(f1)
-      }
-      #[test]
       fn prop_pallas_repr_bytes_consistency(f1 in any::<FWrap<pallas::Scalar>>()) {
           repr_bytes_consistency(f1)
       }
@@ -461,15 +454,6 @@ pub mod tests {
         #[test]
         fn prop_vesta_tag_roundtrip(x in any::<u64>()){
             let f1 = vesta::Scalar::from(x);
-            let bytes = f1.to_repr().as_ref().to_vec();
-            let mut bytes_from_u64 = [0u8; 32];
-            bytes_from_u64[..8].copy_from_slice(&x.to_le_bytes());
-            assert_eq!(bytes, bytes_from_u64);
-        }
-
-        #[test]
-        fn prop_bls_tag_roundtrip(x in any::<u64>()){
-            let f1 = pasta_curves::pallas::Scalar::from(x);
             let bytes = f1.to_repr().as_ref().to_vec();
             let mut bytes_from_u64 = [0u8; 32];
             bytes_from_u64[..8].copy_from_slice(&x.to_le_bytes());

--- a/src/field.rs
+++ b/src/field.rs
@@ -263,10 +263,6 @@ pub trait LurkField: PrimeField + PrimeFieldBits {
     }
 }
 
-impl LurkField for blstrs::Scalar {
-    const FIELD: LanguageField = LanguageField::BLS12_381;
-}
-
 impl LurkField for pasta_curves::pallas::Scalar {
     const FIELD: LanguageField = LanguageField::Pallas;
 }
@@ -348,7 +344,7 @@ impl<'de, F: LurkField> Deserialize<'de> for FWrap<F> {
 #[cfg(test)]
 pub mod tests {
     use crate::z_data::{from_z_data, to_z_data};
-    use blstrs::Scalar as Fr;
+    use pasta_curves::pallas::Scalar as Fr;
     use pasta_curves::{pallas, vesta};
 
     use super::*;
@@ -473,7 +469,7 @@ pub mod tests {
 
         #[test]
         fn prop_bls_tag_roundtrip(x in any::<u64>()){
-            let f1 = blstrs::Scalar::from(x);
+            let f1 = pasta_curves::pallas::Scalar::from(x);
             let bytes = f1.to_repr().as_ref().to_vec();
             let mut bytes_from_u64 = [0u8; 32];
             bytes_from_u64[..8].copy_from_slice(&x.to_le_bytes());

--- a/src/lem/circuit.rs
+++ b/src/lem/circuit.rs
@@ -1574,7 +1574,6 @@ impl Func {
         let bit_decomp_cost = match F::FIELD {
             LanguageField::Pallas => 298,
             LanguageField::Vesta => 301,
-            LanguageField::BLS12_381 => 388,
             _ => todo!(),
         };
 


### PR DESCRIPTION
- Follow-up of #774
- Swapped out `blstrs::Scalar` implementation in `src/field.rs` with pasta_curves::pallas::Scalar
- Readjusted tests to now run on the `pasta_curve` as opposed to the `blstrs`
- Updated `Cargo.toml` by removing `blstrs` from both the workspace and dev dependencies
- Removed the association of `blstrs/portable` from the `portable` feature in `Cargo.toml`