### PR TITLE
Fix rough edges for padding in our pipeline

### DIFF
--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -103,14 +103,14 @@ pub trait MultiFrameTrait<'a, F: LurkField, C: Coprocessor<F> + 'a>:
     /// Counting the number of non-trivial frames in the evaluation
     fn significant_frame_count(frames: &[Self::EvalFrame]) -> usize;
 
-    /// Evaluates and generates the frames of the computation given the expression, environment, and store (IVC only, TODO NIVC)
-    fn get_evaluation_frames(
-        padding_predicate: impl Fn(usize) -> bool, // Determines if the prover needs padding for a given total number of frames
+    /// Evaluates and generates the frames of the computation given the expression, environment, and store
+    fn build_frames(
         expr: Self::Ptr,
         env: Self::Ptr,
         store: &Self::Store,
         limit: usize,
-        land: &Lang<F, C>,
+        lang: &Lang<F, C>,
+        ivc: bool,
     ) -> Result<Vec<Self::EvalFrame>, ProofError>;
 
     /// Returns a public IO vector when equipped with the local store, and the Self::Frame's IO

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -305,14 +305,7 @@ where
         limit: usize,
         lang: &Arc<Lang<F, C>>,
     ) -> Result<(Proof<'a, F, C, M>, Vec<F>, Vec<F>, usize), ProofError> {
-        let frames = M::get_evaluation_frames(
-            |count| self.needs_frame_padding(count),
-            expr,
-            env,
-            store,
-            limit,
-            lang,
-        )?;
+        let frames = M::build_frames(expr, env, store, limit, lang, true)?;
         self.prove(pp, &frames, store, lang)
     }
 }

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -289,14 +289,7 @@ where
         limit: usize,
         lang: Arc<Lang<F, C>>,
     ) -> Result<(Proof<'a, F, C, M>, Vec<F>, Vec<F>, usize, usize), ProofError> {
-        let frames = M::get_evaluation_frames(
-            |count| self.needs_frame_padding(count),
-            expr,
-            env,
-            store,
-            limit,
-            &lang,
-        )?;
+        let frames = M::build_frames(expr, env, store, limit, &lang, false)?;
         info!("got {} evaluation frames", frames.len());
         self.prove(pp, &frames, store, lang)
     }

--- a/src/proof/tests/mod.rs
+++ b/src/proof/tests/mod.rs
@@ -133,15 +133,7 @@ where
     let e = s.initial_empty_env();
 
     let nova_prover = NovaProver::<'a, F, C, M>::new(reduction_count, (*lang).clone());
-    let frames = M::get_evaluation_frames(
-        |frame_count| nova_prover.needs_frame_padding(frame_count),
-        expr,
-        e,
-        s,
-        limit,
-        &lang,
-    )
-    .unwrap();
+    let frames = M::build_frames(expr, e, s, limit, &lang, true).unwrap();
 
     if check_nova {
         let pp = public_params::<_, _, M>(reduction_count, lang.clone());


### PR DESCRIPTION
* Rename `get_evaluation_frames` to `build_frames`
* Eliminate padding predicate from `build_frames`
* Let `build_frames` know whether we're on IVC or NIVC context
* Fix a bug in the frame building for NIVC with the above

Context: padding is no longer a responsibility of the evaluation phase so `build_frames` doesn't need to know about a padding predicate