### PR TITLE
Fix `commit-comment` benchmark comparison

### DIFF
--- a/.github/workflows/merge-tests.yml
+++ b/.github/workflows/merge-tests.yml
@@ -131,7 +131,7 @@ jobs:
         working-directory: ${{ github.workspace }}
       # Create a `criterion-table` and write in commit comment
       - name: Run `criterion-table`
-        run: cat ${{ github.sha }}.json | criterion-table > BENCHMARKS.md
+        run: cat ${{ env.BASE_REF }}.json ${{ github.sha }}.json | criterion-table > BENCHMARKS.md
       - name: Write bench on commit comment
         uses: peter-evans/commit-comment@v3
         with:


### PR DESCRIPTION
Alternate idea to #861: trades a bit of parsing for getting the PR number in the `commit-comment`, which might be nice for easy lookup.

Note: Because `criterion-table` [parses by `/`](https://github.com/nu11ptr/criterion-table#usage), this solution will likely be buggy when attempting to merge into a non-default base branch with a `/` character (e.g. `sb/base-branch` will be truncated by `criterion-table` into `fib-branch=sb`).