### PR TITLE
Add `Op::Unit` for general purpose debugging or data collection

### DIFF
--- a/src/lem/circuit.rs
+++ b/src/lem/circuit.rs
@@ -984,7 +984,7 @@ fn synthesize_block<F: LurkField, CS: ConstraintSystem<F>, C: Coprocessor<F>>(
                 bound_allocations.insert_ptr(tgt[0].clone(), div_ptr);
                 bound_allocations.insert_ptr(tgt[1].clone(), rem_ptr);
             }
-            Op::Emit(_) => (),
+            Op::Emit(_) | Op::Unit(_) => (),
             Op::Hide(tgt, sec, pay) => {
                 let sec = bound_allocations.get_ptr(sec)?;
                 let pay = bound_allocations.get_ptr(pay)?;
@@ -1501,7 +1501,7 @@ impl Func {
                         // three implies_u64, one sub and one linear
                         num_constraints += 197;
                     }
-                    Op::Not(..) | Op::Emit(_) | Op::Cproc(..) | Op::Copy(..) => (),
+                    Op::Not(..) | Op::Emit(_) | Op::Cproc(..) | Op::Copy(..) | Op::Unit(_) => (),
                     Op::Cons2(_, tag, _) => {
                         // tag for the image
                         globals.insert(FWrap(tag.to_field()));

--- a/src/lem/interpreter.rs
+++ b/src/lem/interpreter.rs
@@ -434,6 +434,7 @@ impl Block {
                     bindings.insert_ptr(tgt_secret.clone(), Ptr::Atom(Tag::Expr(Num), *secret));
                     hints.commitment.push(Some(SlotData::FPtr(*secret, *ptr)))
                 }
+                Op::Unit(f) => f(),
             }
         }
         match &self.ctrl {

--- a/src/lem/macros.rs
+++ b/src/lem/macros.rs
@@ -208,6 +208,9 @@ macro_rules! op {
             let func = Box::new($func.clone());
             $crate::lem::Op::Call(out, func, inp)
         }
+    };
+    ( unit($f:expr) ) => {
+        $crate::lem::Op::Unit($f)
     }
 }
 
@@ -587,6 +590,16 @@ macro_rules! block {
             {
                 $($limbs)*
                 $crate::op!(let ($sec, $src) = open($hash) )
+            },
+            $($tail)*
+        )
+    };
+    (@seq {$($limbs:expr)*}, unit($f:expr) ; $($tail:tt)*) => {
+        $crate::block! (
+            @seq
+            {
+                $($limbs)*
+                $crate::op!(unit($f))
             },
             $($tail)*
         )

--- a/src/lem/mod.rs
+++ b/src/lem/mod.rs
@@ -296,6 +296,7 @@ pub enum Op {
     /// `Open(s, p, h)` binds `s` and `p` to the secret and payload (respectively)
     /// of the commitment that resulted on (num or comm) `h`
     Open(Var, Var, Var),
+    Unit(fn()),
 }
 
 impl Func {
@@ -451,6 +452,7 @@ impl Func {
                         is_unique(tgt_secret, map);
                         is_unique(tgt_ptr, map);
                     }
+                    Op::Unit(_) => (),
                 }
             }
             match &block.ctrl {
@@ -735,6 +737,9 @@ impl Block {
                     let sec = insert_one(map, uniq, &sec);
                     let pay = insert_one(map, uniq, &pay);
                     ops.push(Op::Open(sec, pay, comm_or_num))
+                }
+                Op::Unit(x) => {
+                    ops.push(Op::Unit(x));
                 }
             }
         }


### PR DESCRIPTION
This PR implements LEM units as Rust closures for general debugging or data collection purposes.

For example, if we add `unit(...);` in the model, as in:
```rust
// binops
let (op) = get_binop(head);
let op_is_nil = eq_tag(op, nil);
if !op_is_nil {
    if !rest_is_nil {
        let (arg1, more) = decons2(rest);
        let more_is_nil = eq_tag(more, nil);
        if !more_is_nil {
            unit(|| println!("starting a binop"));
            let cont: Cont::Binop = cons4(op, env, more, cont);
            return (arg1, env, cont, ret);
        }
        return (expr, env, err, errctrl);
    }
    return (expr, env, err, errctrl);
}
```
The interpreter will run that closure and this is what we see in the REPL:
```text
Lurk REPL welcomes you.
user> (+ 1 1)
starting a binop
[3 iterations] => 2
```

With that closure we can do tracing etc. The goal is to move towards the level of flexibility we had in Alpha, when the model was already Rust code