### PR TITLE
Make some assertions more conservative

### DIFF
--- a/demo/bank.lurk
+++ b/demo/bank.lurk
@@ -219,7 +219,7 @@ ledger2
 
 ;; Now we can transfer one unit from Church to Satoshi like before.
 
-!(chain 0x0757a47095c97d0a58a8ff66a2146949ee9d60d3f0a82887c203edf1748be711 '(1 0 2))
+!(chain 0x099f5f1cef164ac0a5ef8d6b0cefd930d2d0bf40666df3ae1b12abc33a5d297a '(1 0 2))
 
 !(prove)
 
@@ -227,16 +227,16 @@ ledger2
 
 ;; Then we can transfer 5 more, proceeding from the new head of the chain.
 
-!(chain 0x0d0b562063718f3623c1749268da4dd74ed33142edc411f4e74d7a84e64f3f30 '(5 0 2))
+!(chain 0x11abc1857d88646e3a6a2d0be605a3639feca2b79191c65efb7c6c139465820e '(5 0 2))
 
 !(prove)
 
-!(verify "Nova_Pallas_10_045d2fef5862777cf50a9dc8df50650f1aebfcbfb8135adfea57fb8f45389af4") 
+!(verify "Nova_Pallas_10_3b5c0928297a8380b1003b343b2b35522b3c16a03fbf69b3deea91c50cbdfc66") 
 
 ;; And once more, this time we'll transfer 20 from Turing to Church.
 
-!(chain 0x3e232dc8d44c85697fa4205d0d945014d34b980af498aed9194216c27c489e05 '(20 1 0))
+!(chain 0x007f5ed09b15a2af11a0504a46884aff364eb7bb1e7e9543431443b962166cb5 '(20 1 0))
 
 !(prove)
 
-!(verify "Nova_Pallas_10_25c76318cda48570568b9bb766ee9a906790c4dc94c96b1d6549e96c3bff8aa7")
+!(verify "Nova_Pallas_10_3dc75e7fc1fd2a629b04e6e7469ed20711a4012b03c3f1205c18a351b9cdb7ca")

--- a/demo/vdf.lurk
+++ b/demo/vdf.lurk
@@ -51,7 +51,7 @@
 
 !(prove)
 
-!(verify "Nova_Pallas_10_20c429019e3eade18d0182febe27b987af8da1ab15cf55b0794296deb0435929")
+!(verify "Nova_Pallas_10_0edc673ca67889bd824bb09d6be89a1b93fc7bc013fff4f4cd50e7bf10587831")
 
 !(def timelock-encrypt (lambda (secret-key plaintext rounds)
                           (let ((ciphertext (+ secret-key plaintext))

--- a/src/cli/repl/meta_cmd.rs
+++ b/src/cli/repl/meta_cmd.rs
@@ -598,11 +598,12 @@ impl MetaCmd<F> {
             let Ptr::Atom(Tag::Expr(ExprTag::Comm), hash) = comm else {
                 bail!("Second component of a chain must be a commitment")
             };
-            let (_, fun) = repl
+            // retrieve from store to persist
+            let (secret, fun) = repl
                 .store
                 .open(hash)
                 .expect("data must have been committed");
-            repl.hide(F::NON_HIDING_COMMITMENT_SECRET, *fun)
+            repl.hide(*secret, *fun)
         },
     };
 }

--- a/src/lem/multiframe.rs
+++ b/src/lem/multiframe.rs
@@ -481,7 +481,7 @@ impl<'a, F: LurkField, C: Coprocessor<F> + 'a> MultiFrameTrait<'a, F, C> for Mul
                         let padding_frame = lurk_step
                             .call_simple(&output, store, lang, 0)
                             .expect("reduction step failed");
-                        assert_eq!(padding_frame.input, padding_frame.output);
+                        assert_eq!(output, padding_frame.output);
                         inner_frames.resize(reduction_count, padding_frame.clone());
                         inner_frames
                     } else {
@@ -554,7 +554,7 @@ impl<'a, F: LurkField, C: Coprocessor<F> + 'a> MultiFrameTrait<'a, F, C> for Mul
                             let padding_frame = lurk_step
                                 .call_simple(&output, store, lang, 0)
                                 .expect("reduction step failed");
-                            assert_eq!(padding_frame.input, padding_frame.output);
+                            assert_eq!(output, padding_frame.output);
                             inner_frames.resize(reduction_count, padding_frame);
                         }
 

--- a/tests/lurk-cli-tests.rs
+++ b/tests/lurk-cli-tests.rs
@@ -58,6 +58,7 @@ fn test_prove_and_verify() {
     file.write_all(b"!(verify \"Nova_Pallas_10_3f2526abf20fc9006dd93c0d3ff49954ef070ef52d2e88426974de42cc27bdb2\")\n").unwrap();
 
     let mut cmd = lurk_cmd();
+    cmd.env("LURK_PERF", "max-parallel-simple");
     cmd.arg("load");
     cmd.arg(lurk_file.into_string());
     cmd.arg("--public-params-dir");
@@ -68,4 +69,20 @@ fn test_prove_and_verify() {
     cmd.arg(commit_dir);
 
     cmd.assert().success();
+}
+
+#[test]
+fn test_repl_panic() {
+    let tmp_dir = Builder::new().prefix("tmp").tempdir().unwrap();
+    let tmp_dir = Utf8Path::from_path(tmp_dir.path()).unwrap();
+    let lurk_file = tmp_dir.join("panic.lurk");
+
+    let mut file = File::create(lurk_file.clone()).unwrap();
+    // `x` is not bound
+    file.write_all(b"x\n").unwrap();
+
+    let mut cmd = lurk_cmd();
+    cmd.arg("load");
+    cmd.arg(lurk_file.into_string());
+    cmd.assert().failure();
 }

--- a/tests/lurk-files-tests.rs
+++ b/tests/lurk-files-tests.rs
@@ -37,7 +37,6 @@ fn test_lurk_lib() {
     lurk_lib_examples.into_par_iter().for_each(|f| {
         let mut cmd = lurk_cmd();
         cmd.current_dir(LURK_LIB_EXAMPLES_DIR);
-        cmd.env("LURK_PANIC_IF_CANT_LOAD", "true");
         cmd.arg(f);
         cmd.assert().success();
     });


### PR DESCRIPTION
* Make the REPL raise errors properly instead of just printing locally so loading files
  with mistakes causes an unsuccessful termination
* Fix errors on some of our demos due to the fix above
* Fix the chain meta command so it persists commitments with the right secret
* Assert that the output of the padded frame is the same as the one from the original last frame