### PR TITLE
refactor: Integrate FoldingConfig usage in proof / eval construction

### DIFF
--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -18,12 +18,12 @@ use lurk::{
     eval::lang::Lang,
     field::LurkField,
     lem::{
-        eval::{evaluate, make_eval_step_from_lang},
+        eval::{evaluate, make_eval_step_from_config},
         multiframe::MultiFrame,
         pointers::Ptr,
         store::Store,
     },
-    proof::{nova::NovaProver, supernova::SuperNovaProver, Prover},
+    proof::{nova::NovaProver, supernova::{SuperNovaProver, FoldingConfig}, Prover},
     public_parameters::{
         instance::{Instance, Kind},
         public_params, supernova_public_params,
@@ -109,7 +109,8 @@ fn sha256_ivc_prove<M: measurement::Measurement>(
     lang.add_coprocessor(cproc_sym, Sha256Coprocessor::new(arity));
     let lang_rc = Arc::new(lang.clone());
 
-    let lurk_step = make_eval_step_from_lang(&lang, true);
+    let fc = FoldingConfig::new_ivc(lang_rc.clone(), reduction_count);
+    let lurk_step = make_eval_step_from_config(&fc);
 
     // use cached public params
     let instance: Instance<'_, Fr, Sha256Coproc<Fr>, MultiFrame<'_, _, _>> = Instance::new(
@@ -192,7 +193,8 @@ fn sha256_ivc_prove_compressed<M: measurement::Measurement>(
     lang.add_coprocessor(cproc_sym, Sha256Coprocessor::new(arity));
     let lang_rc = Arc::new(lang.clone());
 
-    let lurk_step = make_eval_step_from_lang(&lang, true);
+    let fc = FoldingConfig::new_ivc(lang_rc.clone(), reduction_count);
+    let lurk_step = make_eval_step_from_config(&fc);
 
     // use cached public params
     let instance = Instance::new(
@@ -277,7 +279,8 @@ fn sha256_nivc_prove<M: measurement::Measurement>(
     lang.add_coprocessor(cproc_sym, Sha256Coprocessor::new(arity));
     let lang_rc = Arc::new(lang.clone());
 
-    let lurk_step = make_eval_step_from_lang(&lang, false);
+    let fc = FoldingConfig::new_ivc(Arc::new(lang.clone()), 1);
+    let lurk_step = make_eval_step_from_config(&fc);
 
     // use cached public params
     let instance = Instance::new(

--- a/examples/sha256_nivc.rs
+++ b/examples/sha256_nivc.rs
@@ -8,12 +8,12 @@ use lurk::{
     eval::lang::Lang,
     field::LurkField,
     lem::{
-        eval::{evaluate, make_eval_step_from_lang},
+        eval::{evaluate, make_eval_step_from_config},
         multiframe::MultiFrame,
         pointers::Ptr,
         store::Store,
     },
-    proof::{supernova::SuperNovaProver, Prover},
+    proof::{supernova::{SuperNovaProver, FoldingConfig}, Prover},
     public_parameters::{
         instance::{Instance, Kind},
         supernova_public_params,
@@ -76,7 +76,8 @@ fn main() {
     lang.add_coprocessor(cproc_sym, Sha256Coprocessor::new(n));
     let lang_rc = Arc::new(lang.clone());
 
-    let lurk_step = make_eval_step_from_lang(&lang, false);
+    let fc = FoldingConfig::new_nivc(lang_rc.clone(), 1);
+    let lurk_step = make_eval_step_from_config(&fc);
     let (frames, _) = evaluate(Some((&lurk_step, &lang)), call, store, 1000).unwrap();
 
     let supernova_prover =

--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -15,7 +15,7 @@ use crate::{
         ContTag::{Error, Terminal},
         ExprTag::Cproc,
     },
-    Symbol,
+    Symbol, proof::supernova::FoldingConfig,
 };
 
 use super::{
@@ -243,12 +243,15 @@ pub fn evaluate_simple<F: LurkField, C: Coprocessor<F>>(
 /// the step function. In the NIVC case, the step function won't be able to reduce
 /// calls to coprocessors and sets up a loop via the `Expr::Cproc` tag, meaning
 /// that the reduction must be done from outside.
-pub fn make_eval_step_from_lang<F: LurkField, C: Coprocessor<F>>(
-    lang: &Lang<F, C>,
-    ivc: bool,
+pub fn make_eval_step_from_config<F: LurkField, C: Coprocessor<F>>(
+    fc: &FoldingConfig<F, C>,
 ) -> Func {
+    let ivc = match fc {
+        FoldingConfig::IVC(_, _) => true,
+        FoldingConfig::NIVC(_, _)=> false,
+    };
     make_eval_step(
-        &lang
+        &fc.lang()
             .coprocessors()
             .iter()
             .map(|(s, c)| (s, c.arity()))

--- a/src/lem/tests/eval_tests.rs
+++ b/src/lem/tests/eval_tests.rs
@@ -1,17 +1,17 @@
 use pasta_curves::pallas::Scalar as Fr;
-use std::{cell::RefCell, rc::Rc};
+use std::{cell::RefCell, rc::Rc, sync::Arc};
 
 use crate::{
     coprocessor::Coprocessor,
     eval::lang::{Coproc, Lang},
     lem::{
-        eval::{evaluate_simple, make_eval_step_from_lang},
+        eval::{evaluate_simple, make_eval_step_from_config},
         pointers::Ptr,
         store::Store,
         Tag,
     },
     state::State,
-    tag::Op,
+    tag::Op, proof::supernova::FoldingConfig,
 };
 
 fn test_aux<C: Coprocessor<Fr>>(
@@ -112,7 +112,8 @@ fn do_test<C: Coprocessor<Fr>>(
     let (output, iterations, emitted) = if lang.is_default() {
         evaluate_simple::<Fr, C>(None, *expr, s, limit).unwrap()
     } else {
-        let func = make_eval_step_from_lang(lang, true);
+        let fc = FoldingConfig::new_ivc(Arc::new(lang.clone()), 1);
+        let func = make_eval_step_from_config(&fc);
         evaluate_simple(Some((&func, lang)), *expr, s, limit).unwrap()
     };
     let new_expr = output[0];

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -109,8 +109,7 @@ pub trait MultiFrameTrait<'a, F: LurkField, C: Coprocessor<F> + 'a>:
         env: Self::Ptr,
         store: &Self::Store,
         limit: usize,
-        lang: &Lang<F, C>,
-        ivc: bool,
+        fc: &FoldingConfig<F, C>,
     ) -> Result<Vec<Self::EvalFrame>, ProofError>;
 
     /// Returns a public IO vector when equipped with the local store, and the Self::Frame's IO

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -305,7 +305,8 @@ where
         limit: usize,
         lang: &Arc<Lang<F, C>>,
     ) -> Result<(Proof<'a, F, C, M>, Vec<F>, Vec<F>, usize), ProofError> {
-        let frames = M::build_frames(expr, env, store, limit, lang, true)?;
+        let fc = FoldingConfig::new_ivc(lang.clone(), self.reduction_count());
+        let frames = M::build_frames(expr, env, store, limit, &fc)?;
         self.prove(pp, &frames, store, lang)
     }
 }

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -289,7 +289,8 @@ where
         limit: usize,
         lang: Arc<Lang<F, C>>,
     ) -> Result<(Proof<'a, F, C, M>, Vec<F>, Vec<F>, usize, usize), ProofError> {
-        let frames = M::build_frames(expr, env, store, limit, &lang, false)?;
+        let fc = FoldingConfig::new_nivc(lang.clone(), self.reduction_count());
+        let frames = M::build_frames(expr, env, store, limit, &fc)?;
         info!("got {} evaluation frames", frames.len());
         self.prove(pp, &frames, store, lang)
     }

--- a/src/proof/tests/mod.rs
+++ b/src/proof/tests/mod.rs
@@ -133,7 +133,8 @@ where
     let e = s.initial_empty_env();
 
     let nova_prover = NovaProver::<'a, F, C, M>::new(reduction_count, (*lang).clone());
-    let frames = M::build_frames(expr, e, s, limit, &lang, true).unwrap();
+    let fc = FoldingConfig::new_ivc(lang.clone(), reduction_count);
+    let frames = M::build_frames(expr, e, s, limit, &fc).unwrap();
 
     if check_nova {
         let pp = public_params::<_, _, M>(reduction_count, lang.clone());


### PR DESCRIPTION
- Updated the `MultiFrameTrait` parameters in the `build_frames` function, replacing `lang` and `ivc` with `FoldingConfig` (fc)
- Altered signature of `make_eval_step_from_lang` function in `lem/eval.rs`, now accepting `&FoldingConfig` as argument
- Introduced a `FoldingConfig` instance in `sha256_ivc_prove`, `sha256_ivc_prove_compressed`, and `sha256_nivc_prove` functions in `benches/sha256.rs`
- Refactored the `from_frames` function in `lem/multiframe.rs` to focus on a switch from language to folding configuration for evaluation step
- Refactored the initialisation process in `evaluate_and_prove` method in `supernova.rs`