### PR TITLE
chore: Rename default branch from `master` to `main`

### DIFF
--- a/.github/workflows/bench-deploy.yml
+++ b/.github/workflows/bench-deploy.yml
@@ -1,8 +1,8 @@
-name: GPU benchmark on `master`
+name: GPU benchmark on `main`
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   # TODO: Account for different `justfile` and `bench.env` files

--- a/.github/workflows/bench-pr-comment.yml
+++ b/.github/workflows/bench-pr-comment.yml
@@ -1,4 +1,4 @@
-# Creates a PR benchmark comment with a comparison to master
+# Creates a PR benchmark comment with a comparison to main
 name: Benchmark pull requests
 on:
   issue_comment:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   merge_group:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [master]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Docs
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - "**.rs"
       - "Cargo.toml"

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -4,7 +4,7 @@ name: GPU tests
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [master]
+    branches: [main]
   merge_group:
 
 env:

--- a/.github/workflows/licenses-audits.yml
+++ b/.github/workflows/licenses-audits.yml
@@ -3,7 +3,7 @@ name: cargo-deny
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 

--- a/.github/workflows/links-check.yml
+++ b/.github/workflows/links-check.yml
@@ -3,7 +3,7 @@ name: "Check documentation links"
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:

--- a/.github/workflows/merge-tests.yml
+++ b/.github/workflows/merge-tests.yml
@@ -4,7 +4,7 @@ name: Merge group tests
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [master]
+    branches: [main]
   merge_group:
 
 concurrency:
@@ -65,7 +65,7 @@ jobs:
           cargo nextest run --profile ci --workspace --cargo-profile dev-no-assertions -E 'test(circuit::gadgets)'
 
   # TODO: Make this a required status check
-  # Run comparative benchmark against master, reject on regression
+  # Run comparative benchmark against main, reject on regression
   gpu-benchmark:
     if: github.event_name != 'pull_request' || github.event.action == 'enqueued'
     name: Run fibonacci bench on GPU
@@ -92,25 +92,25 @@ jobs:
       # Checkout base branch for comparative bench
       - uses: actions/checkout@v4
         with:
-          ref: master
-          path: master
+          ref: main
+          path: main
       # Copy the script so the base can bench with the same parameters
       - name: Copy source script to base branch
-        run: cp justfile bench.env ../master/benches
+        run: cp justfile bench.env ../main/benches
         working-directory: ${{ github.workspace }}/benches
       - name: Set base ref variable
         run: echo "BASE_REF=$(git rev-parse HEAD)" | tee -a $GITHUB_ENV
-        working-directory: ${{ github.workspace }}/master
+        working-directory: ${{ github.workspace }}/main
       - name: Set bench output format type
         run: echo "LURK_BENCH_OUTPUT=commit-comment" | tee -a $GITHUB_ENV
       - name: Run GPU bench on base branch
         run: just --dotenv-filename bench.env gpu-bench fibonacci
-        working-directory: ${{ github.workspace }}/master/benches
+        working-directory: ${{ github.workspace }}/main/benches
       - name: Copy bench output to PR branch
         run: |
           mkdir -p target
-          cp -r master/target/criterion target
-          cp master/${{ env.BASE_REF }}.json .
+          cp -r main/target/criterion target
+          cp main/${{ env.BASE_REF }}.json .
       - name: Run GPU bench on PR branch
         run: just --dotenv-filename bench.env gpu-bench fibonacci
         working-directory: ${{ github.workspace }}/benches

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,4 @@
-name: Nightly tests on master
+name: Nightly tests on main
 
 on:
   schedule:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ We want to make contributing to this project as easy and transparent as possible
 ## Pull Requests
 If you want to contribute a bug fix or feature to lurk, here's how to proceed:
 
-1. Fork the repo and create your branch from `master`.
+1. Fork the repo and create your branch from `main`.
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
 4. Ensure the test suite passes.
@@ -26,7 +26,7 @@ The maintainers will review your pull request as soon as they can, and it can on
 A pull-request must meet certain criteria before it can be merged.
 
 1. If you are fine with a squash merge, your pull-request's final commit should have at least one approval from a reviewer, and from all maintainers listed in the .github/CODEOWNERS file for the touched code sections.
-2. If you prefer a classic merge, the pull-request should meet the above conditions, and and it should be a fast-forward merge from master, which implies it must also be up-to-date.
+2. If you prefer a classic merge, the pull-request should meet the above conditions, and and it should be a fast-forward merge from main, which implies it must also be up-to-date.
 
 **Warning:** An up-to-date, rebased branch is required for a fast-forward merge. This means that your branch should not contain any merge commits: while we do not object to `Merge` as a pull-request merge method, we prefer the pull-request's history to be linear. To achieve this, you can update your local branch with `git pull --rebase` (see [doc](https://www.git-scm.com/docs/git-pull)).
 
@@ -51,9 +51,9 @@ flowchart TD
     Rebase --> Review
 
     Merge --> |It worked| Celebrate
-    Merge --> |Somebody pushed to master before maintainer| Rebase
+    Merge --> |Somebody pushed to main before maintainer| Rebase
 
-    MQueue -.-> |PR squash-merges cleanly on master & passes CI| Celebrate
+    MQueue -.-> |PR squash-merges cleanly on main & passes CI| Celebrate
     MQueue -.-> |Github merge queue found squash-merge or CI issue| Rebase
 ```
 
@@ -82,7 +82,7 @@ Additionally, Lurk-rs depends on the following forked repositories:
 - [pasta-msm](https://github.com/lurk-lab/pasta-msm) (forked from [supranational/pasta-msm](https://github.com/supranational/pasta-msm))
 - [ec-gpu](https://github.com/lurk-lab/ec-gpu) (forked from [filecoin-project/ec-gpu](https://github.com/filecoin-project/ec-gpu))
 
-For rapid iterations and to address issues in these dependencies, Lurk's **master** branch directly depends on the **dev** branch of its dependencies (transitively).
+For rapid iterations and to address issues in these dependencies, Lurk's **main** branch directly depends on the **dev** branch of its dependencies (transitively).
 
 ### Branch Management (forked dependencies)
 

--- a/notes/reduction-notes.md
+++ b/notes/reduction-notes.md
@@ -13,7 +13,7 @@ corresponding arithmetic circuit. The initial Lurk circuit implementation is spe
 
 Because the circuit must check the computation to be proved, many aspects of the implementation itself must be fully
 specified. The reference implementation of Lurk expression evaluation in
-[`eval.rs`](https://github.com/lurk-lab/lurk-rs/blob/master/src/eval.rs) provides an intermediate step between the
+[`eval.rs`](https://github.com/lurk-lab/lurk-rs/blob/main/src/eval.rs) provides an intermediate step between the
 high-level specification and the low-level circuit. Not every aspect of the implementation is essential, but every part
 which directly corresponds to the layout of the constraint system is.
 
@@ -32,7 +32,7 @@ Taking these one at a time:
 1. Because the SNARK-friendly Poseidon hashes (provided by the [Neptune](https://github.com/lurk-lab/neptune)
    library) are relatively expensive, and because Lurk does not provide explicit access to the hash values, we avoid
    computing them during evaluation -- instead relying on the
-   [Store](https://github.com/lurk-lab/lurk-rs/blob/master/src/store.rs) to manage cheaper expression pointers in a way
+   [Store](https://github.com/lurk-lab/lurk-rs/blob/main/src/store.rs) to manage cheaper expression pointers in a way
    that preserves equality. All such pointers are resolved to content-addressable tagged hashes before circuit
    synthesis. The Store is used during synthesis when the preimage of a hash known at synthesis needs to be 'looked
    up'.


### PR DESCRIPTION
This PR prepares CI to run on `main`, as we are changing the default branch from `master` to `main`.

Marking as draft until the above process is ready.