### PR TITLE
Remove premature padding from evaluation

### DIFF
--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -112,11 +112,6 @@ fn build_frames<
         }
         pc = get_pc(&expr, store, lang);
     }
-    // TODO: remove this after #729 is merged
-    if iterations < limit {
-        let frame = lurk_step.call_simple(&input, store, lang, pc)?;
-        frames.push(frame);
-    }
     Ok((frames, iterations))
 }
 

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -204,7 +204,6 @@ pub trait Prover<'a, F: LurkField, C: Coprocessor<F> + 'a, M: MultiFrameTrait<'a
 
     /// Returns the expected total number of iterations for the prover given raw iterations.
     fn expected_total_iterations(&self, raw_iterations: usize) -> usize {
-        let raw_iterations = raw_iterations + 1;
         let cfc = self.reduction_count();
         let full_multiframe_count = raw_iterations / cfc;
         let unfull_multiframe_frame_count = raw_iterations % cfc;


### PR DESCRIPTION
This PR removes the premature creation of a padding frame during evaluation, which is already performed later, if needed, during the creation of the multi-frames.

It targets an item of #716

Closes #729 