### PR TITLE
Fix more pipeline rough edges

### DIFF
--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -18,7 +18,7 @@ use lurk::{
     eval::lang::Lang,
     field::LurkField,
     lem::{
-        eval::{evaluate, make_eval_step_from_lang},
+        eval::{evaluate, make_eval_step_from_config, EvalConfig},
         multiframe::MultiFrame,
         pointers::Ptr,
         store::Store,
@@ -109,7 +109,7 @@ fn sha256_ivc_prove<M: measurement::Measurement>(
     lang.add_coprocessor(cproc_sym, Sha256Coprocessor::new(arity));
     let lang_rc = Arc::new(lang.clone());
 
-    let lurk_step = make_eval_step_from_lang(&lang, true);
+    let lurk_step = make_eval_step_from_config(&EvalConfig::new_ivc(&lang));
 
     // use cached public params
     let instance: Instance<'_, Fr, Sha256Coproc<Fr>, MultiFrame<'_, _, _>> = Instance::new(
@@ -192,7 +192,7 @@ fn sha256_ivc_prove_compressed<M: measurement::Measurement>(
     lang.add_coprocessor(cproc_sym, Sha256Coprocessor::new(arity));
     let lang_rc = Arc::new(lang.clone());
 
-    let lurk_step = make_eval_step_from_lang(&lang, true);
+    let lurk_step = make_eval_step_from_config(&EvalConfig::new_ivc(&lang));
 
     // use cached public params
     let instance = Instance::new(
@@ -277,7 +277,7 @@ fn sha256_nivc_prove<M: measurement::Measurement>(
     lang.add_coprocessor(cproc_sym, Sha256Coprocessor::new(arity));
     let lang_rc = Arc::new(lang.clone());
 
-    let lurk_step = make_eval_step_from_lang(&lang, false);
+    let lurk_step = make_eval_step_from_config(&EvalConfig::new_ivc(&lang));
 
     // use cached public params
     let instance = Instance::new(

--- a/examples/sha256_nivc.rs
+++ b/examples/sha256_nivc.rs
@@ -8,7 +8,7 @@ use lurk::{
     eval::lang::Lang,
     field::LurkField,
     lem::{
-        eval::{evaluate, make_eval_step_from_lang},
+        eval::{evaluate, make_eval_step_from_config, EvalConfig},
         multiframe::MultiFrame,
         pointers::Ptr,
         store::Store,
@@ -76,7 +76,7 @@ fn main() {
     lang.add_coprocessor(cproc_sym, Sha256Coprocessor::new(n));
     let lang_rc = Arc::new(lang.clone());
 
-    let lurk_step = make_eval_step_from_lang(&lang, false);
+    let lurk_step = make_eval_step_from_config(&EvalConfig::new_nivc(&lang));
     let (frames, _) = evaluate(Some((&lurk_step, &lang)), call, store, 1000).unwrap();
 
     let supernova_prover =

--- a/src/lem/tests/eval_tests.rs
+++ b/src/lem/tests/eval_tests.rs
@@ -5,7 +5,7 @@ use crate::{
     coprocessor::Coprocessor,
     eval::lang::{Coproc, Lang},
     lem::{
-        eval::{evaluate_simple, make_eval_step_from_lang},
+        eval::{evaluate_simple, make_eval_step_from_config, EvalConfig},
         pointers::Ptr,
         store::Store,
         Tag,
@@ -112,7 +112,7 @@ fn do_test<C: Coprocessor<Fr>>(
     let (output, iterations, emitted) = if lang.is_default() {
         evaluate_simple::<Fr, C>(None, *expr, s, limit).unwrap()
     } else {
-        let func = make_eval_step_from_lang(lang, true);
+        let func = make_eval_step_from_config(&EvalConfig::new_ivc(lang));
         evaluate_simple(Some((&func, lang)), *expr, s, limit).unwrap()
     };
     let new_expr = output[0];

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -19,6 +19,7 @@ use crate::coprocessor::Coprocessor;
 use crate::error::ProofError;
 use crate::eval::lang::Lang;
 use crate::field::LurkField;
+use crate::lem::eval::EvalConfig;
 
 use ::nova::traits::circuit::StepCircuit;
 use bellpepper::util_cs::witness_cs::WitnessCS;
@@ -103,14 +104,13 @@ pub trait MultiFrameTrait<'a, F: LurkField, C: Coprocessor<F> + 'a>:
     /// Counting the number of non-trivial frames in the evaluation
     fn significant_frame_count(frames: &[Self::EvalFrame]) -> usize;
 
-    /// Evaluates and generates the frames of the computation given the expression, environment, and store (IVC only, TODO NIVC)
-    fn get_evaluation_frames(
-        padding_predicate: impl Fn(usize) -> bool, // Determines if the prover needs padding for a given total number of frames
+    /// Evaluates and generates the frames of the computation given the expression, environment, and store
+    fn build_frames(
         expr: Self::Ptr,
         env: Self::Ptr,
         store: &Self::Store,
         limit: usize,
-        land: &Lang<F, C>,
+        ec: &EvalConfig<'_, F, C>,
     ) -> Result<Vec<Self::EvalFrame>, ProofError>;
 
     /// Returns a public IO vector when equipped with the local store, and the Self::Frame's IO

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -28,6 +28,7 @@ use crate::{
     error::ProofError,
     eval::lang::Lang,
     field::LurkField,
+    lem::eval::EvalConfig,
     proof::{supernova::FoldingConfig, EvaluationStore, FrameLike, MultiFrameTrait, Prover},
 };
 
@@ -305,14 +306,7 @@ where
         limit: usize,
         lang: &Arc<Lang<F, C>>,
     ) -> Result<(Proof<'a, F, C, M>, Vec<F>, Vec<F>, usize), ProofError> {
-        let frames = M::get_evaluation_frames(
-            |count| self.needs_frame_padding(count),
-            expr,
-            env,
-            store,
-            limit,
-            lang,
-        )?;
+        let frames = M::build_frames(expr, env, store, limit, &EvalConfig::new_ivc(lang))?;
         self.prove(pp, &frames, store, lang)
     }
 }

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -21,6 +21,7 @@ use crate::{
     error::ProofError,
     eval::lang::Lang,
     field::LurkField,
+    lem::eval::EvalConfig,
     proof::{
         nova::{CurveCycleEquipped, NovaCircuitShape, G1, G2},
         {EvaluationStore, FrameLike, MultiFrameTrait, Prover},
@@ -289,14 +290,7 @@ where
         limit: usize,
         lang: Arc<Lang<F, C>>,
     ) -> Result<(Proof<'a, F, C, M>, Vec<F>, Vec<F>, usize, usize), ProofError> {
-        let frames = M::get_evaluation_frames(
-            |count| self.needs_frame_padding(count),
-            expr,
-            env,
-            store,
-            limit,
-            &lang,
-        )?;
+        let frames = M::build_frames(expr, env, store, limit, &EvalConfig::new_nivc(&lang))?;
         info!("got {} evaluation frames", frames.len());
         self.prove(pp, &frames, store, lang)
     }

--- a/src/proof/tests/mod.rs
+++ b/src/proof/tests/mod.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use crate::{
     coprocessor::Coprocessor,
     eval::lang::Lang,
+    lem::eval::EvalConfig,
     proof::{
         nova::{public_params, CurveCycleEquipped, NovaProver, G1, G2},
         supernova::FoldingConfig,
@@ -133,15 +134,7 @@ where
     let e = s.initial_empty_env();
 
     let nova_prover = NovaProver::<'a, F, C, M>::new(reduction_count, (*lang).clone());
-    let frames = M::get_evaluation_frames(
-        |frame_count| nova_prover.needs_frame_padding(frame_count),
-        expr,
-        e,
-        s,
-        limit,
-        &lang,
-    )
-    .unwrap();
+    let frames = M::build_frames(expr, e, s, limit, &EvalConfig::new_ivc(&lang)).unwrap();
 
     if check_nova {
         let pp = public_params::<_, _, M>(reduction_count, lang.clone());


### PR DESCRIPTION
* Extract `pad_frames` logic to avoid code duplication
* Rename `get_evaluation_frames` to `build_frames`
* Eliminate padding predicate from `build_frames`
* Introduce `EvalConfig` to avoid plumbing with bools
* Use `EvalConfig` to tell whether `build_frames` is called in an IVC or NIVC context
* Use the above to fix a bug in the SuperNova prover that would cause it to generate frames with IVC characteristics

Context: padding is no longer a responsibility of the evaluation phase so `build_frames` doesn't need to know about a padding predicate

This is an alternative solution to #906 after the insights provided by #909