### PR TITLE
chore: switch to abomonation_derive_ng

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ tap = "1.0.1"
 stable_deref_trait = "1.2.0"
 thiserror = { workspace = true }
 abomonation = { workspace = true }
-abomonation_derive = { git = "https://github.com/lurk-lab/abomonation_derive.git" }
+abomonation_derive = { version = "0.1.0", package = "abomonation_derive_ng" }
 crossbeam = "0.8.2"
 byteorder = "1.4.3"
 circom-scotia = { git = "https://github.com/lurk-lab/circom-scotia", branch = "dev" }
@@ -125,7 +125,7 @@ bincode = "1.3.3"
 clap = "4.3.17"
 ff = "0.13"
 metrics = "0.21.1"
-neptune = { git = "https://github.com/lurk-lab/neptune", branch = "dev" }
+neptune = { git = "https://github.com/lurk-lab/neptune", branch = "dev", features = ["abomonation"] }
 nova = { git = "https://github.com/lurk-lab/arecibo", branch = "dev", package = "nova-snark" }
 once_cell = "1.18.0"
 pairing = { version = "0.23" }


### PR DESCRIPTION
This is fully expected to break on CI, but the full setup was tested locally.

> [!WARNING]  
> Sequencing for this PR:
> 1. this PR is reviewed ✅ despite CI status being ❎ 
> 2. https://github.com/lurk-lab/neptune/tree/dev is reset to https://github.com/lurk-lab/neptune/tree/dev_ng
> 3. companion Arecibo PR is merged ([#105](https://github.com/lurk-lab/arecibo/pull/105))
> 4. this PR's CI is re-run and succeeds
> 5. this PR is merged

> [!NOTE]
> If you want to test this at home:
> 1. checkout https://github.com/lurk-lab/neptune/tree/dev_ng (note the specific branch) to `$FOO/neptune`
> 2. checkout https://github.com/lurk-lab/arecibo/tree/with_abomonation_ng to `$FOO/arecibo` and apply instructions in the Note of https://github.com/lurk-lab/arecibo/pull/105
> 3. change the neptune dependency in *this* repo to `neptune = { path="$FOO/neptune", default-features = false, features = ["abomonation"] }`
> 4. change the nova dependency in *this* repo to `nova = { path="$FOO/arecibo", package = "nova-snark" }`
> 3. run tests as usual