### PR TITLE
refactor: Refactor method names and update nova-snark branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ clap = "4.3.17"
 ff = "0.13"
 metrics = "0.21.1"
 neptune = { git = "https://github.com/lurk-lab/neptune", branch = "dev", features = ["abomonation"] }
-nova = { git = "https://github.com/lurk-lab/arecibo", branch = "dev", package = "nova-snark" }
+nova = { git = "https://github.com/lurk-lab/arecibo", branch = "microsoft_257", package = "nova-snark" }
 once_cell = "1.18.0"
 pairing = { version = "0.23" }
 pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch = "dev" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ clap = "4.3.17"
 ff = "0.13"
 metrics = "0.21.1"
 neptune = { git = "https://github.com/lurk-lab/neptune", branch = "dev", features = ["abomonation"] }
-nova = { git = "https://github.com/lurk-lab/arecibo", branch = "microsoft_257", package = "nova-snark" }
+nova = { git = "https://github.com/lurk-lab/arecibo", branch = "dev", package = "nova-snark" }
 once_cell = "1.18.0"
 pairing = { version = "0.23" }
 pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch = "dev" }

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -203,8 +203,8 @@ where
 {
     let (circuit_primary, circuit_secondary) = circuits(num_iters_per_step, lang);
 
-    let commitment_size_hint1 = <SS1<F> as RelaxedR1CSSNARKTrait<G1<F>>>::commitment_key_floor();
-    let commitment_size_hint2 = <SS2<F> as RelaxedR1CSSNARKTrait<G2<F>>>::commitment_key_floor();
+    let commitment_size_hint1 = <SS1<F> as RelaxedR1CSSNARKTrait<G1<F>>>::ck_floor();
+    let commitment_size_hint2 = <SS2<F> as RelaxedR1CSSNARKTrait<G2<F>>>::ck_floor();
 
     let pp = nova::PublicParams::new(
         &circuit_primary,

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -8,7 +8,7 @@ use nova::{
     },
     traits::{
         circuit_supernova::{StepCircuit as SuperStepCircuit, TrivialSecondaryCircuit},
-        snark::default_commitment_key_hint,
+        snark::default_ck_hint,
         Group,
     },
 };
@@ -94,8 +94,8 @@ where
     // TODO: use `&*SS::commitment_key_floor()`, where `SS<G>: RelaxedR1CSSNARKTrait<G>`` when https://github.com/lurk-lab/arecibo/issues/27 closes
     let pp = SuperNovaPublicParams::<F, M>::new(
         &non_uniform_circuit,
-        &*default_commitment_key_hint(),
-        &*default_commitment_key_hint(),
+        &*default_ck_hint(),
+        &*default_ck_hint(),
     );
     PublicParams { pp }
 }


### PR DESCRIPTION
- companion PR to https://github.com/lurk-lab/arecibo/pull/115
- Renamed methods within `RelaxedR1CSSNARKTrait` in `src/proof/nova.rs`
- Updated the method name in `src/proof/supernova.rs` from `default_commitment_key_hint` to `default_ck_hint`