### PR TITLE
ci: Implement daily scheduled Codecov analysis

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,10 +1,7 @@
 name: Codecov
 on:
-    push: 
-      branches: [master]
-    pull_request:
-      types: [opened, synchronize, reopened, ready_for_review]
-      branches: [master]
+  schedule:
+    - cron:  '0 0 * * *'
     
 jobs:
   codecov-grcov:


### PR DESCRIPTION
- Utilize nightlies for scheduling the Codecov workflow instead of activating on push and pull requests to the master branch.

I was wrong, @arthurpaulino is right, this is taking too much time on our CI runners.