### PR TITLE
ci: Compare `commit-comment` benches by `rc` group

### DIFF
--- a/.github/workflows/merge-tests.yml
+++ b/.github/workflows/merge-tests.yml
@@ -101,6 +101,8 @@ jobs:
       - name: Set base ref variable
         run: echo "BASE_REF=$(git rev-parse HEAD)" | tee -a $GITHUB_ENV
         working-directory: ${{ github.workspace }}/master
+      - name: Set bench output format type
+        run: echo "LURK_BENCH_OUTPUT=commit-comment" | tee -a $GITHUB_ENV
       - name: Run GPU bench on base branch
         run: just --dotenv-filename bench.env gpu-bench fibonacci_lem
         working-directory: ${{ github.workspace }}/master/benches


### PR DESCRIPTION
- Enables the `LURK_BENCH_OUTPUT="commit-comment"` env var option, which configures the benchmark metadata for `criterion-table` formatting.
- Moves the reduction count out of the `BenchmarkId` `name` and into the `BenchmarkGroup`, which separates bench run tables by `rc` in `criterion-table`.
