### PR TITLE
Improving some parts of the proving pipeline

### DIFF
--- a/benches/synthesis.rs
+++ b/benches/synthesis.rs
@@ -55,9 +55,7 @@ fn synthesize<M: measurement::Measurement>(
             let folding_config =
                 Arc::new(FoldingConfig::new_ivc(lang_rc.clone(), *reduction_count));
 
-            let multiframe =
-                MultiFrame::from_frames(*reduction_count, &frames, &store, &folding_config)[0]
-                    .clone();
+            let multiframe = MultiFrame::from_frames(&frames, &store, &folding_config)[0].clone();
 
             b.iter_batched(
                 || (multiframe.clone()), // avoid cloning the frames in the benchmark

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -149,19 +149,10 @@ pub trait MultiFrameTrait<'a, F: LurkField, C: Coprocessor<F> + 'a>:
 
     /// Create an instance from some `Self::Frame`s.
     fn from_frames(
-        reduction_count: usize,
         frames: &[Self::EvalFrame],
         store: &'a Self::Store,
         folding_config: &Arc<FoldingConfig<F, C>>,
     ) -> Vec<Self>;
-
-    /// Make a dummy instance, duplicating `self`'s final `CircuitFrame`.
-    fn make_dummy(
-        reduction_count: usize,
-        circuit_frame: Option<Self::CircuitFrame>,
-        store: &'a Self::Store,
-        folding_config: Arc<FoldingConfig<F, C>>,
-    ) -> Self;
 }
 
 /// Represents a sequential Constraint System for a given proof.
@@ -173,8 +164,8 @@ pub trait Provable<F: LurkField> {
     fn public_inputs(&self) -> Vec<F>;
     /// Returns the size of the public inputs.
     fn public_input_size(&self) -> usize;
-    /// Returns the number of reductions in the provable structure.
-    fn reduction_count(&self) -> usize;
+    /// Returns the number of reduction frames in the provable structure.
+    fn num_frames(&self) -> usize;
 }
 
 /// A trait for a prover that works with a field `F`.

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -280,7 +280,7 @@ where
         let z0 = M::io_to_scalar_vector(store, frames[0].input());
         let zi = M::io_to_scalar_vector(store, frames.last().unwrap().output());
         let folding_config = Arc::new(FoldingConfig::new_ivc(lang.clone(), self.reduction_count()));
-        let circuits = M::from_frames(self.reduction_count(), frames, store, &folding_config);
+        let circuits = M::from_frames(frames, store, &folding_config);
 
         let num_steps = circuits.len();
         let proof = Proof::prove_recursively(

--- a/src/proof/tests/mod.rs
+++ b/src/proof/tests/mod.rs
@@ -161,7 +161,7 @@ where
 
     let folding_config = Arc::new(FoldingConfig::new_ivc(lang, nova_prover.reduction_count()));
 
-    let multiframes = M::from_frames(nova_prover.reduction_count(), &frames, s, &folding_config);
+    let multiframes = M::from_frames(&frames, s, &folding_config);
     let len = multiframes.len();
 
     let adjusted_iterations = nova_prover.expected_total_iterations(expected_iterations);


### PR DESCRIPTION
* Mitigate the overloading of "reduction_count" across the folding config and the number of frames in a MultiFrame
* Drop the duplicated "reduction count" information that was passed to `MultiFrameTrait::from_frames`
* Drop the unused `make_dummy`

Context: when we only had IVC, the number of frames in a `MultiFrame` was always exactly the `reduction_count`. But now that we have NIVC and some `MultiFrame`s can have different numbers of frames (the ones related to coprocessors only have one frame), the `MultiFrame`'s `reduction_count` attribute became confusing. This PR changes its name to `num_frames`.

Targets an item of #716