### PR TITLE
chore: Replace nova::bn256_grumpkin with halo2curves library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ clap = "4.3.17"
 ff = "0.13"
 metrics = "0.21.1"
 neptune = { git = "https://github.com/lurk-lab/neptune", branch = "dev", features = ["abomonation"] }
-nova = { git = "https://github.com/lurk-lab/arecibo", branch = "port_more_nova", package = "nova-snark" }
+nova = { git = "https://github.com/lurk-lab/arecibo", branch = "dev", package = "nova-snark" }
 once_cell = "1.18.0"
 pairing = { version = "0.23" }
 pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch = "dev" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ dashmap = "5.5.0"
 ff = { workspace = true }
 fxhash = "0.2.1"
 generic-array = "0.14.7"
+halo2curves = "0.4"
 hex = { version = "0.4.3", features = ["serde"] }
 indexmap = { version = "2.1.0", features = ["rayon", "serde"] }
 itertools = "0.11"
@@ -126,7 +127,7 @@ clap = "4.3.17"
 ff = "0.13"
 metrics = "0.21.1"
 neptune = { git = "https://github.com/lurk-lab/neptune", branch = "dev", features = ["abomonation"] }
-nova = { git = "https://github.com/lurk-lab/arecibo", branch = "dev", package = "nova-snark" }
+nova = { git = "https://github.com/lurk-lab/arecibo", branch = "port_more_nova", package = "nova-snark" }
 once_cell = "1.18.0"
 pairing = { version = "0.23" }
 pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch = "dev" }

--- a/src/field.rs
+++ b/src/field.rs
@@ -6,7 +6,8 @@
 //! relating this field to the expresions of the language.
 use clap::ValueEnum;
 use ff::{PrimeField, PrimeFieldBits};
-use nova::provider::bn256_grumpkin::{bn256, grumpkin};
+use halo2curves::bn256::Fr as Bn256Scalar;
+use halo2curves::grumpkin::Fr as GrumpkinScalar;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use std::hash::Hash;
@@ -268,11 +269,11 @@ impl LurkField for pasta_curves::vesta::Scalar {
     const FIELD: LanguageField = LanguageField::Vesta;
 }
 
-impl LurkField for bn256::Scalar {
+impl LurkField for Bn256Scalar {
     const FIELD: LanguageField = LanguageField::BN256;
 }
 
-impl LurkField for grumpkin::Scalar {
+impl LurkField for GrumpkinScalar {
     const FIELD: LanguageField = LanguageField::Grumpkin;
 }
 

--- a/src/lem/multiframe.rs
+++ b/src/lem/multiframe.rs
@@ -929,7 +929,8 @@ where
 #[cfg(test)]
 mod tests {
     use bellpepper_core::test_cs::TestConstraintSystem;
-    use nova::provider::bn256_grumpkin::{bn256::Scalar as Bn, grumpkin::Scalar as Gr};
+    use halo2curves::bn256::Fr as Bn;
+    use halo2curves::grumpkin::Fr as Gr;
     use pasta_curves::{Fp, Fq};
 
     use crate::{

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -3,12 +3,10 @@
 use abomonation::Abomonation;
 use bellpepper_core::{num::AllocatedNum, ConstraintSystem};
 use ff::Field;
+use halo2curves::bn256::Fr as Bn256Scalar;
 use nova::{
     errors::NovaError,
-    provider::{
-        bn256_grumpkin::{bn256, Bn256Engine, GrumpkinEngine},
-        pasta::{PallasEngine, VestaEngine},
-    },
+    provider::{Bn256Engine, GrumpkinEngine, PallasEngine, VestaEngine},
     traits::{
         circuit::{StepCircuit, TrivialCircuit},
         evaluation::EvaluationEngineTrait,
@@ -68,7 +66,7 @@ impl CurveCycleEquipped for pallas::Scalar {
 }
 // The impl CurveCycleEquipped for vesta::Scalar is academically possible, but voluntarily omitted to avoid confusion.
 
-impl CurveCycleEquipped for bn256::Scalar {
+impl CurveCycleEquipped for Bn256Scalar {
     type EE1 = nova::provider::ipa_pc::EvaluationEngine<Self::E1>;
     type EE2 = nova::provider::ipa_pc::EvaluationEngine<Self::E2>;
 


### PR DESCRIPTION
- companion PR of https://github.com/lurk-lab/arecibo/pull/135
- Replaced the usage of `nova::provider::bn256_grumpkin` with `halo2curves` in `src/lem/multiframe.rs`, `src/proof/nova.rs`, and `src/field.rs` since the nova module is now private,
- Updated tests in `src/lem/multiframe.rs` to use the `halo2curves` library,
- Replaced `bn256_grumpkin::bn256` with `Bn256Engine` and redefined `CurveCycleEquipped` for `Bn256Scalar` in `src/proof/nova.rs`.
- Added `halo2curves` to the list of dependencies in `Cargo.toml` and updated the `LurkField` implementation in `src/field.rs`.