### PR TITLE
refactor: Refactor to adpt to Arecibo changes in PR 133

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ clap = "4.3.17"
 ff = "0.13"
 metrics = "0.21.1"
 neptune = { git = "https://github.com/lurk-lab/neptune", branch = "dev", features = ["abomonation"] }
-nova = { git = "https://github.com/lurk-lab/arecibo", branch = "port_nova", package = "nova-snark" }
+nova = { git = "https://github.com/lurk-lab/arecibo", branch = "dev", package = "nova-snark" }
 once_cell = "1.18.0"
 pairing = { version = "0.23" }
 pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch = "dev" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ clap = "4.3.17"
 ff = "0.13"
 metrics = "0.21.1"
 neptune = { git = "https://github.com/lurk-lab/neptune", branch = "dev", features = ["abomonation"] }
-nova = { git = "https://github.com/lurk-lab/arecibo", branch = "dev", package = "nova-snark" }
+nova = { git = "https://github.com/lurk-lab/arecibo", branch = "port_nova", package = "nova-snark" }
 once_cell = "1.18.0"
 pairing = { version = "0.23" }
 pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch = "dev" }

--- a/src/cli/lurk_proof.rs
+++ b/src/cli/lurk_proof.rs
@@ -1,6 +1,6 @@
 use ::nova::{
     supernova::NonUniformCircuit,
-    traits::{circuit_supernova::StepCircuit as SuperStepCircuit, Group},
+    traits::{circuit_supernova::StepCircuit as SuperStepCircuit, Engine},
 };
 use abomonation::Abomonation;
 use anyhow::{bail, Result};
@@ -14,7 +14,7 @@ use crate::{
     field::LurkField,
     lem::{pointers::ZPtr, store::Store},
     proof::{
-        nova::{self, CurveCycleEquipped, G1, G2},
+        nova::{self, CurveCycleEquipped, E1, E2},
         supernova::C2,
         MultiFrameTrait,
     },
@@ -157,8 +157,8 @@ pub(crate) enum LurkProof<
     C: Coprocessor<F> + Serialize + DeserializeOwned,
     M: MultiFrameTrait<'a, F, C>,
 > where
-    <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
-    <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E1<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     Nova {
         proof: nova::Proof<'a, F, C, M>,
@@ -177,8 +177,8 @@ impl<
         M: MultiFrameTrait<'a, F, C>,
     > HasFieldModulus for LurkProof<'a, F, C, M>
 where
-    <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
-    <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E1<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     fn field_modulus() -> String {
         F::MODULUS.to_owned()
@@ -192,8 +192,8 @@ impl<
         M: MultiFrameTrait<'a, F, C>,
     > LurkProof<'a, F, C, M>
 where
-    <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
-    <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E1<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     #[inline]
     fn public_io(&self) -> (&[F], &[F]) {
@@ -245,8 +245,8 @@ impl<
         M: MultiFrameTrait<'a, F, C>,
     > LurkProof<'a, F, C, M>
 where
-    <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
-    <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E1<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     #[inline]
     pub(crate) fn persist(self, proof_key: &str) -> Result<()> {
@@ -259,12 +259,12 @@ impl<
         C: Coprocessor<F> + Serialize + DeserializeOwned + 'static,
         M: MultiFrameTrait<'static, F, C>
             + SuperStepCircuit<F>
-            + NonUniformCircuit<G1<F>, G2<F>, M, C2<F>>
+            + NonUniformCircuit<E1<F>, E2<F>, M, C2<F>>
             + 'static,
     > LurkProof<'static, F, C, M>
 where
-    <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
-    <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E1<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     pub(crate) fn verify_proof(proof_key: &str) -> Result<()> {
         let lurk_proof = load::<Self>(&proof_path(proof_key))?;
@@ -309,8 +309,8 @@ pub(crate) struct PackedLurkProof<
     C: Coprocessor<F> + Serialize + DeserializeOwned,
     M: MultiFrameTrait<'a, F, C>,
 > where
-    <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
-    <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E1<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     proof: LurkProof<'a, F, C, M>,
     meta: Option<LurkProofMeta<F>>,
@@ -324,8 +324,8 @@ impl<
         M: MultiFrameTrait<'a, F, C>,
     > HasFieldModulus for PackedLurkProof<'a, F, C, M>
 where
-    <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
-    <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E1<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     fn field_modulus() -> String {
         F::MODULUS.to_owned()
@@ -337,12 +337,12 @@ impl<
         C: Coprocessor<F> + 'static + Serialize + DeserializeOwned,
         M: MultiFrameTrait<'static, F, C>
             + SuperStepCircuit<F>
-            + NonUniformCircuit<G1<F>, G2<F>, M, C2<F>>
+            + NonUniformCircuit<E1<F>, E2<F>, M, C2<F>>
             + 'static,
     > PackedLurkProof<'static, F, C, M>
 where
-    <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
-    <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E1<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     pub(crate) fn pack(
         proof_key: String,

--- a/src/cli/repl/meta_cmd.rs
+++ b/src/cli/repl/meta_cmd.rs
@@ -1,6 +1,6 @@
 use abomonation::Abomonation;
 use anyhow::{bail, Context, Result};
-use nova::traits::Group;
+use nova::traits::Engine;
 use serde::{de::DeserializeOwned, Serialize};
 use std::{collections::HashMap, process};
 
@@ -10,7 +10,7 @@ use crate::{
     field::LurkField,
     lem::{multiframe::MultiFrame, pointers::Ptr, Tag},
     package::{Package, SymbolRef},
-    proof::nova::{CurveCycleEquipped, G1, G2},
+    proof::nova::{CurveCycleEquipped, E1, E2},
     tag::{ContTag, ExprTag},
 };
 
@@ -359,8 +359,8 @@ impl MetaCmd<F> {
 
 impl<F: CurveCycleEquipped + Serialize + DeserializeOwned> MetaCmd<F>
 where
-    <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
-    <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E1<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     const VERIFY: MetaCmd<F> = MetaCmd {
         name: "verify",

--- a/src/lem/multiframe.rs
+++ b/src/lem/multiframe.rs
@@ -4,7 +4,7 @@ use bellpepper::util_cs::witness_cs::WitnessCS;
 use bellpepper_core::{num::AllocatedNum, Circuit, ConstraintSystem, SynthesisError};
 use elsa::sync::FrozenMap;
 use ff::PrimeField;
-use nova::{supernova::NonUniformCircuit, traits::Group};
+use nova::{supernova::NonUniformCircuit, traits::Engine};
 use rayon::prelude::*;
 use std::sync::Arc;
 
@@ -16,7 +16,7 @@ use crate::{
     eval::lang::Lang,
     field::{LanguageField, LurkField},
     proof::{
-        nova::{CurveCycleEquipped, G1, G2},
+        nova::{CurveCycleEquipped, E1, E2},
         supernova::{FoldingConfig, C2},
         CEKState, EvaluationStore, FrameLike, MultiFrameTrait, Provable,
     },
@@ -901,12 +901,12 @@ impl<'a, F: LurkField, C: Coprocessor<F>> nova::traits::circuit_supernova::StepC
     }
 }
 
-impl<'a, F, C> NonUniformCircuit<G1<F>, G2<F>, MultiFrame<'a, F, C>, C2<F>> for MultiFrame<'a, F, C>
+impl<'a, F, C> NonUniformCircuit<E1<F>, E2<F>, MultiFrame<'a, F, C>, C2<F>> for MultiFrame<'a, F, C>
 where
     F: CurveCycleEquipped + LurkField,
     C: Coprocessor<F> + 'a,
-    <<G1<F> as Group>::Scalar as PrimeField>::Repr: Abomonation,
-    <<G2<F> as Group>::Scalar as PrimeField>::Repr: Abomonation,
+    <<E1<F> as Engine>::Scalar as PrimeField>::Repr: Abomonation,
+    <<E2<F> as Engine>::Scalar as PrimeField>::Repr: Abomonation,
 {
     fn num_circuits(&self) -> usize {
         assert_eq!(self.pc, 0);

--- a/src/proof/tests/mod.rs
+++ b/src/proof/tests/mod.rs
@@ -3,7 +3,7 @@ mod nova_tests_lem;
 use abomonation::Abomonation;
 use bellpepper::util_cs::{metric_cs::MetricCS, witness_cs::WitnessCS, Comparable};
 use bellpepper_core::{test_cs::TestConstraintSystem, ConstraintSystem, Delta};
-use nova::traits::Group;
+use nova::traits::Engine;
 use std::sync::Arc;
 
 use crate::{
@@ -11,7 +11,7 @@ use crate::{
     eval::lang::Lang,
     lem::eval::EvalConfig,
     proof::{
-        nova::{public_params, CurveCycleEquipped, NovaProver, G1, G2},
+        nova::{public_params, CurveCycleEquipped, NovaProver, E1, E2},
         supernova::FoldingConfig,
         CEKState, EvaluationStore, MultiFrameTrait, Prover,
     },
@@ -47,8 +47,8 @@ fn test_aux<'a, F: CurveCycleEquipped, C: Coprocessor<F>, M: MultiFrameTrait<'a,
 )
 // technical bounds that would disappear once associated_type_bounds stabilizes
 where
-    <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
-    <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E1<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     for chunk_size in REDUCTION_COUNTS_TO_TEST {
         nova_test_full_aux::<F, C, M>(
@@ -82,8 +82,8 @@ fn nova_test_full_aux<'a, F: CurveCycleEquipped, C: Coprocessor<F>, M: MultiFram
 )
 // technical bounds that would disappear once associated_type_bounds stabilizes
 where
-    <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
-    <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E1<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     let expr = s.read(expr).unwrap();
 
@@ -126,8 +126,8 @@ fn nova_test_full_aux2<'a, F: CurveCycleEquipped, C: Coprocessor<F>, M: MultiFra
 )
 // technical bounds that would disappear once associated_type_bounds stabilizes
 where
-    <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
-    <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E1<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     let limit = limit.unwrap_or(10000);
 

--- a/src/public_parameters/disk_cache.rs
+++ b/src/public_parameters/disk_cache.rs
@@ -4,11 +4,11 @@ use std::marker::PhantomData;
 
 use abomonation::{encode, Abomonation};
 use camino::{Utf8Path, Utf8PathBuf};
-use nova::traits::Group;
+use nova::traits::Engine;
 
 use crate::config::lurk_config;
 use crate::coprocessor::Coprocessor;
-use crate::proof::nova::{CurveCycleEquipped, PublicParams, G1, G2};
+use crate::proof::nova::{CurveCycleEquipped, PublicParams, E1, E2};
 use crate::proof::MultiFrameTrait;
 use crate::public_parameters::error::Error;
 
@@ -34,8 +34,8 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a, M: MultiFrameTrait<'a, F
     DiskCache<'a, F, C, M>
 where
     // technical bounds that would disappear once associated_type_bounds stabilizes
-    <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
-    <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E1<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     pub(crate) fn new(disk_cache_path: &Utf8Path) -> Result<Self, Error> {
         create_dir_all(disk_cache_path)?;

--- a/src/public_parameters/instance.rs
+++ b/src/public_parameters/instance.rs
@@ -45,7 +45,7 @@ use std::{
 use ::nova::{
     constants::NUM_HASH_BITS,
     supernova::NonUniformCircuit,
-    traits::{circuit_supernova::StepCircuit as SuperStepCircuit, Group},
+    traits::{circuit_supernova::StepCircuit as SuperStepCircuit, Engine},
 };
 use abomonation::Abomonation;
 use camino::Utf8Path;
@@ -57,7 +57,7 @@ use crate::{
     eval::lang::Lang,
     proof::MultiFrameTrait,
     proof::{
-        nova::{self, CurveCycleEquipped, G1, G2},
+        nova::{self, CurveCycleEquipped, E1, E2},
         supernova::{self, C2},
     },
 };
@@ -134,11 +134,11 @@ impl<
         'a,
         F: CurveCycleEquipped,
         C: Coprocessor<F>,
-        M: MultiFrameTrait<'a, F, C> + SuperStepCircuit<F> + NonUniformCircuit<G1<F>, G2<F>, M, C2<F>>,
+        M: MultiFrameTrait<'a, F, C> + SuperStepCircuit<F> + NonUniformCircuit<E1<F>, E2<F>, M, C2<F>>,
     > Instance<'a, F, C, M>
 where
-    <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
-    <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E1<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     pub fn new(rc: usize, lang: Arc<Lang<F, C>>, abomonated: bool, kind: Kind) -> Self {
         let cache_key = match kind {
@@ -196,8 +196,8 @@ where
 impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>, M: MultiFrameTrait<'a, F, C>>
     Instance<'a, F, C, M>
 where
-    <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
-    <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E1<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     /// The key (or cache_key) of this [Instance] used to retrieve it from the file cache
     pub fn lang(&self) -> Arc<Lang<F, C>> {

--- a/src/public_parameters/mem_cache.rs
+++ b/src/public_parameters/mem_cache.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use abomonation::{decode, Abomonation};
-use nova::traits::Group;
+use nova::traits::Engine;
 use once_cell::sync::Lazy;
 use tap::TapFallible;
 use tracing::{info, warn};
@@ -12,7 +12,7 @@ use tracing::{info, warn};
 use crate::proof::MultiFrameTrait;
 use crate::{
     coprocessor::Coprocessor,
-    proof::nova::{PublicParams, G1, G2},
+    proof::nova::{PublicParams, E1, E2},
 };
 use crate::{proof::nova::CurveCycleEquipped, public_parameters::error::Error};
 
@@ -51,8 +51,8 @@ impl PublicParamMemCache {
         default: Fn,
     ) -> Result<Arc<PublicParams<F, M>>, Error>
     where
-        <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
-        <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+        <<E1<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
+        <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
     {
         // subdirectory search
         let disk_cache = DiskCache::new(public_params_dir()).unwrap();
@@ -111,8 +111,8 @@ impl PublicParamMemCache {
         default: Fn,
     ) -> Result<Arc<PublicParams<F, M>>, Error>
     where
-        <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
-        <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+        <<E1<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
+        <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
     {
         // re-grab the lock
         let mut mem_cache = self.mem_cache.lock().unwrap();

--- a/src/public_parameters/mod.rs
+++ b/src/public_parameters/mod.rs
@@ -1,10 +1,10 @@
-use ::nova::traits::Group;
+use ::nova::traits::Engine;
 use abomonation::{decode, Abomonation};
 use std::sync::Arc;
 
 use crate::coprocessor::Coprocessor;
 use crate::proof::nova::{self, NovaCircuitShape, PublicParams};
-use crate::proof::nova::{CurveCycleEquipped, G1, G2};
+use crate::proof::nova::{CurveCycleEquipped, E1, E2};
 use crate::proof::MultiFrameTrait;
 
 pub mod disk_cache;
@@ -27,8 +27,8 @@ pub fn public_params<
     instance: &Instance<'static, F, C, M>,
 ) -> Result<Arc<PublicParams<F, M>>, Error>
 where
-    <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
-    <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E1<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     let f = |instance: &Instance<'static, F, C, M>| {
         Arc::new(nova::public_params(instance.rc, instance.lang()))
@@ -50,8 +50,8 @@ where
     C: Coprocessor<F> + 'a,
     M: MultiFrameTrait<'a, F, C>,
     Fn: FnOnce(&PublicParams<F, M>) -> T,
-    <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
-    <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E1<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     let default =
         |instance: &Instance<'a, F, C, M>| nova::public_params(instance.rc, instance.lang());
@@ -88,8 +88,8 @@ pub fn supernova_circuit_params<
     instance: &Instance<'a, F, C, M>,
 ) -> Result<NovaCircuitShape<F>, Error>
 where
-    <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
-    <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E1<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     let disk_cache = DiskCache::<F, C, M>::new(public_params_dir()).unwrap();
 
@@ -114,8 +114,8 @@ pub fn supernova_aux_params<
     instance: &Instance<'a, F, C, M>,
 ) -> Result<SuperNovaAuxParams<F>, Error>
 where
-    <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
-    <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E1<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     let disk_cache = DiskCache::<F, C, M>::new(public_params_dir()).unwrap();
 
@@ -140,13 +140,13 @@ pub fn supernova_public_params<
     'a,
     F: CurveCycleEquipped,
     C: Coprocessor<F> + 'a,
-    M: MultiFrameTrait<'a, F, C> + SuperStepCircuit<F> + NonUniformCircuit<G1<F>, G2<F>, M, C2<F>>,
+    M: MultiFrameTrait<'a, F, C> + SuperStepCircuit<F> + NonUniformCircuit<E1<F>, E2<F>, M, C2<F>>,
 >(
     instance_primary: &Instance<'a, F, C, M>,
 ) -> Result<supernova::PublicParams<F, M>, Error>
 where
-    <<G1<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
-    <<G2<F> as Group>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E1<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     let default = |instance: &Instance<'a, F, C, M>| {
         supernova::public_params::<'a, F, C, M>(instance.rc, instance.lang())


### PR DESCRIPTION
Companion Arecibo PR:
https://github.com/lurk-lab/arecibo/pull/133

- Adapted the codebase to replace the `Group` types and traits with `Engine`, and replaced `G1` and `G2` with `E1` and `E2`.
- Updated the trait `EvaluationEngineTrait<G>` and `RelaxedR1CSSNARKTrait` along with type aliases to reflect these changes.
- Modified the `CurveCycleEquipped` implementation for `bn256::Scalar` and `pallas::Scalar`.
- Made necessary adjustments to the aid functions and type aliases related to `NovaProver` for compatibility with the new group types.
- Made changes in the SuperNova proving system to accommodate new `Engine` types.