### PR TITLE
Implement `pack` and `unpack` commands

### DIFF
--- a/src/cli/commitment.rs
+++ b/src/cli/commitment.rs
@@ -13,7 +13,7 @@ use crate::{
 use super::{
     field_data::{dump, HasFieldModulus},
     paths::commitment_path,
-    zstore::{populate_z_store, ZStore},
+    zstore::ZStore,
 };
 
 /// Holds data for commitments.
@@ -37,7 +37,7 @@ impl<F: LurkField> Commitment<F> {
         let secret = secret.unwrap_or(F::NON_HIDING_COMMITMENT_SECRET);
         let (hash, z_payload) = store.hide_and_return_z_payload(secret, payload);
         let mut z_store = ZStore::<F>::default();
-        populate_z_store(&mut z_store, &payload, store, &mut HashMap::default());
+        z_store.populate_with(&payload, store, &mut HashMap::default());
         z_store.add_comm(hash, secret, z_payload);
         Self { hash, z_store }
     }

--- a/src/cli/lurk_proof.rs
+++ b/src/cli/lurk_proof.rs
@@ -1,16 +1,16 @@
-use std::{collections::HashMap, sync::Arc};
-
 use ::nova::{
     supernova::NonUniformCircuit,
     traits::{circuit_supernova::StepCircuit as SuperStepCircuit, Group},
 };
 use abomonation::Abomonation;
-use anyhow::Result;
+use anyhow::{bail, Result};
+use camino::Utf8PathBuf;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::{collections::HashMap, sync::Arc};
 
 use crate::{
     coprocessor::Coprocessor,
-    eval::lang::{Coproc, Lang},
+    eval::lang::Lang,
     field::LurkField,
     lem::{pointers::ZPtr, store::Store},
     proof::{
@@ -28,25 +28,17 @@ use crate::{
 use super::{
     field_data::{dump, load, HasFieldModulus},
     paths::{proof_meta_path, proof_path},
-    zstore::{populate_store, ZStore},
+    zstore::ZDag,
 };
 
-/// Carries extra information to help with visualization, experiments etc.
-///
-/// Note: the `ZStore` in this struct only has enough data to recover the meaning
-/// of the claim being proven: `expr`, when evaluated in the context of `env` and
-/// continuation `cont`, is reduced to `expr_out`, resulting on environment
-/// `env_out` and continuation `cont_out`. It doesn't contain private data.
+/// Carries information to help with visualization
 #[derive(Serialize, Deserialize)]
 pub(crate) struct LurkProofMeta<F: LurkField> {
     pub(crate) iterations: usize,
-    pub(crate) expr: ZPtr<F>,
-    pub(crate) env: ZPtr<F>,
-    pub(crate) cont: ZPtr<F>,
-    pub(crate) expr_out: ZPtr<F>,
-    pub(crate) env_out: ZPtr<F>,
-    pub(crate) cont_out: ZPtr<F>,
-    pub(crate) z_store: ZStore<F>,
+    pub(crate) expr_io: (ZPtr<F>, ZPtr<F>),
+    pub(crate) env_io: Option<(ZPtr<F>, ZPtr<F>)>,
+    pub(crate) cont_io: (ZPtr<F>, ZPtr<F>),
+    pub(crate) z_dag: ZDag<F>,
 }
 
 impl<F: LurkField> HasFieldModulus for LurkProofMeta<F> {
@@ -55,37 +47,42 @@ impl<F: LurkField> HasFieldModulus for LurkProofMeta<F> {
     }
 }
 
-/// Minimal data structure containing just enough for proof verification
-#[non_exhaustive]
-#[derive(Serialize, Deserialize)]
-#[serde(bound(serialize = "F: Serialize", deserialize = "F: DeserializeOwned"))]
-pub(crate) enum LurkProof<
-    'a,
-    F: CurveCycleEquipped,
-    C: Coprocessor<F>,
-    M: MultiFrameTrait<'a, F, C>,
-> where
-    <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
-    <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
-{
-    Nova {
-        proof: nova::Proof<'a, F, C, M>,
-        public_inputs: Vec<F>,
-        public_outputs: Vec<F>,
-        num_steps: usize,
-        rc: usize,
-        lang: Lang<F, Coproc<F>>,
-    },
-}
-
-impl<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a, M: MultiFrameTrait<'a, F, C>>
-    HasFieldModulus for LurkProof<'a, F, C, M>
+impl<
+        'a,
+        F: CurveCycleEquipped,
+        C: Coprocessor<F> + 'a + Serialize + DeserializeOwned,
+        M: MultiFrameTrait<'a, F, C>,
+    > HasFieldModulus for LurkProof<'a, F, C, M>
 where
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     fn field_modulus() -> String {
         F::MODULUS.to_owned()
+    }
+}
+
+impl<F: LurkField> LurkProofMeta<F> {
+    fn without_envs(self) -> Result<Self> {
+        if self.env_io.is_none() {
+            return Ok(self);
+        }
+        let Self {
+            iterations,
+            expr_io: (expr, expr_out),
+            env_io: _,
+            cont_io: (cont, cont_out),
+            z_dag,
+        } = self;
+        // creating a new `ZDag` without data from envs
+        let z_dag = z_dag.filtered(&[&expr, &expr_out, &cont, &cont_out])?;
+        Ok(Self {
+            iterations,
+            expr_io: (expr, expr_out),
+            env_io: None,
+            cont_io: (cont, cont_out),
+            z_dag,
+        })
     }
 }
 
@@ -102,29 +99,51 @@ impl<F: LurkField + DeserializeOwned> LurkProofMeta<F> {
         store_state: Option<(&Store<F>, &State)>,
         full: bool,
     ) -> Result<()> {
-        let proof_meta: LurkProofMeta<F> = load(&proof_meta_path(proof_key))?;
+        let Ok(proof_meta) = load::<LurkProofMeta<F>>(&proof_meta_path(proof_key)) else {
+            bail!("Missing or corrupted proof meta file. Prove again to regenerate.")
+        };
         let do_inspect = |store: &Store<F>, state: &State| {
             let mut cache = HashMap::default();
-            let z_store = &proof_meta.z_store;
-            let expr = populate_store(store, &proof_meta.expr, z_store, &mut cache)?;
-            let expr_out = populate_store(store, &proof_meta.expr_out, z_store, &mut cache)?;
+            let z_dag = &proof_meta.z_dag;
+            let (expr, expr_out) = &proof_meta.expr_io;
+            let expr = z_dag.populate_store(expr, store, &mut cache)?;
+            let expr_out = z_dag.populate_store(expr_out, store, &mut cache)?;
             if full {
-                let env = populate_store(store, &proof_meta.env, z_store, &mut cache)?;
-                let cont = populate_store(store, &proof_meta.cont, z_store, &mut cache)?;
-                let env_out = populate_store(store, &proof_meta.env_out, z_store, &mut cache)?;
-                let cont_out = populate_store(store, &proof_meta.cont_out, z_store, &mut cache)?;
-                println!(
-                    "Input:\n  Expr: {}\n  Env:  {}\n  Cont: {}",
-                    expr.fmt_to_string(store, state),
-                    env.fmt_to_string(store, state),
-                    cont.fmt_to_string(store, state),
-                );
-                println!(
-                    "Output:\n  Expr: {}\n  Env:  {}\n  Cont: {}",
-                    expr_out.fmt_to_string(store, state),
-                    env_out.fmt_to_string(store, state),
-                    cont_out.fmt_to_string(store, state),
-                );
+                let envs = match &proof_meta.env_io {
+                    Some((env, env_out)) => Some((
+                        z_dag.populate_store(env, store, &mut cache)?,
+                        z_dag.populate_store(env_out, store, &mut cache)?,
+                    )),
+                    None => None,
+                };
+                let (cont, cont_out) = &proof_meta.cont_io;
+                let cont = z_dag.populate_store(cont, store, &mut cache)?;
+                let cont_out = z_dag.populate_store(cont_out, store, &mut cache)?;
+                if let Some((env, env_out)) = envs {
+                    println!(
+                        "Input:\n  Expr: {}\n  Env:  {}\n  Cont: {}",
+                        expr.fmt_to_string(store, state),
+                        env.fmt_to_string(store, state),
+                        cont.fmt_to_string(store, state),
+                    );
+                    println!(
+                        "Output:\n  Expr: {}\n  Env:  {}\n  Cont: {}",
+                        expr_out.fmt_to_string(store, state),
+                        env_out.fmt_to_string(store, state),
+                        cont_out.fmt_to_string(store, state),
+                    );
+                } else {
+                    println!(
+                        "Input:\n  Expr: {}\n  Cont: {}",
+                        expr.fmt_to_string(store, state),
+                        cont.fmt_to_string(store, state),
+                    );
+                    println!(
+                        "Output:\n  Expr: {}\n  Cont: {}",
+                        expr_out.fmt_to_string(store, state),
+                        cont_out.fmt_to_string(store, state),
+                    );
+                }
             } else {
                 println!(
                     "Input:\n  {}\nOutput:\n  {}",
@@ -143,8 +162,35 @@ impl<F: LurkField + DeserializeOwned> LurkProofMeta<F> {
     }
 }
 
-impl<'a, F: CurveCycleEquipped + Serialize, M: MultiFrameTrait<'a, F, Coproc<F>>>
-    LurkProof<'a, F, Coproc<F>, M>
+/// Minimal data structure containing just enough for proof verification
+#[non_exhaustive]
+#[derive(Serialize, Deserialize)]
+#[serde(bound(serialize = "F: Serialize", deserialize = "F: DeserializeOwned"))]
+pub(crate) enum LurkProof<
+    'a,
+    F: CurveCycleEquipped,
+    C: Coprocessor<F> + Serialize + DeserializeOwned,
+    M: MultiFrameTrait<'a, F, C>,
+> where
+    <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+{
+    Nova {
+        proof: nova::Proof<'a, F, C, M>,
+        public_inputs: Vec<F>,
+        public_outputs: Vec<F>,
+        num_steps: usize,
+        rc: usize,
+        lang: Lang<F, C>,
+    },
+}
+
+impl<
+        'a,
+        F: CurveCycleEquipped + Serialize,
+        C: Coprocessor<F> + Serialize + DeserializeOwned,
+        M: MultiFrameTrait<'a, F, C>,
+    > LurkProof<'a, F, C, M>
 where
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
@@ -156,18 +202,19 @@ where
 }
 
 impl<
-        F: CurveCycleEquipped + DeserializeOwned,
-        M: MultiFrameTrait<'static, F, Coproc<F>>
+        F: CurveCycleEquipped + Serialize + DeserializeOwned,
+        C: Coprocessor<F> + Serialize + DeserializeOwned + 'static,
+        M: MultiFrameTrait<'static, F, C>
             + SuperStepCircuit<F>
             + NonUniformCircuit<G1<F>, G2<F>, M, C2<F>>
             + 'static,
-    > LurkProof<'static, F, Coproc<F>, M>
+    > LurkProof<'static, F, C, M>
 where
     <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     pub(crate) fn verify_proof(proof_key: &str) -> Result<()> {
-        let lurk_proof: LurkProof<'_, F, Coproc<F>, M> = load(&proof_path(proof_key))?;
+        let lurk_proof: LurkProof<'_, F, C, M> = load(&proof_path(proof_key))?;
         if lurk_proof.verify()? {
             println!("✓ Proof \"{proof_key}\" verified");
         } else {
@@ -176,7 +223,12 @@ where
         Ok(())
     }
 
-    fn verify(self) -> Result<bool> {
+    pub(crate) fn is_cached(proof_key: &str) -> bool {
+        let lurk_proof: Result<LurkProof<'_, F, C, M>> = load(&proof_path(proof_key));
+        lurk_proof.is_ok()
+    }
+
+    fn verify(&self) -> Result<bool> {
         match self {
             Self::Nova {
                 proof,
@@ -187,10 +239,94 @@ where
                 lang,
             } => {
                 tracing::info!("Loading public parameters");
-                let instance = Instance::new(rc, Arc::new(lang), true, Kind::NovaPublicParams);
+                let instance =
+                    Instance::new(*rc, Arc::new(lang.clone()), true, Kind::NovaPublicParams);
                 let pp = public_params(&instance)?;
-                Ok(proof.verify(&pp, num_steps, &public_inputs, &public_outputs)?)
+                Ok(proof.verify(&pp, *num_steps, public_inputs, public_outputs)?)
             }
         }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(bound(serialize = "F: Serialize", deserialize = "F: DeserializeOwned"))]
+pub(crate) struct PackedLurkProof<
+    'a,
+    F: CurveCycleEquipped,
+    C: Coprocessor<F> + Serialize + DeserializeOwned,
+    M: MultiFrameTrait<'a, F, C>,
+> where
+    <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+{
+    proof: LurkProof<'a, F, C, M>,
+    meta: Option<LurkProofMeta<F>>,
+    key: String,
+}
+
+impl<
+        'a,
+        F: CurveCycleEquipped,
+        C: Coprocessor<F> + 'a + Serialize + DeserializeOwned,
+        M: MultiFrameTrait<'a, F, C>,
+    > HasFieldModulus for PackedLurkProof<'a, F, C, M>
+where
+    <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+{
+    fn field_modulus() -> String {
+        F::MODULUS.to_owned()
+    }
+}
+
+impl<
+        F: CurveCycleEquipped + Serialize + DeserializeOwned,
+        C: Coprocessor<F> + 'static + Serialize + DeserializeOwned,
+        M: MultiFrameTrait<'static, F, C>
+            + SuperStepCircuit<F>
+            + NonUniformCircuit<G1<F>, G2<F>, M, C2<F>>
+            + 'static,
+    > PackedLurkProof<'static, F, C, M>
+where
+    <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+{
+    pub(crate) fn pack(
+        proof_key: String,
+        path: &Utf8PathBuf,
+        exclude_meta: bool,
+        include_envs: bool,
+    ) -> Result<()> {
+        let proof: LurkProof<'_, F, C, M> = load(&proof_path(&proof_key))?;
+        let meta = if exclude_meta {
+            None
+        } else {
+            let meta: LurkProofMeta<F> = load(&proof_meta_path(&proof_key))?;
+            if include_envs {
+                Some(meta)
+            } else {
+                Some(meta.without_envs()?)
+            }
+        };
+        let packed_proof = PackedLurkProof {
+            proof,
+            meta,
+            key: proof_key,
+        };
+        dump(packed_proof, path)
+    }
+
+    pub(crate) fn unpack(path: &Utf8PathBuf) -> Result<()> {
+        let packed_proof: PackedLurkProof<'_, F, C, M> = load(path)?;
+        let PackedLurkProof { proof, meta, key } = packed_proof;
+        if !proof.verify()? {
+            bail!("Proof verification failed")
+        }
+        proof.persist(&key)?;
+        if let Some(meta) = meta {
+            meta.persist(&key)?;
+        }
+        println!("Proof {key} unpacked");
+        Ok(())
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -36,7 +36,7 @@ use crate::cli::{
     zstore::ZStore,
 };
 
-use self::field_data::load;
+use self::{field_data::load, lurk_proof::PackedLurkProof};
 
 #[derive(Parser, Debug)]
 #[clap(version)]
@@ -61,6 +61,10 @@ enum Command {
     #[command(verbatim_doc_comment)]
     Circom(CircomArgs),
     PublicParams(PublicParamArgs),
+    /// Packs a proof on a file to be shared
+    Pack(PackArgs),
+    /// Unpacks a proof into Lurk's internal data storage
+    Unpack(UnpackArgs),
 }
 
 #[derive(Args, Debug)]
@@ -398,7 +402,7 @@ impl LoadCli {
         // Initializes CLI config with CLI arguments as overrides
         let config = cli_config(self.config.as_ref(), Some(&cli_settings));
 
-        create_lurk_dirs().unwrap();
+        create_lurk_dirs()?;
 
         let rc = config.rc;
         let limit = config.limit;
@@ -577,6 +581,52 @@ impl PublicParamArgs {
     }
 }
 
+#[derive(Args, Debug)]
+struct PackArgs {
+    /// Key of the proof to be packed
+    #[clap(value_parser)]
+    proof_key: String,
+
+    /// Path to the packed proof output
+    #[clap(long, short = 'o', value_parser)]
+    output: Utf8PathBuf,
+
+    /// Flag to exclude meta data
+    #[arg(long)]
+    exclude_meta: bool,
+
+    /// Flag to include envs in the meta data. Irrelevant if exclude_meta is true
+    #[arg(long)]
+    include_envs: bool,
+
+    /// Path to proofs directory
+    #[clap(long, value_parser)]
+    proofs_dir: Option<Utf8PathBuf>,
+
+    /// Config file, containing the lowest precedence parameters
+    #[clap(long, value_parser)]
+    config: Option<Utf8PathBuf>,
+}
+
+#[derive(Args, Debug)]
+struct UnpackArgs {
+    /// Packed proof path
+    #[clap(value_parser)]
+    proof_path: Utf8PathBuf,
+
+    /// Path to public parameters directory
+    #[clap(long, value_parser)]
+    public_params_dir: Option<Utf8PathBuf>,
+
+    /// Path to proofs directory
+    #[clap(long, value_parser)]
+    proofs_dir: Option<Utf8PathBuf>,
+
+    /// Config file, containing the lowest precedence parameters
+    #[clap(long, value_parser)]
+    config: Option<Utf8PathBuf>,
+}
+
 impl Cli {
     fn run(self) -> Result<()> {
         match self.command {
@@ -636,6 +686,33 @@ impl Cli {
 
                 create_lurk_dirs()?;
                 public_params_args.run()
+            }
+            Command::Pack(pack_args) => {
+                let mut cli_settings = HashMap::new();
+                if let Some(dir) = pack_args.proofs_dir {
+                    cli_settings.insert("proofs_dir", dir.to_string());
+                }
+                cli_config(pack_args.config.as_ref(), Some(&cli_settings));
+                PackedLurkProof::<_, _, MultiFrame<'_, _, Coproc<pallas::Scalar>>>::pack(
+                    pack_args.proof_key,
+                    &pack_args.output,
+                    pack_args.exclude_meta,
+                    pack_args.include_envs,
+                )
+            }
+            Command::Unpack(unpack_args) => {
+                let mut cli_settings = HashMap::new();
+                if let Some(dir) = unpack_args.public_params_dir {
+                    cli_settings.insert("public_params_dir", dir.to_string());
+                }
+                if let Some(dir) = unpack_args.proofs_dir {
+                    cli_settings.insert("proofs_dir", dir.to_string());
+                }
+                cli_config(unpack_args.config.as_ref(), Some(&cli_settings));
+                create_lurk_dirs()?;
+                PackedLurkProof::<_, _, MultiFrame<'_, _, Coproc<pallas::Scalar>>>::unpack(
+                    &unpack_args.proof_path,
+                )
             }
         }
     }

--- a/src/cli/zstore.rs
+++ b/src/cli/zstore.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::{
     field::{FWrap, LurkField},
@@ -23,10 +23,189 @@ pub(crate) enum ZPtrType<F: LurkField> {
     Tuple4(ZPtr<F>, ZPtr<F>, ZPtr<F>, ZPtr<F>),
 }
 
+/// Holds a mapping from `ZPtr`s to their `ZPtrType`s
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub(crate) struct ZDag<F: LurkField>(BTreeMap<ZPtr<F>, ZPtrType<F>>);
+
+impl<F: LurkField> ZDag<F> {
+    pub(crate) fn populate_with(
+        &mut self,
+        ptr: &Ptr<F>,
+        store: &Store<F>,
+        cache: &mut HashMap<Ptr<F>, ZPtr<F>>,
+    ) -> ZPtr<F> {
+        let mut recurse = |ptr: &Ptr<F>| -> ZPtr<F> {
+            if let Some(z_ptr) = cache.get(ptr) {
+                *z_ptr
+            } else {
+                let z_ptr = match ptr {
+                    Ptr::Atom(tag, f) => {
+                        let z_ptr = ZPtr::from_parts(*tag, *f);
+                        self.0.insert(z_ptr, ZPtrType::Atom);
+                        z_ptr
+                    }
+                    Ptr::Tuple2(tag, idx) => {
+                        let (a, b) = store.expect_2_ptrs(*idx);
+                        let a = self.populate_with(a, store, cache);
+                        let b = self.populate_with(b, store, cache);
+                        let z_ptr = ZPtr::from_parts(
+                            *tag,
+                            store.poseidon_cache.hash4(&[
+                                a.tag_field(),
+                                *a.value(),
+                                b.tag_field(),
+                                *b.value(),
+                            ]),
+                        );
+                        self.0.insert(z_ptr, ZPtrType::Tuple2(a, b));
+                        z_ptr
+                    }
+                    Ptr::Tuple3(tag, idx) => {
+                        let (a, b, c) = store.expect_3_ptrs(*idx);
+                        let a = self.populate_with(a, store, cache);
+                        let b = self.populate_with(b, store, cache);
+                        let c = self.populate_with(c, store, cache);
+                        let z_ptr = ZPtr::from_parts(
+                            *tag,
+                            store.poseidon_cache.hash6(&[
+                                a.tag_field(),
+                                *a.value(),
+                                b.tag_field(),
+                                *b.value(),
+                                c.tag_field(),
+                                *c.value(),
+                            ]),
+                        );
+                        self.0.insert(z_ptr, ZPtrType::Tuple3(a, b, c));
+                        z_ptr
+                    }
+                    Ptr::Tuple4(tag, idx) => {
+                        let (a, b, c, d) = store.expect_4_ptrs(*idx);
+                        let a = self.populate_with(a, store, cache);
+                        let b = self.populate_with(b, store, cache);
+                        let c = self.populate_with(c, store, cache);
+                        let d = self.populate_with(d, store, cache);
+                        let z_ptr = ZPtr::from_parts(
+                            *tag,
+                            store.poseidon_cache.hash8(&[
+                                a.tag_field(),
+                                *a.value(),
+                                b.tag_field(),
+                                *b.value(),
+                                c.tag_field(),
+                                *c.value(),
+                                d.tag_field(),
+                                *d.value(),
+                            ]),
+                        );
+                        self.0.insert(z_ptr, ZPtrType::Tuple4(a, b, c, d));
+                        z_ptr
+                    }
+                };
+                cache.insert(*ptr, z_ptr);
+                z_ptr
+            }
+        };
+        recurse(ptr)
+    }
+
+    fn get_type(&self, z_ptr: &ZPtr<F>) -> Option<&ZPtrType<F>> {
+        self.0.get(z_ptr)
+    }
+
+    pub(crate) fn populate_store(
+        &self,
+        z_ptr: &ZPtr<F>,
+        store: &Store<F>,
+        cache: &mut HashMap<ZPtr<F>, Ptr<F>>,
+    ) -> Result<Ptr<F>> {
+        let mut recurse = |z_ptr: &ZPtr<F>| -> Result<Ptr<F>> {
+            if let Some(z_ptr) = cache.get(z_ptr) {
+                Ok(*z_ptr)
+            } else {
+                let ptr = match self.get_type(z_ptr) {
+                    None => bail!("Couldn't find ZPtr on ZStore"),
+                    Some(ZPtrType::Atom) => Ptr::Atom(*z_ptr.tag(), *z_ptr.value()),
+                    Some(ZPtrType::Tuple2(z1, z2)) => {
+                        let ptr1 = self.populate_store(z1, store, cache)?;
+                        let ptr2 = self.populate_store(z2, store, cache)?;
+                        store.intern_2_ptrs_hydrated(*z_ptr.tag(), ptr1, ptr2, *z_ptr)
+                    }
+                    Some(ZPtrType::Tuple3(z1, z2, z3)) => {
+                        let ptr1 = self.populate_store(z1, store, cache)?;
+                        let ptr2 = self.populate_store(z2, store, cache)?;
+                        let ptr3 = self.populate_store(z3, store, cache)?;
+                        store.intern_3_ptrs_hydrated(*z_ptr.tag(), ptr1, ptr2, ptr3, *z_ptr)
+                    }
+                    Some(ZPtrType::Tuple4(z1, z2, z3, z4)) => {
+                        let ptr1 = self.populate_store(z1, store, cache)?;
+                        let ptr2 = self.populate_store(z2, store, cache)?;
+                        let ptr3 = self.populate_store(z3, store, cache)?;
+                        let ptr4 = self.populate_store(z4, store, cache)?;
+                        store.intern_4_ptrs_hydrated(*z_ptr.tag(), ptr1, ptr2, ptr3, ptr4, *z_ptr)
+                    }
+                };
+                cache.insert(*z_ptr, ptr);
+                Ok(ptr)
+            }
+        };
+        recurse(z_ptr)
+    }
+
+    /// Populates a `ZDag` with data from self
+    pub(crate) fn populate_z_dag(
+        &self,
+        z_ptr: &ZPtr<F>,
+        z_dag: &mut ZDag<F>,
+        cache: &mut HashSet<ZPtr<F>>,
+    ) -> Result<()> {
+        let mut recurse = |z_ptr: &ZPtr<F>| -> Result<()> {
+            if !cache.contains(z_ptr) {
+                match self.get_type(z_ptr) {
+                    None => bail!("Couldn't find ZPtr on ZStore"),
+                    Some(ZPtrType::Atom) => {
+                        z_dag.0.insert(*z_ptr, ZPtrType::Atom);
+                    }
+                    Some(ZPtrType::Tuple2(z1, z2)) => {
+                        self.populate_z_dag(z1, z_dag, cache)?;
+                        self.populate_z_dag(z2, z_dag, cache)?;
+                        z_dag.0.insert(*z_ptr, ZPtrType::Tuple2(*z1, *z2));
+                    }
+                    Some(ZPtrType::Tuple3(z1, z2, z3)) => {
+                        self.populate_z_dag(z1, z_dag, cache)?;
+                        self.populate_z_dag(z2, z_dag, cache)?;
+                        self.populate_z_dag(z3, z_dag, cache)?;
+                        z_dag.0.insert(*z_ptr, ZPtrType::Tuple3(*z1, *z2, *z3));
+                    }
+                    Some(ZPtrType::Tuple4(z1, z2, z3, z4)) => {
+                        self.populate_z_dag(z1, z_dag, cache)?;
+                        self.populate_z_dag(z2, z_dag, cache)?;
+                        self.populate_z_dag(z3, z_dag, cache)?;
+                        self.populate_z_dag(z4, z_dag, cache)?;
+                        z_dag.0.insert(*z_ptr, ZPtrType::Tuple4(*z1, *z2, *z3, *z4));
+                    }
+                };
+                cache.insert(*z_ptr);
+            }
+            Ok(())
+        };
+        recurse(z_ptr)
+    }
+
+    pub(crate) fn filtered(&self, z_ptrs: &[&ZPtr<F>]) -> Result<Self> {
+        let mut z_dag_new = ZDag::default();
+        let mut cache = HashSet::default();
+        for z_ptr in z_ptrs {
+            self.populate_z_dag(z_ptr, &mut z_dag_new, &mut cache)?;
+        }
+        Ok(z_dag_new)
+    }
+}
+
 /// A `ZStore` is a stable IO format for `Store`, without index-based references
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub(crate) struct ZStore<F: LurkField> {
-    dag: BTreeMap<ZPtr<F>, ZPtrType<F>>,
+    z_dag: ZDag<F>,
     comms: BTreeMap<FWrap<F>, (F, ZPtr<F>)>,
 }
 
@@ -47,141 +226,35 @@ impl<F: LurkField> ZStore<F> {
         self.comms.get(&FWrap(hash))
     }
 
-    #[inline]
-    pub(crate) fn get_type(&self, z_ptr: &ZPtr<F>) -> Option<&ZPtrType<F>> {
-        self.dag.get(z_ptr)
-    }
-
     pub(crate) fn to_store(&self) -> Result<Store<F>> {
         let store = Store::default();
         let mut cache = HashMap::default();
-        for z_ptr in self.dag.keys() {
-            populate_store(&store, z_ptr, self, &mut cache)?;
+        for z_ptr in self.z_dag.0.keys() {
+            self.populate_store(z_ptr, &store, &mut cache)?;
         }
         for (hash, (secret, z_payload)) in &self.comms {
-            let payload = populate_store(&store, z_payload, self, &mut cache)?;
+            let payload = self.populate_store(z_payload, &store, &mut cache)?;
             store.add_comm(hash.0, *secret, payload);
         }
         Ok(store)
     }
-}
 
-pub(crate) fn populate_z_store<F: LurkField>(
-    z_store: &mut ZStore<F>,
-    ptr: &Ptr<F>,
-    store: &Store<F>,
-    cache: &mut HashMap<Ptr<F>, ZPtr<F>>,
-) -> ZPtr<F> {
-    let mut recurse = |ptr: &Ptr<F>| -> ZPtr<F> {
-        if let Some(z_ptr) = cache.get(ptr) {
-            *z_ptr
-        } else {
-            let z_ptr = match ptr {
-                Ptr::Atom(tag, f) => {
-                    let z_ptr = ZPtr::from_parts(*tag, *f);
-                    z_store.dag.insert(z_ptr, ZPtrType::Atom);
-                    z_ptr
-                }
-                Ptr::Tuple2(tag, idx) => {
-                    let (a, b) = store.expect_2_ptrs(*idx);
-                    let a = populate_z_store(z_store, a, store, cache);
-                    let b = populate_z_store(z_store, b, store, cache);
-                    let z_ptr = ZPtr::from_parts(
-                        *tag,
-                        store.poseidon_cache.hash4(&[
-                            a.tag_field(),
-                            *a.value(),
-                            b.tag_field(),
-                            *b.value(),
-                        ]),
-                    );
-                    z_store.dag.insert(z_ptr, ZPtrType::Tuple2(a, b));
-                    z_ptr
-                }
-                Ptr::Tuple3(tag, idx) => {
-                    let (a, b, c) = store.expect_3_ptrs(*idx);
-                    let a = populate_z_store(z_store, a, store, cache);
-                    let b = populate_z_store(z_store, b, store, cache);
-                    let c = populate_z_store(z_store, c, store, cache);
-                    let z_ptr = ZPtr::from_parts(
-                        *tag,
-                        store.poseidon_cache.hash6(&[
-                            a.tag_field(),
-                            *a.value(),
-                            b.tag_field(),
-                            *b.value(),
-                            c.tag_field(),
-                            *c.value(),
-                        ]),
-                    );
-                    z_store.dag.insert(z_ptr, ZPtrType::Tuple3(a, b, c));
-                    z_ptr
-                }
-                Ptr::Tuple4(tag, idx) => {
-                    let (a, b, c, d) = store.expect_4_ptrs(*idx);
-                    let a = populate_z_store(z_store, a, store, cache);
-                    let b = populate_z_store(z_store, b, store, cache);
-                    let c = populate_z_store(z_store, c, store, cache);
-                    let d = populate_z_store(z_store, d, store, cache);
-                    let z_ptr = ZPtr::from_parts(
-                        *tag,
-                        store.poseidon_cache.hash8(&[
-                            a.tag_field(),
-                            *a.value(),
-                            b.tag_field(),
-                            *b.value(),
-                            c.tag_field(),
-                            *c.value(),
-                            d.tag_field(),
-                            *d.value(),
-                        ]),
-                    );
-                    z_store.dag.insert(z_ptr, ZPtrType::Tuple4(a, b, c, d));
-                    z_ptr
-                }
-            };
-            cache.insert(*ptr, z_ptr);
-            z_ptr
-        }
-    };
-    recurse(ptr)
-}
+    #[inline]
+    pub(crate) fn populate_with(
+        &mut self,
+        ptr: &Ptr<F>,
+        store: &Store<F>,
+        cache: &mut HashMap<Ptr<F>, ZPtr<F>>,
+    ) -> ZPtr<F> {
+        self.z_dag.populate_with(ptr, store, cache)
+    }
 
-pub(crate) fn populate_store<F: LurkField>(
-    store: &Store<F>,
-    z_ptr: &ZPtr<F>,
-    z_store: &ZStore<F>,
-    cache: &mut HashMap<ZPtr<F>, Ptr<F>>,
-) -> Result<Ptr<F>> {
-    let mut recurse = |z_ptr: &ZPtr<F>| -> Result<Ptr<F>> {
-        if let Some(z_ptr) = cache.get(z_ptr) {
-            Ok(*z_ptr)
-        } else {
-            let ptr = match z_store.get_type(z_ptr) {
-                None => bail!("Couldn't find ZPtr on ZStore"),
-                Some(ZPtrType::Atom) => Ptr::Atom(*z_ptr.tag(), *z_ptr.value()),
-                Some(ZPtrType::Tuple2(z1, z2)) => {
-                    let ptr1 = populate_store(store, z1, z_store, cache)?;
-                    let ptr2 = populate_store(store, z2, z_store, cache)?;
-                    store.intern_2_ptrs_hydrated(*z_ptr.tag(), ptr1, ptr2, *z_ptr)
-                }
-                Some(ZPtrType::Tuple3(z1, z2, z3)) => {
-                    let ptr1 = populate_store(store, z1, z_store, cache)?;
-                    let ptr2 = populate_store(store, z2, z_store, cache)?;
-                    let ptr3 = populate_store(store, z3, z_store, cache)?;
-                    store.intern_3_ptrs_hydrated(*z_ptr.tag(), ptr1, ptr2, ptr3, *z_ptr)
-                }
-                Some(ZPtrType::Tuple4(z1, z2, z3, z4)) => {
-                    let ptr1 = populate_store(store, z1, z_store, cache)?;
-                    let ptr2 = populate_store(store, z2, z_store, cache)?;
-                    let ptr3 = populate_store(store, z3, z_store, cache)?;
-                    let ptr4 = populate_store(store, z4, z_store, cache)?;
-                    store.intern_4_ptrs_hydrated(*z_ptr.tag(), ptr1, ptr2, ptr3, ptr4, *z_ptr)
-                }
-            };
-            cache.insert(*z_ptr, ptr);
-            Ok(ptr)
-        }
-    };
-    recurse(z_ptr)
+    pub(crate) fn populate_store(
+        &self,
+        z_ptr: &ZPtr<F>,
+        store: &Store<F>,
+        cache: &mut HashMap<ZPtr<F>, Ptr<F>>,
+    ) -> Result<Ptr<F>> {
+        self.z_dag.populate_store(z_ptr, store, cache)
+    }
 }


### PR DESCRIPTION
This PR implements the `pack` and `unpack` commands, which are meant to support proof sharing safely.

Proof meta files now carry a `ZDag`, which are incapable of holding commitment secrets *by definition*, mitigating a concern raised in [Zulip](https://zulip.lurk-lab.com/#narrow/stream/17-lurk/topic/Using.20Lurk.20in.20a.20protocol/near/127889)