### PR TITLE
ci: Fix `merge_group` cache key bug in filename

### DIFF
--- a/.github/workflows/bench-deploy.yml
+++ b/.github/workflows/bench-deploy.yml
@@ -35,7 +35,9 @@ jobs:
       - name: Install criterion
         run: cargo install cargo-criterion
       - name: Run benchmarks
-        run: just --dotenv-filename bench.env gpu-bench fibonacci
+        run: |
+          just --dotenv-filename bench.env gpu-bench fibonacci
+          cp ${{ github.sha }}.json ..
         working-directory: ${{ github.workspace }}/benches
       # TODO: Prettify labels for easier viewing
       # Compress the benchmark file and metadata for later analysis
@@ -43,6 +45,7 @@ jobs:
         run: |
           echo $LABELS > labels.md
           tar -cvzf ${{ github.sha }}.tar.gz Cargo.lock ${{ github.sha }}.json labels.md
+        working-directory: ${{ github.workspace }}
       - name: Deploy latest benchmark report
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/merge-tests.yml
+++ b/.github/workflows/merge-tests.yml
@@ -94,6 +94,7 @@ jobs:
           echo "LURK_BENCH_OUTPUT=commit-comment" | tee -a $GITHUB_ENV
           echo "BASE_COMMIT=${{ github.event.merge_group.base_sha }}" | tee -a $GITHUB_ENV
           echo "GPU_NAME=$(nvidia-smi --query-gpu=gpu_name --format=csv,noheader,nounits | tail -n1)" | tee -a $GITHUB_ENV
+          echo "GPU_ID=$(echo ${{ env.GPU_NAME }} | awk '{ print $NF }')" | tee -a $GITHUB_ENV
       # Checkout gh-pages to check for cached bench result
       - name: Checkout gh-pages
         uses: actions/checkout@v4
@@ -103,7 +104,7 @@ jobs:
       - name: Check for cached bench result
         id: cached-bench
         run: |
-          if [ -f "${{ env.BASE_COMMIT }}-${{ env.GPU_NAME }}.json" ]
+          if [ -f "${{ env.BASE_COMMIT }}-${{ env.GPU_ID }}.json" ]
           then
             echo "cached=true" | tee -a $GITHUB_OUTPUT
             cp ${{ env.BASE_COMMIT }}-${{ env.GPU_NAME }}.json ../${{ env.BASE_COMMIT }}.json
@@ -200,4 +201,4 @@ jobs:
         with:
           branch: gh-pages
           commit_message: '[automated] GPU Benchmark from PR #${{ env.PR_NUMBER }}'
-          file_pattern: '${{ github.sha }}-${{ env.GPU_NAME }}.json'
+          file_pattern: '${{ github.sha }}-${{ env.GPU_ID }}.json'


### PR DESCRIPTION
#907 introduced a bug by appending the `$GPU_NAME` env var to the benchmark JSON filename, which contained spaces and thus caused errors in https://github.com/lurk-lab/lurk-rs/actions/runs/6938182407/job/18873513559. This PR fixes the bug by only using the GPU model name (e.g. `4070` or `L4`).

Also fixes an issue where #907 changed the `justfile` bench location, but forgot to update the `bench-deploy` action accordingly.