### PR TITLE
Create tests for basic hashing; add an API to create opaque pointers

### DIFF
--- a/src/lem/pointers.rs
+++ b/src/lem/pointers.rs
@@ -92,6 +92,14 @@ impl<F: LurkField> Ptr<F> {
         Self::zero(Tag::Expr(Nil))
     }
 
+    /// Creates an atom pointer from a `ZPtr`, with its tag and hash. Thus hashing
+    /// such pointer will result on the same original `ZPtr`
+    #[inline]
+    pub fn opaque(z_ptr: ZPtr<F>) -> Self {
+        let crate::z_data::z_ptr::ZPtr(t, h) = z_ptr;
+        Ptr::Atom(t, h)
+    }
+
     #[inline]
     pub fn cast(self, tag: Tag) -> Self {
         match self {


### PR DESCRIPTION
This PR is a follow up to #878 because I realized that we didn't have tests for the basic cases of `Store::hash_ptr`.

This PR also shows how to achieve opaque functionality with `ZPtr`s.