### PR TITLE
Properly handle halting coprocessors

### DIFF
--- a/src/lem/tests/eval_tests.rs
+++ b/src/lem/tests/eval_tests.rs
@@ -2939,7 +2939,7 @@ fn test_trie_lang() {
         None,
         None,
         None,
-        5,
+        4,
         &Some(&lang),
     );
 
@@ -3009,7 +3009,7 @@ fn test_trie_lang() {
         None,
         None,
         None,
-        10,
+        9,
         &Some(&lang),
     );
 
@@ -3026,7 +3026,35 @@ fn test_trie_lang() {
         None,
         None,
         None,
-        14,
+        13,
+        &Some(&lang),
+    );
+}
+
+#[test]
+fn test_terminator_lang() {
+    use crate::{coprocessor::test::Terminator, state::user_sym};
+
+    let mut lang = Lang::<Fr, Terminator<Fr>>::new();
+    let dumb = Terminator::new();
+    let name = user_sym("terminate");
+
+    let s = &Store::default();
+    lang.add_coprocessor(name, dumb, s);
+
+    let expr = "(terminate)";
+
+    let res = s.intern_nil();
+    let terminal = s.cont_terminal();
+
+    test_aux(
+        s,
+        expr,
+        Some(res),
+        None,
+        Some(terminal),
+        None,
+        1,
         &Some(&lang),
     );
 }

--- a/src/proof/tests/nova_tests_lem.rs
+++ b/src/proof/tests/nova_tests_lem.rs
@@ -3368,6 +3368,34 @@ fn test_dumb_lang() {
 }
 
 #[test]
+fn test_terminator_lang() {
+    use crate::{coprocessor::test::Terminator, state::user_sym};
+
+    let mut lang = Lang::<Fr, Terminator<Fr>>::new();
+    let dumb = Terminator::new();
+    let name = user_sym("terminate");
+
+    let s = &Store::default();
+    lang.add_coprocessor(name, dumb, s);
+
+    let expr = "(terminate)";
+
+    let res = s.intern_nil();
+    let terminal = s.cont_terminal();
+
+    test_aux::<_, _, C1LEM<'_, _, Terminator<_>>>(
+        s,
+        expr,
+        Some(res),
+        None,
+        Some(terminal),
+        None,
+        1,
+        &Some(lang.into()),
+    );
+}
+
+#[test]
 fn test_trie_lang() {
     use crate::coprocessor::trie::{install_lem, TrieCoproc};
 
@@ -3396,7 +3424,7 @@ fn test_trie_lang() {
         None,
         Some(terminal),
         None,
-        5,
+        4,
         DEFAULT_REDUCTION_COUNT,
         false,
         None,
@@ -3474,7 +3502,7 @@ fn test_trie_lang() {
         None,
         Some(terminal),
         None,
-        10,
+        9,
         DEFAULT_REDUCTION_COUNT,
         false,
         None,
@@ -3493,7 +3521,7 @@ fn test_trie_lang() {
         None,
         Some(terminal),
         None,
-        14,
+        13,
         DEFAULT_REDUCTION_COUNT,
         false,
         None,


### PR DESCRIPTION
Prior to this PR, the CEK machine was completely unable to handle coprocessors that inadvertently halt the computation. Although that's not encouraged for coprocessors authors, we do want to fix such inability.

Extra: when testing the fix, I noticed that the model was wasting an iteration when evaluating a coprocessor call with no arguments. This PR also fixes that.