### PR TITLE
refactor: Refactor trait requirements and update CurveCycleEquipped

### DIFF
--- a/src/cli/lurk_proof.rs
+++ b/src/cli/lurk_proof.rs
@@ -100,8 +100,6 @@ impl<'a, F: CurveCycleEquipped + Serialize, M: MultiFrameTrait<'a, F, Coproc<F>>
 where
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
-    <F as CurveCycleEquipped>::CK1: Sync + Send,
-    <F as CurveCycleEquipped>::CK2: Sync + Send,
 {
     #[inline]
     pub(crate) fn persist(self, proof_key: &str) -> Result<()> {
@@ -119,8 +117,6 @@ impl<
 where
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
-    <F as CurveCycleEquipped>::CK1: Sync + Send,
-    <F as CurveCycleEquipped>::CK2: Sync + Send,
 {
     pub(crate) fn verify_proof(proof_key: &str) -> Result<()> {
         let lurk_proof: LurkProof<'_, F, Coproc<F>, M> = load(&proof_path(proof_key))?;

--- a/src/cli/repl/meta_cmd.rs
+++ b/src/cli/repl/meta_cmd.rs
@@ -367,11 +367,8 @@ impl MetaCmd<F> {
 
 impl<F: CurveCycleEquipped + DeserializeOwned> MetaCmd<F>
 where
-    // TODO(huitseeker): this is a bit pedantic, revisit later.
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
-    <F as CurveCycleEquipped>::CK1: Sync + Send,
-    <F as CurveCycleEquipped>::CK2: Sync + Send,
 {
     const VERIFY: MetaCmd<F> = MetaCmd {
         name:

--- a/src/public_parameters/mem_cache.rs
+++ b/src/public_parameters/mem_cache.rs
@@ -111,8 +111,6 @@ impl PublicParamMemCache {
         default: Fn,
     ) -> Result<Arc<PublicParams<F, M>>, Error>
     where
-        F::CK1: Sync + Send,
-        F::CK2: Sync + Send,
         <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
         <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     {

--- a/src/public_parameters/mod.rs
+++ b/src/public_parameters/mod.rs
@@ -27,8 +27,6 @@ pub fn public_params<
     instance: &Instance<'static, F, C, M>,
 ) -> Result<Arc<PublicParams<F, M>>, Error>
 where
-    F::CK1: Sync + Send,
-    F::CK2: Sync + Send,
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
@@ -90,8 +88,6 @@ pub fn supernova_circuit_params<
     instance: &Instance<'a, F, C, M>,
 ) -> Result<NovaCircuitShape<F>, Error>
 where
-    F::CK1: Sync + Send,
-    F::CK2: Sync + Send,
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
@@ -118,8 +114,6 @@ pub fn supernova_aux_params<
     instance: &Instance<'a, F, C, M>,
 ) -> Result<SuperNovaAuxParams<F>, Error>
 where
-    F::CK1: Sync + Send,
-    F::CK2: Sync + Send,
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
@@ -151,8 +145,6 @@ pub fn supernova_public_params<
     instance_primary: &Instance<'a, F, C, M>,
 ) -> Result<supernova::PublicParams<F, M>, Error>
 where
-    F::CK1: Sync + Send,
-    F::CK2: Sync + Send,
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {


### PR DESCRIPTION
**Context**:

Developing [zeromorph](https://github.com/lurk-lab/arecibo/tree/zeromorph) forced me to abstract several Nova APIs over the used `EvaluationEngineTrait` (which was the point of the whole exercise). And it forced me to realize that Nova APIs that genericise over the group implementations, in order to represent the concept of a given curve cycle, become a lot simpler when they jointly abstract over the associated `EvaluationEngine`.

This insight led to https://github.com/microsoft/Nova/pull/234

**This PR**:

We prepare the code base from where it is now (hard-coding that the Evaluation Engine used in nova is the IPA, and requiring the corresponding idiosyncratic trait bound `CommitmentKeyExtTrait`) to something that's Zeromorph-ready (recognizing that any curve cycle may have its unspecified choice of `EvaluationEngineTrait` implementations). We reap the associated simplicity benefits.

**In Detail**:

- Removed Sync and Send trait requirements for multiple associated types across various modules, simplifying the codebase.
- Significant updates made to the trait `CurveCycleEquipped` in `nova.rs`. Removed four previous type and introduced two new ones, `EE1` and `EE2`, shifting the focus towards an improved Evaluation Engine.
- This change in trait `CurveCycleEquipped` is also reflected in the pallas::Scalar and bn256::Scalar trait implementations.
- The necessity for detailed explanations about the removed type aliases in `CurveCycleEquipped` was eliminated. Added brief explanations for the new type aliases.
- Removed `Sync + Send` trait bounds from `F::CK1` and `F::CK2` in the `public_params`, `supernova_circuit_params`, and `supernova_aux_params` functions, resulting in simpler functions.