### PR TITLE
ci: use stable git references & differential output

### DIFF
--- a/.github/workflows/merge-tests.yml
+++ b/.github/workflows/merge-tests.yml
@@ -131,7 +131,7 @@ jobs:
         working-directory: ${{ github.workspace }}
       # Create a `criterion-table` and write in commit comment
       - name: Run `criterion-table`
-        run: cat ${{ github.sha }}.json | criterion-table > BENCHMARKS.md
+        run: cat ${{ env.BASE_REF }}.json ${{ github.sha }}.json | criterion-table > BENCHMARKS.md
       - name: Write bench on commit comment
         uses: peter-evans/commit-comment@v3
         with:

--- a/benches/fibonacci_lem.rs
+++ b/benches/fibonacci_lem.rs
@@ -61,7 +61,7 @@ impl ProveParams {
         match output_type.as_ref() {
             "pr-comment" => ("fib".into(), format!("num-{}", self.fib_n)),
             "commit-comment" => (
-                format!("fib-branch={}", env!("VERGEN_GIT_BRANCH")),
+                format!("fib-ref={}", env!("VERGEN_GIT_SHA")),
                 format!("num-{}", self.fib_n),
             ),
             // TODO: refine "gh-pages",


### PR DESCRIPTION
- avoids using git branches in CI : branches move, and the CI infra is likely to resolve the branch to the gh merge queue branch in several cases,
- uses differential output in criterion-table for commit-comment.