### PR TITLE
ci: Cache PR benchmarks on `gh-pages`

### DIFF
--- a/.github/workflows/merge-tests.yml
+++ b/.github/workflows/merge-tests.yml
@@ -89,49 +89,67 @@ jobs:
         run: |
           cargo install cargo-criterion
           cargo install criterion-table
+      - name: Set bench output format and base SHA
+        run: |
+          echo "LURK_BENCH_OUTPUT=commit-comment" | tee -a $GITHUB_ENV
+          echo "BASE_COMMIT=${{ github.event.merge_group.base_sha }}" | tee -a $GITHUB_ENV
+          echo "GPU_NAME=$(nvidia-smi --query-gpu=gpu_name --format=csv,noheader,nounits | tail -n1)" | tee -a $GITHUB_ENV
+      # Checkout gh-pages to check for cached bench result
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages
+      - name: Check for cached bench result
+        id: cached-bench
+        run: |
+          if [ -f "${{ env.BASE_COMMIT }}-${{ env.GPU_NAME }}.json" ]
+          then
+            echo "cached=true" | tee -a $GITHUB_OUTPUT
+            cp ${{ env.BASE_COMMIT }}-${{ env.GPU_NAME }}.json ../${{ env.BASE_COMMIT }}.json
+          else
+            echo "cached=false" | tee -a $GITHUB_OUTPUT
+          fi
+        working-directory: ${{ github.workspace }}/gh-pages
       # Checkout base branch for comparative bench
       - uses: actions/checkout@v4
+        if: steps.cached-bench.outputs.cached == 'false'
         with:
           ref: main
           path: main
       # Copy the script so the base can bench with the same parameters
-      - name: Copy source script to base branch
-        run: cp justfile bench.env ../main/benches
-        working-directory: ${{ github.workspace }}/benches
-      - name: Set base ref variable
-        run: echo "BASE_REF=$(git rev-parse HEAD)" | tee -a $GITHUB_ENV
-        working-directory: ${{ github.workspace }}/main
-      - name: Set bench output format type
-        run: echo "LURK_BENCH_OUTPUT=commit-comment" | tee -a $GITHUB_ENV
       - name: Run GPU bench on base branch
-        run: just --dotenv-filename bench.env gpu-bench fibonacci
-        working-directory: ${{ github.workspace }}/main/benches
-      - name: Copy bench output to PR branch
+        if: steps.cached-bench.outputs.cached == 'false'
         run: |
-          mkdir -p target
-          cp -r main/target/criterion target
-          cp main/${{ env.BASE_REF }}.json .
+          # Copy justfile & env to main, overwriting existing config with that of PR branch
+          cp ../benches/justfile ../benches/bench.env .
+          # Run benchmark
+          just --dotenv-filename bench.env gpu-bench fibonacci
+          # Copy bench output to PR branch
+          cp ${{ env.BASE_COMMIT }}.json ..
+        working-directory: ${{ github.workspace }}/main
       - name: Run GPU bench on PR branch
-        run: just --dotenv-filename bench.env gpu-bench fibonacci
+        run: |
+          just --dotenv-filename bench.env gpu-bench fibonacci
+          cp ${{ github.sha }}.json ..
         working-directory: ${{ github.workspace }}/benches
       - name: copy the benchmark template and prepare it with data
         run: |
           cp .github/tables.toml .
-          # Get GPU name
-          GPU_NAME=$(nvidia-smi --query-gpu=gpu_name --format=csv,noheader,nounits | tail -n1)
           # Get CPU model
           CPU_MODEL=$(grep '^model name' /proc/cpuinfo | head -1 | awk -F ': ' '{ print $2 }')
           # Get total RAM in GB
           TOTAL_RAM=$(grep MemTotal /proc/meminfo | awk '{$2=$2/(1024^2); print $2, "GB RAM";}')
           
           # Use conditionals to ensure that only non-empty variables are inserted
-          [[ ! -z "$GPU_NAME" ]] && sed -i "/^\"\"\"$/i $GPU_NAME" tables.toml
+          [[ ! -z "${{ env.GPU_NAME }}" ]] && sed -i "/^\"\"\"$/i ${{ env.GPU_NAME }}" tables.toml
           [[ ! -z "$CPU_MODEL" ]] && sed -i "/^\"\"\"$/i $CPU_MODEL" tables.toml
           [[ ! -z "$TOTAL_RAM" ]] && sed -i "/^\"\"\"$/i $TOTAL_RAM" tables.toml          
+          sed -i "/^\"\"\"$/i Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" tables.toml
         working-directory: ${{ github.workspace }}
       # Create a `criterion-table` and write in commit comment
       - name: Run `criterion-table`
-        run: cat ${{ env.BASE_REF }}.json ${{ github.sha }}.json | criterion-table > BENCHMARKS.md
+        run: cat ${{ env.BASE_COMMIT }}.json ${{ github.sha }}.json | criterion-table > BENCHMARKS.md
       - name: Write bench on commit comment
         uses: peter-evans/commit-comment@v3
         with:
@@ -171,3 +189,15 @@ jobs:
           labels: |
             P-Performance
             automated issue
+      - name: Remove old main bench
+        run: |
+          rm ${{ env.BASE_COMMIT }}.json
+          mv ${{ github.sha }}.json ${{ github.sha }}-${{ env.GPU_NAME }}.json
+        working-directory: ${{ github.workspace }}
+      - name: Commit bench result to `gh-pages` branch if no regression
+        if: steps.regression-check.outcome != 'failure'
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          branch: gh-pages
+          commit_message: '[automated] GPU Benchmark from PR #${{ env.PR_NUMBER }}'
+          file_pattern: '${{ github.sha }}-${{ env.GPU_NAME }}.json'

--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -61,7 +61,7 @@ impl ProveParams {
         match output_type.as_ref() {
             "pr-comment" => ("fib".into(), format!("num-{}", self.fib_n)),
             "commit-comment" => (
-                format!("fib-ref={}", env!("VERGEN_GIT_SHA")),
+                format!("fib-ref={}", self.sha),
                 format!("num-{}", self.fib_n),
             ),
             // TODO: refine "gh-pages",

--- a/benches/justfile
+++ b/benches/justfile
@@ -28,7 +28,7 @@ gpu-bench +benches:
   env | grep -E "LURK|EC_GPU|CUDA"
   if [ '{{benches}}' != '' ]; then
     for bench in {{benches}}; do
-      cargo criterion --bench $bench --features "cuda" --message-format=json > ../{{commit}}.json
+      cargo criterion --bench $bench --features "cuda" --message-format=json > {{commit}}.json
     done
   else
     echo "Invalid input, enter at least one non-empty string"


### PR DESCRIPTION
## PR `commit-comment` benchmark caching 
Commits successful PR benchmark results to `gh-pages` as `<${{ github.sha }}>-<$GPU_MODEL>.json`. When the next PR runs the benchmark workflow, it will restore the previously saved `gh-pages` file as the new base benchmark if it still exists and was run on the same GPU. Then the PR benchmark will run and compare to the base benchmark as usual.

On a cache hit, this should save 13-20 minutes on the `merge_group` GPU bench workflow, down from 35-40 minutes to the low 20s. The GPU benchmarks would currently be the bottleneck on merging a PR if made a required status check, but the cache would alleviate this by bringing them into the ballpark of the other `merge_group` tests. 

## Example Runs
Cache hit: https://github.com/lurk-lab/ci-lab/actions/runs/6912455892
Cache miss: https://github.com/lurk-lab/ci-lab/actions/runs/6912478875

## Future work 
- Adjust the runner GPU hardware to be more homogeneous.
- Integrate the cache with the deployed `gh-pages` benchmarks. This requires reconciling the different output formats such that the web benchmarks can render appropriately despite using a format meant for `criterion-table` rather than `critcmp`.