### PR TITLE
ci: fix GPU benches

### DIFF
--- a/benches/fibonacci_lem.rs
+++ b/benches/fibonacci_lem.rs
@@ -64,7 +64,7 @@ impl ProveParams {
                 format!("fib-branch={}", env!("VERGEN_GIT_BRANCH")),
                 format!("num-{}", self.fib_n),
             ),
-            "gh-pages" => todo!(),
+            // TODO: refine "gh-pages",
             _ => (
                 "fib".into(),
                 format!("num-{}-{}-{}", self.fib_n, self.sha, self.date),


### PR DESCRIPTION
#852 broke GPU benches
https://github.com/lurk-lab/lurk-rs/actions/runs/6773544195/job/18408644257

This results in :
> thread 'main' panicked at benches/fibonacci_lem.rs:67:33:
> not yet implemented

This PR collapses the `gh-pages` job into the default case, making sure the unimplemented at this line isn't there to hit.