### PR TITLE
Start slots witnesses with known capacities

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -6,7 +6,7 @@
 //! relating this field to the expresions of the language.
 use clap::ValueEnum;
 use ff::{PrimeField, PrimeFieldBits};
-use nova::provider::bn256_grumpkin::bn256;
+use nova::provider::bn256_grumpkin::{bn256, grumpkin};
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use std::hash::Hash;
@@ -270,6 +270,10 @@ impl LurkField for pasta_curves::vesta::Scalar {
 
 impl LurkField for bn256::Scalar {
     const FIELD: LanguageField = LanguageField::BN256;
+}
+
+impl LurkField for grumpkin::Scalar {
+    const FIELD: LanguageField = LanguageField::Grumpkin;
 }
 
 // The impl LurkField for grumpkin::Scalar is technically possible, but voluntarily omitted to avoid confusion.

--- a/src/lem/circuit.rs
+++ b/src/lem/circuit.rs
@@ -1594,10 +1594,10 @@ impl Func {
         };
 
         // fixed cost for each slot
-        let slot_constraints = 289 * self.slots_count.hash4
-            + 337 * self.slots_count.hash6
-            + 388 * self.slots_count.hash8
-            + 265 * self.slots_count.commitment
+        let slot_constraints = store.hash4_cost() * self.slots_count.hash4
+            + store.hash6_cost() * self.slots_count.hash6
+            + store.hash8_cost() * self.slots_count.hash8
+            + store.hash3_cost() * self.slots_count.commitment
             + bit_decomp_cost * self.slots_count.bit_decomp;
         let num_constraints = recurse(&self.body, globals, store, false);
         slot_constraints + num_constraints + globals.len()

--- a/src/lem/store.rs
+++ b/src/lem/store.rs
@@ -1,10 +1,12 @@
 use anyhow::{bail, Result};
 use arc_swap::ArcSwap;
+use bellpepper::util_cs::witness_cs::SizedWitness;
 use elsa::{
     sync::{FrozenMap, FrozenVec},
     sync_index_set::FrozenIndexSet,
 };
 use indexmap::IndexSet;
+use neptune::Poseidon;
 use nom::{sequence::preceded, Parser};
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use std::{cell::RefCell, rc::Rc, sync::Arc};
@@ -102,6 +104,30 @@ impl<F: LurkField> Default for Store<F> {
 }
 
 impl<F: LurkField> Store<F> {
+    /// Cost of poseidon hash with arity 3, including the input
+    #[inline]
+    pub fn hash3_cost(&self) -> usize {
+        Poseidon::new(self.poseidon_cache.constants.c3()).num_aux() + 1
+    }
+
+    /// Cost of poseidon hash with arity 4, including the input
+    #[inline]
+    pub fn hash4_cost(&self) -> usize {
+        Poseidon::new(self.poseidon_cache.constants.c4()).num_aux() + 1
+    }
+
+    /// Cost of poseidon hash with arity 6, including the input
+    #[inline]
+    pub fn hash6_cost(&self) -> usize {
+        Poseidon::new(self.poseidon_cache.constants.c6()).num_aux() + 1
+    }
+
+    /// Cost of poseidon hash with arity 8, including the input
+    #[inline]
+    pub fn hash8_cost(&self) -> usize {
+        Poseidon::new(self.poseidon_cache.constants.c8()).num_aux() + 1
+    }
+
     /// Creates a `Ptr` that's a parent of two children
     pub fn intern_2_ptrs(&self, tag: Tag, a: Ptr<F>, b: Ptr<F>) -> Ptr<F> {
         let (idx, inserted) = self.tuple2.insert_probe(Box::new((a, b)));


### PR DESCRIPTION
I got some improvements for synthesis on my machine:
```text
synthesis/Synthesis-rc/8                                                                            
                        time:   [6.2669 ms 6.4224 ms 6.5533 ms]
                        change: [-6.2341% -3.8673% -1.8713%] (p = 0.00 < 0.05)
                        Performance has improved.
synthesis/Synthesis-rc/16                                                                            
                        time:   [4.7671 ms 4.8198 ms 4.8714 ms]
                        change: [-2.9545% -1.6521% -0.4143%] (p = 0.02 < 0.05)
                        Change within noise threshold.
synthesis/Synthesis-rc/24                                                                            
                        time:   [6.7224 ms 6.7568 ms 6.7920 ms]
                        change: [-1.6682% -0.9685% -0.2239%] (p = 0.01 < 0.05)
                        Change within noise threshold.
synthesis/Synthesis-rc/32                                                                            
                        time:   [8.4923 ms 8.5334 ms 8.5706 ms]
                        change: [-2.4480% -1.7619% -1.1174%] (p = 0.00 < 0.05)
                        Performance has improved.
synthesis/Synthesis-rc/64                                                                            
                        time:   [13.447 ms 13.493 ms 13.539 ms]
                        change: [-0.8879% -0.3201% +0.2570%] (p = 0.30 > 0.05)
                        No change in performance detected.
synthesis/Synthesis-rc/128                                                                           
                        time:   [37.025 ms 37.278 ms 37.523 ms]
                        change: [-3.4201% -2.5735% -1.7471%] (p = 0.00 < 0.05)
                        Performance has improved.
synthesis/Synthesis-rc/256                                                                           
                        time:   [62.348 ms 62.594 ms 62.824 ms]
                        change: [-0.7295% -0.0956% +0.4956%] (p = 0.77 > 0.05)
                        No change in performance detected.
synthesis/Synthesis-rc/512                                                                           
                        time:   [111.31 ms 111.61 ms 111.88 ms]
                        change: [+0.6540% +0.9731% +1.2892%] (p = 0.00 < 0.05)
                        Change within noise threshold.
```