### PR TITLE
refactor: lower `Ptr` memory cost

### DIFF
--- a/benches/end2end.rs
+++ b/benches/end2end.rs
@@ -26,7 +26,7 @@ use common::set_bench_config;
 
 const DEFAULT_REDUCTION_COUNT: usize = 10;
 
-fn go_base<F: LurkField>(store: &Store<F>, state: Rc<RefCell<State>>, a: u64, b: u64) -> Ptr<F> {
+fn go_base<F: LurkField>(store: &Store<F>, state: Rc<RefCell<State>>, a: u64, b: u64) -> Ptr {
     let program = format!(
         r#"
 (let ((foo (lambda (a b)

--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -24,7 +24,7 @@ use lurk::{
 mod common;
 use common::set_bench_config;
 
-fn fib<F: LurkField>(store: &Store<F>, state: Rc<RefCell<State>>, _a: u64) -> Ptr<F> {
+fn fib<F: LurkField>(store: &Store<F>, state: Rc<RefCell<State>>, _a: u64) -> Ptr {
     let program = r#"
 (letrec ((next (lambda (a b) (next b (+ a b))))
            (fib (next 0 1)))

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -40,7 +40,7 @@ fn sha256_ivc<F: LurkField>(
     arity: usize,
     n: usize,
     input: &Vec<usize>,
-) -> Ptr<F> {
+) -> Ptr {
     assert_eq!(n, input.len());
     let input = input
         .iter()

--- a/benches/synthesis.rs
+++ b/benches/synthesis.rs
@@ -16,7 +16,7 @@ use lurk::{
     state::State,
 };
 
-fn fib<F: LurkField>(store: &Store<F>, state: Rc<RefCell<State>>, a: u64) -> Ptr<F> {
+fn fib<F: LurkField>(store: &Store<F>, state: Rc<RefCell<State>>, a: u64) -> Ptr {
     let program = format!(
         r#"
 (let ((fib (lambda (target)

--- a/examples/circom.rs
+++ b/examples/circom.rs
@@ -80,9 +80,9 @@ impl<F: LurkField> CircomGadget<F> for CircomSha256<F> {
         vec![a, b]
     }
 
-    fn evaluate_simple(&self, _s: &Store<F>, _args: &[Ptr<F>]) -> Ptr<F> {
+    fn evaluate_simple(&self, s: &Store<F>, _args: &[Ptr]) -> Ptr {
         // TODO: actually use the lurk inputs
-        Ptr::num(
+        s.num(
             F::from_str_vartime(
                 "55165702627807990590530466439275329993482327026534454077267643456",
             )

--- a/examples/fibonacci.rs
+++ b/examples/fibonacci.rs
@@ -5,7 +5,7 @@ use lurk::{
 };
 use pasta_curves::Fq;
 
-fn fib_expr<F: LurkField>(store: &Store<F>) -> Ptr<F> {
+fn fib_expr<F: LurkField>(store: &Store<F>) -> Ptr {
     let program = r#"
 (letrec ((next (lambda (a b) (next b (+ a b))))
            (fib (next 0 1)))
@@ -28,7 +28,7 @@ fn fib_limit(n: usize, rc: usize) -> usize {
     rc * (frame / rc + usize::from(frame % rc != 0))
 }
 
-fn lurk_fib(store: &Store<Fq>, n: usize, _rc: usize) -> Ptr<Fq> {
+fn lurk_fib(store: &Store<Fq>, n: usize, _rc: usize) -> Ptr {
     let frame_idx = fib_frame(n);
     // let limit = fib_limit(n, rc);
     let limit = frame_idx;

--- a/examples/sha256_ivc.rs
+++ b/examples/sha256_ivc.rs
@@ -18,7 +18,7 @@ use lurk::{
 
 const REDUCTION_COUNT: usize = 10;
 
-fn sha256_ivc<F: LurkField>(store: &Store<F>, n: usize, input: &[usize]) -> Ptr<F> {
+fn sha256_ivc<F: LurkField>(store: &Store<F>, n: usize, input: &[usize]) -> Ptr {
     assert_eq!(n, input.len());
     let input = input
         .iter()

--- a/examples/sha256_nivc.rs
+++ b/examples/sha256_nivc.rs
@@ -23,7 +23,7 @@ use lurk::{
 
 const REDUCTION_COUNT: usize = 10;
 
-fn sha256_nivc<F: LurkField>(store: &Store<F>, n: usize, input: &[usize]) -> Ptr<F> {
+fn sha256_nivc<F: LurkField>(store: &Store<F>, n: usize, input: &[usize]) -> Ptr {
     assert_eq!(n, input.len());
     let input = input
         .iter()

--- a/lurk-macros/src/lib.rs
+++ b/lurk-macros/src/lib.rs
@@ -53,19 +53,19 @@ fn impl_enum_coproc(name: &Ident, variants: &DataEnum) -> TokenStream {
                 }
             }
 
-            fn evaluate_internal(&self, s: &lurk::lem::store::Store<F>, ptrs: &[lurk::lem::pointers::Ptr<F>]) -> Vec<lurk::lem::pointers::Ptr<F>> {
+            fn evaluate_internal(&self, s: &lurk::lem::store::Store<F>, ptrs: &[lurk::lem::pointers::Ptr]) -> Vec<lurk::lem::pointers::Ptr> {
                 match self {
                     #evaluate_internal_arms
                 }
             }
 
-            fn evaluate(&self, s: &lurk::lem::store::Store<F>, args: &[lurk::lem::pointers::Ptr<F>], env: &lurk::lem::pointers::Ptr<F>, cont: &lurk::lem::pointers::Ptr<F>) -> Vec<lurk::lem::pointers::Ptr<F>> {
+            fn evaluate(&self, s: &lurk::lem::store::Store<F>, args: &[lurk::lem::pointers::Ptr], env: &lurk::lem::pointers::Ptr, cont: &lurk::lem::pointers::Ptr) -> Vec<lurk::lem::pointers::Ptr> {
                 match self {
                     #evaluate_arms
                 }
             }
 
-            fn evaluate_simple(&self, s: &lurk::lem::store::Store<F>, args: &[lurk::lem::pointers::Ptr<F>]) -> lurk::lem::pointers::Ptr<F> {
+            fn evaluate_simple(&self, s: &lurk::lem::store::Store<F>, args: &[lurk::lem::pointers::Ptr]) -> lurk::lem::pointers::Ptr {
                 match self {
                     #evaluate_simple_arms
                 }

--- a/src/circuit/gadgets/circom/mod.rs
+++ b/src/circuit/gadgets/circom/mod.rs
@@ -25,5 +25,5 @@ pub trait CircomGadget<F: LurkField>: Send + Sync + Clone {
 
     fn into_circom_input(self, input: &[AllocatedPtr<F>]) -> Vec<(String, Vec<F>)>;
 
-    fn evaluate_simple(&self, s: &Store<F>, args: &[Ptr<F>]) -> Ptr<F>;
+    fn evaluate_simple(&self, s: &Store<F>, args: &[Ptr]) -> Ptr;
 }

--- a/src/cli/commitment.rs
+++ b/src/cli/commitment.rs
@@ -33,7 +33,7 @@ impl<F: LurkField> HasFieldModulus for Commitment<F> {
 }
 
 impl<F: LurkField> Commitment<F> {
-    pub(crate) fn new(secret: Option<F>, payload: Ptr<F>, store: &Store<F>) -> Self {
+    pub(crate) fn new(secret: Option<F>, payload: Ptr, store: &Store<F>) -> Self {
         let secret = secret.unwrap_or(F::NON_HIDING_COMMITMENT_SECRET);
         let (hash, z_payload) = store.hide_and_return_z_payload(secret, payload);
         let mut z_store = ZStore::<F>::default();

--- a/src/coprocessor/circom.rs
+++ b/src/coprocessor/circom.rs
@@ -131,7 +131,7 @@ Then run `lurk coprocessor --name {name} <{}_FOLDER>` to instantiate a new gadge
             0
         }
 
-        fn evaluate_simple(&self, s: &Store<F>, args: &[Ptr<F>]) -> Ptr<F> {
+        fn evaluate_simple(&self, s: &Store<F>, args: &[Ptr]) -> Ptr {
             self.gadget.evaluate_simple(s, args)
         }
 

--- a/src/coprocessor/gadgets.rs
+++ b/src/coprocessor/gadgets.rs
@@ -142,10 +142,7 @@ pub(crate) fn construct_list<F: LurkField, CS: ConstraintSystem<F>>(
 /// Retrieves the `Ptr` that corresponds to `a_ptr` by using the `Store` as the
 /// hint provider
 #[allow(dead_code)]
-fn get_ptr<F: LurkField>(
-    a_ptr: &AllocatedPtr<F>,
-    store: &Store<F>,
-) -> Result<Ptr<F>, SynthesisError> {
+fn get_ptr<F: LurkField>(a_ptr: &AllocatedPtr<F>, store: &Store<F>) -> Result<Ptr, SynthesisError> {
     let z_ptr = ZPtr::from_parts(
         Tag::from_field(
             &a_ptr
@@ -457,8 +454,8 @@ pub(crate) fn car_cdr<F: LurkField, CS: ConstraintSystem<F>>(
 ///
 /// let ab = store.intern_string("ab");
 /// let z_ab = store.hash_ptr(&ab);
-/// let a = Ptr::char('a');
-/// let b = Ptr::char('b');
+/// let a = store.char('a');
+/// let b = store.char('b');
 /// let z_a = store.hash_ptr(&a);
 /// let z_b = store.hash_ptr(&b);
 /// let a_ab = AllocatedPtr::alloc_infallible(&mut cs.namespace(|| "ab"), || z_ab);
@@ -537,7 +534,7 @@ mod test {
             deconstruct_tuple4,
         },
         field::LurkField,
-        lem::{circuit::GlobalAllocator, pointers::Ptr, store::Store},
+        lem::{circuit::GlobalAllocator, store::Store},
         tag::ExprTag,
     };
 
@@ -602,7 +599,7 @@ mod test {
         let mut cs = WitnessCS::new();
         let mut g = GlobalAllocator::default();
         let store = Store::<Fq>::default();
-        let one = Ptr::num_u64(1);
+        let one = store.num_u64(1);
         let nil = store.intern_nil();
         let z_one = store.hash_ptr(&one);
         let z_nil = store.hash_ptr(&nil);
@@ -705,7 +702,7 @@ mod test {
         assert_eq!(not_empty.get_value(), Some(false));
 
         // cons
-        let one = Ptr::num_u64(1);
+        let one = store.num_u64(1);
         let z_one = store.hash_ptr(&one);
         let cons = store.cons(one, one);
         let z_cons = store.hash_ptr(&cons);
@@ -740,7 +737,7 @@ mod test {
         // non-empty string
         let abc = store.intern_string("abc");
         let bc = store.intern_string("bc");
-        let a = Ptr::char('a');
+        let a = store.char('a');
         let z_abc = store.hash_ptr(&abc);
         let z_bc = store.hash_ptr(&bc);
         let z_a = store.hash_ptr(&a);
@@ -776,8 +773,8 @@ mod test {
         // string
         let ab = store.intern_string("ab");
         let z_ab = store.hash_ptr(&ab);
-        let a = Ptr::char('a');
-        let b = Ptr::char('b');
+        let a = store.char('a');
+        let b = store.char('b');
         let z_a = store.hash_ptr(&a);
         let z_b = store.hash_ptr(&b);
         let a_ab = AllocatedPtr::alloc_infallible(&mut cs.namespace(|| "ab"), || z_ab);

--- a/src/coprocessor/sha256.rs
+++ b/src/coprocessor/sha256.rs
@@ -110,9 +110,9 @@ impl<F: LurkField> Coprocessor<F> for Sha256Coprocessor<F> {
         true
     }
 
-    fn evaluate_simple(&self, s: &Store<F>, args: &[Ptr<F>]) -> Ptr<F> {
+    fn evaluate_simple(&self, s: &Store<F>, args: &[Ptr]) -> Ptr {
         let z_ptrs = args.iter().map(|ptr| s.hash_ptr(ptr)).collect::<Vec<_>>();
-        Ptr::num(compute_sha256(self.n, &z_ptrs))
+        s.num(compute_sha256(self.n, &z_ptrs))
     }
 }
 

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -67,10 +67,10 @@ impl<F: LurkField> Coprocessor<F> for NewCoprocessor<F> {
         0
     }
 
-    fn evaluate_simple(&self, s: &Store<F>, _args: &[Ptr<F>]) -> Ptr<F> {
+    fn evaluate_simple(&self, s: &Store<F>, _args: &[Ptr]) -> Ptr {
         let trie: StandardTrie<'_, F> = Trie::new(&s.poseidon_cache, &s.inverse_poseidon_cache);
         // TODO: Use a custom type.
-        Ptr::num(trie.root)
+        s.num(trie.root)
     }
 
     fn has_circuit(&self) -> bool {
@@ -96,7 +96,7 @@ impl<F: LurkField> CoCircuit<F> for NewCoprocessor<F> {
         let trie: StandardTrie<'_, F> = Trie::new(&s.poseidon_cache, &s.inverse_poseidon_cache);
 
         // TODO: Use a custom type.
-        let root = Ptr::num(trie.root);
+        let root = s.num(trie.root);
         let root_z_ptr = s.hash_ptr(&root);
 
         AllocatedPtr::alloc_constant(cs, root_z_ptr)
@@ -113,7 +113,7 @@ impl<F: LurkField> Coprocessor<F> for LookupCoprocessor<F> {
         2
     }
 
-    fn evaluate_simple(&self, s: &Store<F>, args: &[Ptr<F>]) -> Ptr<F> {
+    fn evaluate_simple(&self, s: &Store<F>, args: &[Ptr]) -> Ptr {
         let root_ptr = &args[0];
         let key_ptr = &args[1];
 
@@ -123,7 +123,7 @@ impl<F: LurkField> Coprocessor<F> for LookupCoprocessor<F> {
         let trie: StandardTrie<'_, F> =
             Trie::new_with_root(&s.poseidon_cache, &s.inverse_poseidon_cache, root_scalar);
 
-        Ptr::comm(trie.lookup_aux(key_scalar).unwrap())
+        s.comm(trie.lookup_aux(key_scalar).unwrap())
     }
 
     fn has_circuit(&self) -> bool {
@@ -217,7 +217,7 @@ impl<F: LurkField> Coprocessor<F> for InsertCoprocessor<F> {
         3
     }
 
-    fn evaluate_simple(&self, s: &Store<F>, args: &[Ptr<F>]) -> Ptr<F> {
+    fn evaluate_simple(&self, s: &Store<F>, args: &[Ptr]) -> Ptr {
         let root_ptr = &args[0];
         let key_ptr = &args[1];
         let val_ptr = &args[2];
@@ -228,7 +228,7 @@ impl<F: LurkField> Coprocessor<F> for InsertCoprocessor<F> {
             Trie::new_with_root(&s.poseidon_cache, &s.inverse_poseidon_cache, root_scalar);
         trie.insert(key_scalar, val_scalar).unwrap();
 
-        Ptr::num(trie.root)
+        s.num(trie.root)
     }
 
     fn has_circuit(&self) -> bool {

--- a/src/eval/lang.rs
+++ b/src/eval/lang.rs
@@ -31,7 +31,7 @@ impl<F: LurkField> Coprocessor<F> for DummyCoprocessor<F> {
 
     /// And does nothing but return nil. It should probably never be used and can perhaps be eliminated,
     /// but for now it exists as an exemplar demonstrating the intended shape of enums like the default, `Coproc`.
-    fn evaluate_simple(&self, s: &Store<F>, _args: &[Ptr<F>]) -> Ptr<F> {
+    fn evaluate_simple(&self, s: &Store<F>, _args: &[Ptr]) -> Ptr {
         s.intern_nil()
     }
 }

--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -36,7 +36,7 @@ pub fn eval_step() -> &'static Func {
 
 #[inline]
 fn get_pc<F: LurkField, C: Coprocessor<F>>(
-    expr: &Ptr<F>,
+    expr: &Ptr,
     store: &Store<F>,
     lang: &Lang<F, C>,
 ) -> usize {
@@ -59,12 +59,12 @@ fn get_pc<F: LurkField, C: Coprocessor<F>>(
 fn compute_frame<F: LurkField, C: Coprocessor<F>>(
     lurk_step: &Func,
     cprocs_run: &[Func],
-    input: &[Ptr<F>],
+    input: &[Ptr],
     store: &Store<F>,
     lang: &Lang<F, C>,
-    emitted: &mut Vec<Ptr<F>>,
+    emitted: &mut Vec<Ptr>,
     pc: usize,
-) -> Result<(Frame<F>, bool)> {
+) -> Result<(Frame, bool)> {
     let func = if pc == 0 {
         lurk_step
     } else {
@@ -83,16 +83,16 @@ fn compute_frame<F: LurkField, C: Coprocessor<F>>(
 fn build_frames<
     F: LurkField,
     C: Coprocessor<F>,
-    LogFmt: Fn(usize, &[Ptr<F>], &[Ptr<F>], &Store<F>) -> String,
+    LogFmt: Fn(usize, &[Ptr], &[Ptr], &Store<F>) -> String,
 >(
     lurk_step: &Func,
     cprocs_run: &[Func],
-    mut input: Vec<Ptr<F>>,
+    mut input: Vec<Ptr>,
     store: &Store<F>,
     limit: usize,
     lang: &Lang<F, C>,
     log_fmt: LogFmt,
-) -> Result<(Vec<Frame<F>>, usize)> {
+) -> Result<(Vec<Frame>, usize)> {
     let mut pc = 0;
     let mut frames = vec![];
     let mut iterations = 0;
@@ -120,11 +120,11 @@ fn build_frames<
 fn traverse_frames<F: LurkField, C: Coprocessor<F>>(
     lurk_step: &Func,
     cprocs_run: &[Func],
-    mut input: Vec<Ptr<F>>,
+    mut input: Vec<Ptr>,
     store: &Store<F>,
     limit: usize,
     lang: &Lang<F, C>,
-) -> Result<(Vec<Ptr<F>>, usize, Vec<Ptr<F>>)> {
+) -> Result<(Vec<Ptr>, usize, Vec<Ptr>)> {
     let mut pc = 0;
     let mut iterations = 0;
     let mut emitted = vec![];
@@ -145,14 +145,14 @@ fn traverse_frames<F: LurkField, C: Coprocessor<F>>(
 
 pub fn evaluate_with_env_and_cont<F: LurkField, C: Coprocessor<F>>(
     func_lang: Option<(&Func, &Lang<F, C>)>,
-    expr: Ptr<F>,
-    env: Ptr<F>,
-    cont: Ptr<F>,
+    expr: Ptr,
+    env: Ptr,
+    cont: Ptr,
     store: &Store<F>,
     limit: usize,
-) -> Result<(Vec<Frame<F>>, usize)> {
+) -> Result<(Vec<Frame>, usize)> {
     let state = initial_lurk_state();
-    let log_fmt = |i: usize, inp: &[Ptr<F>], emit: &[Ptr<F>], store: &Store<F>| {
+    let log_fmt = |i: usize, inp: &[Ptr], emit: &[Ptr], store: &Store<F>| {
         let mut out = format!(
             "Frame: {i}\n\tExpr: {}\n\tEnv:  {}\n\tCont: {}",
             inp[0].fmt_to_string(store, state),
@@ -182,21 +182,21 @@ pub fn evaluate_with_env_and_cont<F: LurkField, C: Coprocessor<F>>(
 #[inline]
 pub fn evaluate_with_env<F: LurkField, C: Coprocessor<F>>(
     func_lang: Option<(&Func, &Lang<F, C>)>,
-    expr: Ptr<F>,
-    env: Ptr<F>,
+    expr: Ptr,
+    env: Ptr,
     store: &Store<F>,
     limit: usize,
-) -> Result<(Vec<Frame<F>>, usize)> {
+) -> Result<(Vec<Frame>, usize)> {
     evaluate_with_env_and_cont(func_lang, expr, env, store.cont_outermost(), store, limit)
 }
 
 #[inline]
 pub fn evaluate<F: LurkField, C: Coprocessor<F>>(
     func_lang: Option<(&Func, &Lang<F, C>)>,
-    expr: Ptr<F>,
+    expr: Ptr,
     store: &Store<F>,
     limit: usize,
-) -> Result<(Vec<Frame<F>>, usize)> {
+) -> Result<(Vec<Frame>, usize)> {
     evaluate_with_env_and_cont(
         func_lang,
         expr,
@@ -209,11 +209,11 @@ pub fn evaluate<F: LurkField, C: Coprocessor<F>>(
 
 pub fn evaluate_simple_with_env<F: LurkField, C: Coprocessor<F>>(
     func_lang: Option<(&Func, &Lang<F, C>)>,
-    expr: Ptr<F>,
-    env: Ptr<F>,
+    expr: Ptr,
+    env: Ptr,
     store: &Store<F>,
     limit: usize,
-) -> Result<(Vec<Ptr<F>>, usize, Vec<Ptr<F>>)> {
+) -> Result<(Vec<Ptr>, usize, Vec<Ptr>)> {
     let input = vec![expr, env, store.cont_outermost()];
     match func_lang {
         None => {
@@ -230,10 +230,10 @@ pub fn evaluate_simple_with_env<F: LurkField, C: Coprocessor<F>>(
 #[inline]
 pub fn evaluate_simple<F: LurkField, C: Coprocessor<F>>(
     func_lang: Option<(&Func, &Lang<F, C>)>,
-    expr: Ptr<F>,
+    expr: Ptr,
     store: &Store<F>,
     limit: usize,
-) -> Result<(Vec<Ptr<F>>, usize, Vec<Ptr<F>>)> {
+) -> Result<(Vec<Ptr>, usize, Vec<Ptr>)> {
     evaluate_simple_with_env(func_lang, expr, store.intern_nil(), store, limit)
 }
 
@@ -1805,7 +1805,7 @@ mod tests {
     fn test_counts() {
         let store = Store::default();
         let func = eval_step();
-        let frame = Frame::<Fr>::blank(func, 0);
+        let frame = Frame::blank(func, 0);
         let mut cs = TestConstraintSystem::<Fr>::new();
         let lang: Lang<Fr, Coproc<Fr>> = Lang::new();
         let _ = func.synthesize_frame_aux(&mut cs, &store, &frame, &lang);

--- a/src/lem/mod.rs
+++ b/src/lem/mod.rs
@@ -180,11 +180,11 @@ pub enum Lit {
 }
 
 impl Lit {
-    pub fn to_ptr<F: LurkField>(&self, store: &Store<F>) -> Ptr<F> {
+    pub fn to_ptr<F: LurkField>(&self, store: &Store<F>) -> Ptr {
         match self {
             Self::Symbol(s) => store.intern_symbol(s),
             Self::String(s) => store.intern_string(s),
-            Self::Num(num) => Ptr::num(F::from_u128(*num)),
+            Self::Num(num) => store.num(F::from_u128(*num)),
         }
     }
 }

--- a/src/lem/multiframe.rs
+++ b/src/lem/multiframe.rs
@@ -45,9 +45,9 @@ pub struct MultiFrame<'a, F: LurkField, C: Coprocessor<F>> {
     /// Cached coprocessor functions according to the `folding_config`. Holds
     /// `None` in case of IVC
     cprocs: Option<Arc<[Func]>>,
-    input: Option<Vec<Ptr<F>>>,
-    output: Option<Vec<Ptr<F>>>,
-    frames: Option<Vec<Frame<F>>>,
+    input: Option<Vec<Ptr>>,
+    output: Option<Vec<Ptr>>,
+    frames: Option<Vec<Frame>>,
     cached_witness: Option<WitnessCS<F>>,
     num_frames: usize,
     folding_config: Arc<FoldingConfig<F, C>>,
@@ -70,20 +70,20 @@ impl<'a, F: LurkField, C: Coprocessor<F>> MultiFrame<'a, F, C> {
     }
 }
 
-impl<F: LurkField> CEKState<Ptr<F>, Ptr<F>> for Vec<Ptr<F>> {
-    fn expr(&self) -> &Ptr<F> {
+impl CEKState<Ptr, Ptr> for Vec<Ptr> {
+    fn expr(&self) -> &Ptr {
         &self[0]
     }
-    fn env(&self) -> &Ptr<F> {
+    fn env(&self) -> &Ptr {
         &self[1]
     }
-    fn cont(&self) -> &Ptr<F> {
+    fn cont(&self) -> &Ptr {
         &self[2]
     }
 }
 
-impl<F: LurkField> FrameLike<Ptr<F>, Ptr<F>> for Frame<F> {
-    type FrameIO = Vec<Ptr<F>>;
+impl FrameLike<Ptr, Ptr> for Frame {
+    type FrameIO = Vec<Ptr>;
     fn input(&self) -> &Self::FrameIO {
         &self.input
     }
@@ -93,8 +93,8 @@ impl<F: LurkField> FrameLike<Ptr<F>, Ptr<F>> for Frame<F> {
 }
 
 impl<F: LurkField> EvaluationStore for Store<F> {
-    type Ptr = Ptr<F>;
-    type ContPtr = Ptr<F>;
+    type Ptr = Ptr;
+    type ContPtr = Ptr;
     type Error = anyhow::Error;
 
     fn read(&self, expr: &str) -> Result<Self::Ptr, Self::Error> {
@@ -124,7 +124,7 @@ impl<F: LurkField> EvaluationStore for Store<F> {
 fn assert_eq_ptrs_aptrs<F: LurkField>(
     store: &Store<F>,
     blank: bool,
-    ptrs: &[Ptr<F>],
+    ptrs: &[Ptr],
     aptrs: &[AllocatedPtr<F>],
 ) -> Result<(), SynthesisError> {
     assert_eq!(ptrs.len(), aptrs.len());
@@ -171,7 +171,7 @@ fn compute_witness_size<F: LurkField>(slot_type: &SlotType, store: &Store<F>) ->
 /// with dummy data, we cache their (dummy) witnesses for extra speed
 fn generate_slots_witnesses<F: LurkField>(
     store: &Store<F>,
-    frames: &[Frame<F>],
+    frames: &[Frame],
     num_slots_per_frame: usize,
     parallel: bool,
 ) -> Vec<Arc<SlotWitness<F>>> {
@@ -250,7 +250,7 @@ fn synthesize_frames_sequential<F: LurkField, CS: ConstraintSystem<F>, C: Coproc
     g: &GlobalAllocator<F>,
     store: &Store<F>,
     input: &[AllocatedPtr<F>],
-    frames: &[Frame<F>],
+    frames: &[Frame],
     func: &Func,
     lang: &Lang<F, C>,
     slots_witnesses_num_slots_per_frame: Option<(&[Arc<SlotWitness<F>>], usize)>,
@@ -289,7 +289,7 @@ fn synthesize_frames_parallel<F: LurkField, CS: ConstraintSystem<F>, C: Coproces
     g: &GlobalAllocator<F>,
     store: &Store<F>,
     input: Vec<AllocatedPtr<F>>,
-    frames: &[Frame<F>],
+    frames: &[Frame],
     func: &Func,
     lang: &Lang<F, C>,
     slots_witnesses: &[Arc<SlotWitness<F>>],
@@ -367,8 +367,8 @@ fn synthesize_frames_parallel<F: LurkField, CS: ConstraintSystem<F>, C: Coproces
 /// function. For efficiency, `frames` should have enough capacity to avoid
 /// reallocations
 fn pad_frames<F: LurkField, C: Coprocessor<F>>(
-    frames: &mut Vec<Frame<F>>,
-    input: &[Ptr<F>],
+    frames: &mut Vec<Frame>,
+    input: &[Ptr],
     lurk_step: &Func,
     lang: &Lang<F, C>,
     size: usize,
@@ -383,22 +383,22 @@ fn pad_frames<F: LurkField, C: Coprocessor<F>>(
 }
 
 impl<'a, F: LurkField, C: Coprocessor<F> + 'a> MultiFrameTrait<'a, F, C> for MultiFrame<'a, F, C> {
-    type Ptr = Ptr<F>;
-    type ContPtr = Ptr<F>;
+    type Ptr = Ptr;
+    type ContPtr = Ptr;
     type Store = Store<F>;
     type StoreError = store::Error;
-    type EvalFrame = Frame<F>;
-    type CircuitFrame = Frame<F>;
+    type EvalFrame = Frame;
+    type CircuitFrame = Frame;
     type GlobalAllocation = GlobalAllocator<F>;
     type AllocatedIO = Vec<AllocatedPtr<F>>;
 
-    fn emitted(_store: &Store<F>, eval_frame: &Self::EvalFrame) -> Vec<Ptr<F>> {
+    fn emitted(_store: &Store<F>, eval_frame: &Self::EvalFrame) -> Vec<Ptr> {
         eval_frame.emitted.to_vec()
     }
 
     fn io_to_scalar_vector(
         store: &Self::Store,
-        io: &<Self::EvalFrame as FrameLike<Ptr<F>, Ptr<F>>>::FrameIO,
+        io: &<Self::EvalFrame as FrameLike<Ptr, Ptr>>::FrameIO,
     ) -> Vec<F> {
         store.to_scalar_vector(io)
     }
@@ -423,7 +423,7 @@ impl<'a, F: LurkField, C: Coprocessor<F> + 'a> MultiFrameTrait<'a, F, C> for Mul
         &mut self.cached_witness
     }
 
-    fn output(&self) -> &Option<<Self::EvalFrame as FrameLike<Ptr<F>, Ptr<F>>>::FrameIO> {
+    fn output(&self) -> &Option<<Self::EvalFrame as FrameLike<Ptr, Ptr>>::FrameIO> {
         &self.output
     }
 
@@ -520,7 +520,7 @@ impl<'a, F: LurkField, C: Coprocessor<F> + 'a> MultiFrameTrait<'a, F, C> for Mul
     }
 
     fn from_frames(
-        frames: &[Frame<F>],
+        frames: &[Frame],
         store: &'a Self::Store,
         folding_config: Arc<FoldingConfig<F, C>>,
     ) -> Vec<Self> {
@@ -682,7 +682,7 @@ impl<'a, F: LurkField, C: Coprocessor<F> + 'a> MultiFrameTrait<'a, F, C> for Mul
     }
 
     fn significant_frame_count(frames: &[Self::EvalFrame]) -> usize {
-        let stop_cond = |output: &[Ptr<F>]| {
+        let stop_cond = |output: &[Ptr]| {
             matches!(
                 output[2].tag(),
                 Tag::Cont(ContTag::Terminal | ContTag::Error)
@@ -698,70 +698,69 @@ impl<'a, F: LurkField, C: Coprocessor<F> + 'a> MultiFrameTrait<'a, F, C> for Mul
 
 impl<'a, F: LurkField, C: Coprocessor<F>> Circuit<F> for MultiFrame<'a, F, C> {
     fn synthesize<CS: ConstraintSystem<F>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
-        let mut synth =
-            |store: &Store<F>, frames: &[Frame<F>], input: &[Ptr<F>], output: &[Ptr<F>]| {
-                let mut allocated_input = Vec::with_capacity(input.len());
-                for (i, ptr) in input.iter().enumerate() {
-                    let z_ptr = store.hash_ptr(ptr);
+        let mut synth = |store: &Store<F>, frames: &[Frame], input: &[Ptr], output: &[Ptr]| {
+            let mut allocated_input = Vec::with_capacity(input.len());
+            for (i, ptr) in input.iter().enumerate() {
+                let z_ptr = store.hash_ptr(ptr);
 
-                    let allocated_tag = AllocatedNum::alloc_infallible(
-                        &mut cs.namespace(|| format!("allocated tag for input {i}")),
-                        || z_ptr.tag_field(),
-                    );
-                    allocated_tag
-                        .inputize(&mut cs.namespace(|| format!("inputized tag for input {i}")))?;
+                let allocated_tag = AllocatedNum::alloc_infallible(
+                    &mut cs.namespace(|| format!("allocated tag for input {i}")),
+                    || z_ptr.tag_field(),
+                );
+                allocated_tag
+                    .inputize(&mut cs.namespace(|| format!("inputized tag for input {i}")))?;
 
-                    let allocated_hash = AllocatedNum::alloc_infallible(
-                        &mut cs.namespace(|| format!("allocated hash for input {i}")),
-                        || *z_ptr.value(),
-                    );
-                    allocated_hash
-                        .inputize(&mut cs.namespace(|| format!("inputized hash for input {i}")))?;
+                let allocated_hash = AllocatedNum::alloc_infallible(
+                    &mut cs.namespace(|| format!("allocated hash for input {i}")),
+                    || *z_ptr.value(),
+                );
+                allocated_hash
+                    .inputize(&mut cs.namespace(|| format!("inputized hash for input {i}")))?;
 
-                    allocated_input.push(AllocatedPtr::from_parts(allocated_tag, allocated_hash));
-                }
+                allocated_input.push(AllocatedPtr::from_parts(allocated_tag, allocated_hash));
+            }
 
-                let mut allocated_output = Vec::with_capacity(output.len());
-                for (i, ptr) in output.iter().enumerate() {
-                    let z_ptr = store.hash_ptr(ptr);
+            let mut allocated_output = Vec::with_capacity(output.len());
+            for (i, ptr) in output.iter().enumerate() {
+                let z_ptr = store.hash_ptr(ptr);
 
-                    let allocated_tag = AllocatedNum::alloc_infallible(
-                        &mut cs.namespace(|| format!("allocated tag for output {i}")),
-                        || z_ptr.tag_field(),
-                    );
-                    allocated_tag
-                        .inputize(&mut cs.namespace(|| format!("inputized tag for output {i}")))?;
+                let allocated_tag = AllocatedNum::alloc_infallible(
+                    &mut cs.namespace(|| format!("allocated tag for output {i}")),
+                    || z_ptr.tag_field(),
+                );
+                allocated_tag
+                    .inputize(&mut cs.namespace(|| format!("inputized tag for output {i}")))?;
 
-                    let allocated_hash = AllocatedNum::alloc_infallible(
-                        &mut cs.namespace(|| format!("allocated hash for output {i}")),
-                        || *z_ptr.value(),
-                    );
-                    allocated_hash
-                        .inputize(&mut cs.namespace(|| format!("inputized hash for output {i}")))?;
+                let allocated_hash = AllocatedNum::alloc_infallible(
+                    &mut cs.namespace(|| format!("allocated hash for output {i}")),
+                    || *z_ptr.value(),
+                );
+                allocated_hash
+                    .inputize(&mut cs.namespace(|| format!("inputized hash for output {i}")))?;
 
-                    allocated_output.push(AllocatedPtr::from_parts(allocated_tag, allocated_hash));
-                }
+                allocated_output.push(AllocatedPtr::from_parts(allocated_tag, allocated_hash));
+            }
 
-                let g = self.lurk_step.alloc_globals(cs, store)?;
+            let g = self.lurk_step.alloc_globals(cs, store)?;
 
-                let allocated_output_result =
-                    self.synthesize_frames(cs, store, allocated_input, frames, &g)?;
+            let allocated_output_result =
+                self.synthesize_frames(cs, store, allocated_input, frames, &g)?;
 
-                assert_eq!(allocated_output.len(), allocated_output_result.len());
+            assert_eq!(allocated_output.len(), allocated_output_result.len());
 
-                for (i, (o_res, o)) in allocated_output_result
-                    .iter()
-                    .zip(allocated_output)
-                    .enumerate()
-                {
-                    o_res.enforce_equal(
-                        &mut cs.namespace(|| format!("outer output {i} is correct")),
-                        &o,
-                    );
-                }
+            for (i, (o_res, o)) in allocated_output_result
+                .iter()
+                .zip(allocated_output)
+                .enumerate()
+            {
+                o_res.enforce_equal(
+                    &mut cs.namespace(|| format!("outer output {i} is correct")),
+                    &o,
+                );
+            }
 
-                Ok(())
-            };
+            Ok(())
+        };
 
         match self.store {
             Some(store) => {
@@ -778,8 +777,8 @@ impl<'a, F: LurkField, C: Coprocessor<F>> Circuit<F> for MultiFrame<'a, F, C> {
             }
             None => {
                 assert!(self.frames.is_none());
-                let dummy_io = [Ptr::dummy(); 3];
                 let store = Store::default();
+                let dummy_io = [store.dummy(); 3];
                 let blank_frame = Frame::blank(self.get_func(), self.pc);
                 let frames = vec![blank_frame; self.num_frames];
                 synth(&store, &frames, &dummy_io, &dummy_io)

--- a/src/lem/slot.rs
+++ b/src/lem/slot.rs
@@ -104,7 +104,6 @@
 //! expression and so will STEP 3.
 
 use super::{pointers::Ptr, Block, Ctrl, Op};
-use crate::field::LurkField;
 
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SlotsCounter {
@@ -234,11 +233,16 @@ impl Block {
     }
 }
 
+/// Holds data to feed the slots
 #[derive(Clone, Debug)]
-pub enum SlotData<F: LurkField> {
-    PtrVec(Vec<Ptr<F>>),
-    FPtr(F, Ptr<F>),
-    F(F),
+pub enum SlotData {
+    /// A sequence of pointers, holding hashing preimages
+    PtrVec(Vec<Ptr>),
+    /// An element of the finite field (cached in a `Store`) and a `Ptr` for
+    /// commitments
+    FPtr(usize, Ptr),
+    /// An element of the finite field (cached in a `Store`) for bit decompositions
+    F(usize),
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
@@ -261,7 +265,7 @@ impl SlotType {
         }
     }
 
-    pub(crate) fn is_compatible<F: LurkField>(&self, slot_data: &SlotData<F>) -> bool {
+    pub(crate) fn is_compatible(&self, slot_data: &SlotData) -> bool {
         matches!(
             (self, slot_data),
             (Self::Hash4, SlotData::PtrVec(..))

--- a/src/lem/tests/eval_tests.rs
+++ b/src/lem/tests/eval_tests.rs
@@ -17,10 +17,10 @@ use crate::{
 fn test_aux<C: Coprocessor<Fr>>(
     s: &Store<Fr>,
     expr: &str,
-    expected_result: Option<Ptr<Fr>>,
-    expected_env: Option<Ptr<Fr>>,
-    expected_cont: Option<Ptr<Fr>>,
-    expected_emitted: Option<Vec<Ptr<Fr>>>,
+    expected_result: Option<Ptr>,
+    expected_env: Option<Ptr>,
+    expected_cont: Option<Ptr>,
+    expected_emitted: Option<Vec<Ptr>>,
     expected_iterations: usize,
     lang: &Option<&Lang<Fr, C>>,
 ) {
@@ -41,10 +41,10 @@ fn test_aux_with_state<C: Coprocessor<Fr>>(
     s: &Store<Fr>,
     state: Rc<RefCell<State>>,
     expr: &str,
-    expected_result: Option<Ptr<Fr>>,
-    expected_env: Option<Ptr<Fr>>,
-    expected_cont: Option<Ptr<Fr>>,
-    expected_emitted: Option<Vec<Ptr<Fr>>>,
+    expected_result: Option<Ptr>,
+    expected_env: Option<Ptr>,
+    expected_cont: Option<Ptr>,
+    expected_emitted: Option<Vec<Ptr>>,
     expected_iterations: usize,
     lang: &Option<&Lang<Fr, C>>,
 ) {
@@ -64,11 +64,11 @@ fn test_aux_with_state<C: Coprocessor<Fr>>(
 #[inline]
 fn do_test_aux<C: Coprocessor<Fr>>(
     s: &Store<Fr>,
-    ptr: &Ptr<Fr>,
-    expected_result: Option<Ptr<Fr>>,
-    expected_env: Option<Ptr<Fr>>,
-    expected_cont: Option<Ptr<Fr>>,
-    expected_emitted: Option<Vec<Ptr<Fr>>>,
+    ptr: &Ptr,
+    expected_result: Option<Ptr>,
+    expected_env: Option<Ptr>,
+    expected_cont: Option<Ptr>,
+    expected_emitted: Option<Vec<Ptr>>,
     expected_iterations: usize,
     lang: &Option<&Lang<Fr, C>>,
 ) {
@@ -100,11 +100,11 @@ fn do_test_aux<C: Coprocessor<Fr>>(
 
 fn do_test<C: Coprocessor<Fr>>(
     s: &Store<Fr>,
-    expr: &Ptr<Fr>,
-    expected_result: Option<Ptr<Fr>>,
-    expected_env: Option<Ptr<Fr>>,
-    expected_cont: Option<Ptr<Fr>>,
-    expected_emitted: Option<Vec<Ptr<Fr>>>,
+    expr: &Ptr,
+    expected_result: Option<Ptr>,
+    expected_env: Option<Ptr>,
+    expected_cont: Option<Ptr>,
+    expected_emitted: Option<Vec<Ptr>>,
     expected_iterations: usize,
     lang: &Lang<Fr, C>,
 ) {
@@ -145,13 +145,13 @@ fn do_test<C: Coprocessor<Fr>>(
 fn self_evaluating() {
     let s = &Store::<Fr>::default();
     let expr_num = "999";
-    let expt_num = Ptr::num_u64(999);
+    let expt_num = s.num_u64(999);
 
     let expr_u64 = "999u64";
-    let expt_u64 = Ptr::u64(999);
+    let expt_u64 = s.u64(999);
 
     let expr_char = "'a'";
-    let expt_char = Ptr::char('a');
+    let expt_char = s.char('a');
 
     let expr_str = "\"abc\"";
     let expt_str = s.intern_string("abc");
@@ -188,8 +188,8 @@ fn evaluate_cons() {
     let s = &Store::<Fr>::default();
     let expr = "(cons 1 2)";
 
-    let car = Ptr::num_u64(1);
-    let cdr = Ptr::num_u64(2);
+    let car = s.num_u64(1);
+    let cdr = s.num_u64(2);
     let expected = s.cons(car, cdr);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
@@ -208,7 +208,7 @@ fn evaluate_cons() {
 fn emit_output() {
     let s = &Store::<Fr>::default();
     let expr = "(emit 123)";
-    let expected = Ptr::num_u64(123);
+    let expected = s.num_u64(123);
     let emitted = vec![expected];
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
@@ -228,7 +228,7 @@ fn evaluate_lambda() {
     let s = &Store::<Fr>::default();
     let expr = "((lambda (x) x) 123)";
 
-    let expected = Ptr::num_u64(123);
+    let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -247,7 +247,7 @@ fn evaluate_empty_args_lambda() {
     let s = &Store::<Fr>::default();
     let expr = "((lambda () 123))";
 
-    let expected = Ptr::num_u64(123);
+    let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -266,7 +266,7 @@ fn evaluate_lambda2() {
     let s = &Store::<Fr>::default();
     let expr = "((lambda (y) ((lambda (x) y) 321)) 123)";
 
-    let expected = Ptr::num_u64(123);
+    let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -285,7 +285,7 @@ fn evaluate_lambda3() {
     let s = &Store::<Fr>::default();
     let expr = "((lambda (y) ((lambda (x) ((lambda (z) z) x)) y)) 123)";
 
-    let expected = Ptr::num_u64(123);
+    let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -306,7 +306,7 @@ fn evaluate_lambda4() {
         // NOTE: We pass two different values. This tests which is returned.
             "((lambda (y) ((lambda (x) ((lambda (z) z) x)) 888)) 999)";
 
-    let expected = Ptr::num_u64(888);
+    let expected = s.num_u64(888);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -327,7 +327,7 @@ fn evaluate_lambda5() {
         // Bind a function to the name FN, then call it.
             "(((lambda (fn) (lambda (x) (fn x))) (lambda (y) y)) 999)";
 
-    let expected = Ptr::num_u64(999);
+    let expected = s.num_u64(999);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -346,7 +346,7 @@ fn evaluate_sum() {
     let s = &Store::<Fr>::default();
     let expr = "(+ 2 (+ 3 4))";
 
-    let expected = Ptr::num_u64(9);
+    let expected = s.num_u64(9);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -365,7 +365,7 @@ fn evaluate_diff() {
     let s = &Store::<Fr>::default();
     let expr = "(- 9 5)";
 
-    let expected = Ptr::num_u64(4);
+    let expected = s.num_u64(4);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -384,7 +384,7 @@ fn evaluate_product() {
     let s = &Store::<Fr>::default();
     let expr = "(* 9 5)";
 
-    let expected = Ptr::num_u64(45);
+    let expected = s.num_u64(45);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -403,7 +403,7 @@ fn evaluate_quotient() {
     let s = &Store::<Fr>::default();
     let expr = "(/ 21 7)";
 
-    let expected = Ptr::num_u64(3);
+    let expected = s.num_u64(3);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -469,7 +469,7 @@ fn evaluate_adder1() {
     let s = &Store::<Fr>::default();
     let expr = "(((lambda (x) (lambda (y) (+ x y))) 2) 3)";
 
-    let expected = Ptr::num_u64(5);
+    let expected = s.num_u64(5);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -490,7 +490,7 @@ fn evaluate_adder2() {
     let expr = "(let ((make-adder (lambda (x) (lambda (y) (+ x y)))))
                    ((make-adder 2) 3))";
 
-    let expected = Ptr::num_u64(5);
+    let expected = s.num_u64(5);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -509,7 +509,7 @@ fn evaluate_let_simple() {
     let s = &Store::<Fr>::default();
     let expr = "(let ((a 1)) a)";
 
-    let expected = Ptr::num_u64(1);
+    let expected = s.num_u64(1);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -528,7 +528,7 @@ fn evaluate_empty_let_bug() {
     let s = &Store::<Fr>::default();
     let expr = "(let () (+ 1 2))";
 
-    let expected = Ptr::num_u64(3);
+    let expected = s.num_u64(3);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -549,7 +549,7 @@ fn evaluate_let() {
                         (b 2))
                    (+ a b))";
 
-    let expected = Ptr::num_u64(3);
+    let expected = s.num_u64(3);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -623,7 +623,7 @@ fn evaluate_let_parallel_binding() {
     let s = &Store::<Fr>::default();
     let expr = "(let ((a 1) (b a)) b)";
 
-    let expected = Ptr::num_u64(1);
+    let expected = s.num_u64(1);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -645,7 +645,7 @@ fn evaluate_arithmetic_let() {
                         (c 2))
                    (/ (+ a b) c))";
 
-    let expected = Ptr::num_u64(3);
+    let expected = s.num_u64(3);
     let new_env = s.intern_nil();
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
@@ -677,7 +677,7 @@ fn evaluate_fundamental_conditional() {
                                        ((cond a) b))))))
                        (((iff 5) 6) true))";
 
-        let expected = Ptr::num_u64(5);
+        let expected = s.num_u64(5);
         let terminal = s.cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
@@ -704,7 +704,7 @@ fn evaluate_fundamental_conditional() {
                                        ((cond a) b))))))
                        (((iff 5) 6) false))";
 
-        let expected = Ptr::num_u64(6);
+        let expected = s.num_u64(6);
         let terminal = s.cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
@@ -725,7 +725,7 @@ fn evaluate_if() {
         let s = &Store::<Fr>::default();
         let expr = "(if t 5 6)";
 
-        let expected = Ptr::num_u64(5);
+        let expected = s.num_u64(5);
         let terminal = s.cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
@@ -742,7 +742,7 @@ fn evaluate_if() {
         let s = &Store::<Fr>::default();
         let expr = "(if nil 5 6)";
 
-        let expected = Ptr::num_u64(6);
+        let expected = s.num_u64(6);
         let terminal = s.cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
@@ -763,7 +763,7 @@ fn evaluate_fully_evaluates() {
         let s = &Store::<Fr>::default();
         let expr = "(if t (+ 5 5) 6)";
 
-        let expected = Ptr::num_u64(10);
+        let expected = s.num_u64(10);
         let terminal = s.cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
@@ -788,7 +788,7 @@ fn evaluate_recursion1() {
                                         (* base ((exp base) (- exponent 1))))))))
                    ((exp 5) 3))";
 
-    let expected = Ptr::num_u64(125);
+    let expected = s.num_u64(125);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -813,7 +813,7 @@ fn evaluate_recursion2() {
                                           (((exp base) (- exponent 1)) (* acc base))))))))
                    (((exp 5) 5) 1))";
 
-    let expected = Ptr::num_u64(3125);
+    let expected = s.num_u64(3125);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -836,7 +836,7 @@ fn evaluate_recursion_multiarg() {
                                       (* base (exp base (- exponent 1)))))))
                           (exp 5 3))";
 
-    let expected = Ptr::num_u64(125);
+    let expected = s.num_u64(125);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -862,7 +862,7 @@ fn evaluate_recursion_optimized() {
                                         base-inner))))
                     ((exp 5) 3))";
 
-    let expected = Ptr::num_u64(125);
+    let expected = s.num_u64(125);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -887,7 +887,7 @@ fn evaluate_tail_recursion() {
                                           (((exp base) (- exponent-remaining 1)) (* acc base))))))))
                           (((exp 5) 3) 1))";
 
-    let expected = Ptr::num_u64(125);
+    let expected = s.num_u64(125);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -915,7 +915,7 @@ fn evaluate_tail_recursion_somewhat_optimized() {
                                       base-inner))))
                    (((exp 5) 3) 1))";
 
-    let expected = Ptr::num_u64(125);
+    let expected = s.num_u64(125);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -936,7 +936,7 @@ fn evaluate_multiple_letrec_bindings() {
                            (square (lambda (x) (* x x))))
                    (+ (square 3) (double 2)))";
 
-    let expected = Ptr::num_u64(13);
+    let expected = s.num_u64(13);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -957,7 +957,7 @@ fn evaluate_multiple_letrec_bindings_referencing() {
                            (double-inc (lambda (x) (+ 1 (double x)))))
                    (+ (double 3) (double-inc 2)))";
 
-    let expected = Ptr::num_u64(11);
+    let expected = s.num_u64(11);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -989,7 +989,7 @@ fn evaluate_multiple_letrec_bindings_recursive() {
                    (+ (+ (exp 3 2) (exp2 2 3))
                       (exp3 4 2)))";
 
-    let expected = Ptr::num_u64(33);
+    let expected = s.num_u64(33);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -1007,7 +1007,7 @@ fn evaluate_multiple_letrec_bindings_recursive() {
 fn nested_let_closure_regression() {
     let s = &Store::<Fr>::default();
     let terminal = s.cont_terminal();
-    let expected = Ptr::num_u64(6);
+    let expected = s.num_u64(6);
 
     {
         // This always works.
@@ -1125,7 +1125,7 @@ fn evaluate_zero_arg_lambda() {
     {
         let expr = "((lambda () 123))";
 
-        let expected = Ptr::num_u64(123);
+        let expected = s.num_u64(123);
         test_aux::<Coproc<Fr>>(
             s,
             expr,
@@ -1140,7 +1140,7 @@ fn evaluate_zero_arg_lambda() {
     {
         let expected = {
             let arg = s.intern_user_symbol("x");
-            let num = Ptr::num_u64(123);
+            let num = s.num_u64(123);
             let body = s.list(vec![num]);
             let env = s.intern_nil();
             s.intern_fun(arg, body, env)
@@ -1162,7 +1162,7 @@ fn evaluate_zero_arg_lambda() {
     {
         let expr = "(letrec ((x 9) (f (lambda () (+ x 1)))) (f))";
 
-        let expected = Ptr::num_u64(10);
+        let expected = s.num_u64(10);
         test_aux::<Coproc<Fr>>(
             s,
             expr,
@@ -1348,7 +1348,7 @@ fn dont_discard_rest_env() {
                                  (b 2)
                                  (l (lambda (x) (+ z x))))
                          (l 9)))";
-        let expected = Ptr::num_u64(18);
+        let expected = s.num_u64(18);
         let terminal = s.cont_terminal();
         test_aux::<Coproc<Fr>>(
             s,
@@ -1572,7 +1572,7 @@ fn go_translate() {
     // }
 
     let s = &Store::<Fr>::default();
-    let n = Ptr::num_u64(0x1044);
+    let n = s.num_u64(0x1044);
     test_aux::<Coproc<Fr>>(
         s,
         r#"
@@ -1611,7 +1611,7 @@ fn begin() {
     {
         let s = &Store::<Fr>::default();
         let expr = "(car (begin 1 2 '(3 . 4)))";
-        let expected = Ptr::num_u64(3);
+        let expected = s.num_u64(3);
         test_aux::<Coproc<Fr>>(s, expr, Some(expected), None, None, None, 6, &None);
     }
 }
@@ -1623,7 +1623,7 @@ fn begin_current_env1() {
         let expr = "(let ((a 1))
                        (begin 123 (current-env)))";
         let a = s.intern_user_symbol("a");
-        let one = Ptr::num_u64(1);
+        let one = s.num_u64(1);
         let binding = s.cons(a, one);
         let expected = s.list(vec![binding]);
         test_aux::<Coproc<Fr>>(s, expr, Some(expected), None, None, None, 5, &None);
@@ -1645,7 +1645,7 @@ fn hide_opaque_open_available() {
     let (output, ..) = evaluate_simple::<Fr, Coproc<Fr>>(None, expr, s, 10).unwrap();
 
     let c = *s.hash_ptr(&output[0]).value();
-    let comm = Ptr::comm(c);
+    let comm = s.comm(c);
 
     let open = s.intern_lurk_symbol("open");
     let x = s.intern_user_symbol("x");
@@ -1659,13 +1659,13 @@ fn hide_opaque_open_available() {
     {
         let secret = s.intern_lurk_symbol("secret");
         let expr = s.list(vec![secret, comm]);
-        let sec = Ptr::num_u64(123);
+        let sec = s.num_u64(123);
         do_test::<Coproc<Fr>>(s, &expr, Some(sec), None, None, None, 2, &lang);
     }
 
     {
         // We can open a commitment identified by its corresponding `Num`.
-        let comm_num = Ptr::num(c);
+        let comm_num = s.num(c);
         let expr2 = s.list(vec![open, comm_num]);
         do_test::<Coproc<Fr>>(s, &expr2, Some(x), None, None, None, 2, &lang);
     }
@@ -1681,7 +1681,7 @@ fn hide_opaque_open_unavailable() {
     let c = *s.hash_ptr(&output[0]).value();
 
     let s2 = &Store::<Fr>::default();
-    let comm = Ptr::comm(c);
+    let comm = s.comm(c);
     let open = s2.intern_lurk_symbol("open");
     let x = s2.intern_user_symbol("x");
 
@@ -1779,7 +1779,7 @@ fn char_error() {
 fn prove_commit_secret() {
     let s = &Store::<Fr>::default();
     let expr = "(secret (commit 123))";
-    let expected = Ptr::num_u64(0);
+    let expected = s.num_u64(0);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -1797,7 +1797,7 @@ fn prove_commit_secret() {
 fn num() {
     let s = &Store::<Fr>::default();
     let expr = "(num 123)";
-    let expected = Ptr::num_u64(123);
+    let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -1815,7 +1815,7 @@ fn num() {
 fn num_char() {
     let s = &Store::<Fr>::default();
     let expr = r"(num #\a)";
-    let expected = Ptr::num_u64(97);
+    let expected = s.num_u64(97);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -1877,7 +1877,7 @@ fn commit_num() {
 fn hide_open_comm_num() {
     let s = &Store::<Fr>::default();
     let expr = "(open (comm (num (hide 123 456))))";
-    let expected = Ptr::num_u64(456);
+    let expected = s.num_u64(456);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -1895,7 +1895,7 @@ fn hide_open_comm_num() {
 fn hide_secret_comm_num() {
     let s = &Store::<Fr>::default();
     let expr = "(secret (comm (num (hide 123 456))))";
-    let expected = Ptr::num_u64(123);
+    let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -1913,7 +1913,7 @@ fn hide_secret_comm_num() {
 fn commit_open_comm_num() {
     let s = &Store::<Fr>::default();
     let expr = "(open (comm (num (commit 123))))";
-    let expected = Ptr::num_u64(123);
+    let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -1931,7 +1931,7 @@ fn commit_open_comm_num() {
 fn commit_secret_comm_num() {
     let s = &Store::<Fr>::default();
     let expr = "(secret (comm (num (commit 123))))";
-    let expected = Ptr::num_u64(0);
+    let expected = s.num_u64(0);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -1949,7 +1949,7 @@ fn commit_secret_comm_num() {
 fn commit_num_open() {
     let s = &Store::<Fr>::default();
     let expr = "(open (num (commit 123)))";
-    let expected = Ptr::num_u64(123);
+    let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -2282,7 +2282,7 @@ fn test_quoted_symbols() {
     let expr = "(let ((|foo bar| 9)
                           (|Foo \\| Bar| (lambda (x) (* x x))))
                       (|Foo \\| Bar| |foo bar|))";
-    let res = Ptr::num_u64(81);
+    let res = s.num_u64(81);
     let terminal = s.cont_terminal();
 
     test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 13, &None);
@@ -2293,8 +2293,8 @@ fn test_eval() {
     let s = &Store::<Fr>::default();
     let expr = "(* 3 (eval (cons '+ (cons 1 (cons 2 nil)))))";
     let expr2 = "(* 5 (eval '(+ 1 a) '((a . 3))))"; // two-arg eval, optional second arg is env.
-    let res = Ptr::num_u64(9);
-    let res2 = Ptr::num_u64(20);
+    let res = s.num_u64(9);
+    let res2 = s.num_u64(20);
     let terminal = s.cont_terminal();
 
     test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 17, &None);
@@ -2306,7 +2306,7 @@ fn test_eval_env_regression() {
     let s = &Store::<Fr>::default();
     let expr = "(let ((a 1)) (eval 'a))";
     let expr2 = "(let ((a 1)) (eval 'a (current-env)))";
-    let res = Ptr::num_u64(1);
+    let res = s.num_u64(1);
     let error = s.cont_error();
     let terminal = s.cont_terminal();
 
@@ -2321,7 +2321,7 @@ fn test_u64_mul() {
     let expr = "(* (u64 18446744073709551615) (u64 2))";
     let expr2 = "(* 18446744073709551615u64 2u64)";
     let expr3 = "(* (- 0u64 1u64) 2u64)";
-    let res = Ptr::u64(18446744073709551614);
+    let res = s.u64(18446744073709551614);
     let terminal = s.cont_terminal();
 
     test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 7, &None);
@@ -2335,7 +2335,7 @@ fn test_u64_add() {
 
     let expr = "(+ 18446744073709551615u64 2u64)";
     let expr2 = "(+ (- 0u64 1u64) 2u64)";
-    let res = Ptr::u64(1);
+    let res = s.u64(1);
     let terminal = s.cont_terminal();
 
     test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 3, &None);
@@ -2349,9 +2349,9 @@ fn test_u64_sub() {
     let expr = "(- 2u64 1u64)";
     let expr2 = "(- 0u64 1u64)";
     let expr3 = "(+ 1u64 (- 0u64 1u64))";
-    let res = Ptr::u64(1);
-    let res2 = Ptr::u64(18446744073709551615);
-    let res3 = Ptr::u64(0);
+    let res = s.u64(1);
+    let res2 = s.u64(18446744073709551615);
+    let res3 = s.u64(0);
     let terminal = s.cont_terminal();
 
     test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 3, &None);
@@ -2364,10 +2364,10 @@ fn test_u64_div() {
     let s = &Store::<Fr>::default();
 
     let expr = "(/ 100u64 2u64)";
-    let res = Ptr::u64(50);
+    let res = s.u64(50);
 
     let expr2 = "(/ 100u64 3u64)";
-    let res2 = Ptr::u64(33);
+    let res2 = s.u64(33);
 
     let expr3 = "(/ 100u64 0u64)";
 
@@ -2384,10 +2384,10 @@ fn test_u64_mod() {
     let s = &Store::<Fr>::default();
 
     let expr = "(% 100u64 2u64)";
-    let res = Ptr::u64(0);
+    let res = s.u64(0);
 
     let expr2 = "(% 100u64 3u64)";
-    let res2 = Ptr::u64(1);
+    let res2 = s.u64(1);
 
     let expr3 = "(% 100u64 0u64)";
 
@@ -2467,10 +2467,10 @@ fn test_u64_conversion() {
     let expr6 = "(u64)";
     let expr7 = "(u64 1 1)";
 
-    let res = Ptr::num_u64(1);
-    let res2 = Ptr::num_u64(2);
-    let res3 = Ptr::u64(2);
-    let res5 = Ptr::u64(123);
+    let res = s.num_u64(1);
+    let res2 = s.num_u64(2);
+    let res3 = s.u64(2);
+    let res5 = s.u64(123);
     let terminal = s.cont_terminal();
     let error = s.cont_error();
 
@@ -2632,7 +2632,7 @@ fn test_fold_cons_regression() {
                                          (fold op (op acc (car l)) (cdr l))
                                          acc))))
                       (fold (lambda (x y) (+ x y)) 0 '(1 2 3)))";
-    let res = Ptr::num_u64(6);
+    let res = s.num_u64(6);
     let terminal = s.cont_terminal();
 
     test_aux::<Coproc<Fr>>(s, expr, Some(res), None, Some(terminal), None, 152, &None);
@@ -2819,11 +2819,11 @@ fn test_dumb_lang() {
     let expr6_ = "(cproc-dumb 'x' 'y')";
     let expr7 = "(cproc-dumb 0 'y')";
 
-    let res = Ptr::num_u64(89);
-    let error4 = s.list(vec![Ptr::num_u64(123), Ptr::num_u64(8), Ptr::num_u64(9)]);
-    let error5 = s.list(vec![Ptr::num_u64(9)]);
-    let error6 = Ptr::char('x');
-    let error7 = Ptr::char('y');
+    let res = s.num_u64(89);
+    let error4 = s.list(vec![s.num_u64(123), s.num_u64(8), s.num_u64(9)]);
+    let error5 = s.list(vec![s.num_u64(9)]);
+    let error6 = s.char('x');
+    let error7 = s.char('y');
 
     let error = s.cont_error();
     let terminal = s.cont_terminal();
@@ -2942,7 +2942,7 @@ fn test_trie_lang() {
 
     let expr2 =
         "(.lurk.trie.lookup 0x1cc5b90039db85fd519af975afa1de9d2b92960a585a546637b653b115bc3b53 123)";
-    let res2 = Ptr::comm(Fr::zero());
+    let res2 = s.comm(Fr::zero());
 
     test_aux_with_state(
         s,
@@ -2978,7 +2978,7 @@ fn test_trie_lang() {
 
     let expr4 =
         "(.lurk.trie.lookup 0x1b22dc5a394231c34e4529af674dc56a736fbd07508acfd1d12c0e67c8b4de27 123)";
-    let res4 = Ptr::comm(Fr::from(456));
+    let res4 = s.comm(Fr::from(456));
 
     test_aux_with_state(
         s,
@@ -2996,7 +2996,7 @@ fn test_trie_lang() {
     let expr5 = "(let ((trie (.lurk.trie.new))
                        (found (.lurk.trie.lookup trie 123)))
                       found)";
-    let res5 = Ptr::comm(Fr::zero());
+    let res5 = s.comm(Fr::zero());
 
     test_aux_with_state(
         s,
@@ -3013,7 +3013,7 @@ fn test_trie_lang() {
     let expr6 = "(let ((trie (.lurk.trie.insert (.lurk.trie.new) 123 456))
                        (found (.lurk.trie.lookup trie 123)))
                       found)";
-    let res6 = Ptr::comm(Fr::from(456));
+    let res6 = s.comm(Fr::from(456));
 
     test_aux_with_state(
         s,

--- a/src/lem/tests/misc.rs
+++ b/src/lem/tests/misc.rs
@@ -15,8 +15,12 @@ use crate::{
 ///   therefore this parameter can be used to test circuit uniformity among all the
 ///   provided expressions.
 ///   - `expected_slots` gives the number of expected slots for each type of hash.
-fn synthesize_test_helper(func: &Func, inputs: Vec<Ptr<Fr>>, expected_num_slots: SlotsCounter) {
-    let store = &Store::default();
+fn synthesize_test_helper(
+    func: &Func,
+    inputs: Vec<Ptr>,
+    expected_num_slots: SlotsCounter,
+    store: &Store<Fr>,
+) {
     let nil = store.intern_nil();
     let outermost = store.cont_outermost();
 
@@ -82,8 +86,9 @@ fn accepts_virtual_nested_match_tag() {
         }
     });
 
-    let inputs = vec![Ptr::num(Fr::from_u64(42))];
-    synthesize_test_helper(&lem, inputs, SlotsCounter::default());
+    let store = Store::default();
+    let inputs = vec![store.num(Fr::from_u64(42))];
+    synthesize_test_helper(&lem, inputs, SlotsCounter::default(), &store);
 }
 
 #[test]
@@ -106,8 +111,9 @@ fn resolves_conflicts_of_clashing_names_in_parallel_branches() {
         }
     });
 
-    let inputs = vec![Ptr::num(Fr::from_u64(42))];
-    synthesize_test_helper(&lem, inputs, SlotsCounter::default());
+    let store = Store::default();
+    let inputs = vec![store.num(Fr::from_u64(42))];
+    synthesize_test_helper(&lem, inputs, SlotsCounter::default(), &store);
 }
 
 #[test]
@@ -121,8 +127,9 @@ fn handles_non_ssa() {
         return (x, x, cont_out_terminal);
     });
 
-    let inputs = vec![Ptr::num(Fr::from_u64(42))];
-    synthesize_test_helper(&func, inputs, SlotsCounter::new((2, 0, 0, 0, 0)));
+    let store = Store::default();
+    let inputs = vec![store.num(Fr::from_u64(42))];
+    synthesize_test_helper(&func, inputs, SlotsCounter::new((2, 0, 0, 0, 0)), &store);
 }
 
 #[test]
@@ -132,8 +139,9 @@ fn test_simple_all_paths_delta() {
         return (expr_in, env_in, cont_out_terminal);
     });
 
-    let inputs = vec![Ptr::num(Fr::from_u64(42)), Ptr::char('c')];
-    synthesize_test_helper(&lem, inputs, SlotsCounter::default());
+    let store = Store::default();
+    let inputs = vec![store.num(Fr::from_u64(42)), store.char('c')];
+    synthesize_test_helper(&lem, inputs, SlotsCounter::default(), &store);
 }
 
 #[test]
@@ -151,8 +159,9 @@ fn test_match_all_paths_delta() {
         }
     });
 
-    let inputs = vec![Ptr::num(Fr::from_u64(42)), Ptr::char('c')];
-    synthesize_test_helper(&lem, inputs, SlotsCounter::default());
+    let store = Store::default();
+    let inputs = vec![store.num(Fr::from_u64(42)), store.char('c')];
+    synthesize_test_helper(&lem, inputs, SlotsCounter::default(), &store);
 }
 
 #[test]
@@ -182,8 +191,9 @@ fn test_hash_slots() {
         }
     });
 
-    let inputs = vec![Ptr::num(Fr::from_u64(42)), Ptr::char('c')];
-    synthesize_test_helper(&lem, inputs, SlotsCounter::new((2, 2, 2, 0, 0)));
+    let store = Store::default();
+    let inputs = vec![store.num(Fr::from_u64(42)), store.char('c')];
+    synthesize_test_helper(&lem, inputs, SlotsCounter::new((2, 2, 2, 0, 0)), &store);
 }
 
 #[test]
@@ -216,8 +226,9 @@ fn test_unhash_slots() {
         }
     });
 
-    let inputs = vec![Ptr::num(Fr::from_u64(42)), Ptr::char('c')];
-    synthesize_test_helper(&lem, inputs, SlotsCounter::new((3, 3, 3, 0, 0)));
+    let store = Store::default();
+    let inputs = vec![store.num(Fr::from_u64(42)), store.char('c')];
+    synthesize_test_helper(&lem, inputs, SlotsCounter::new((3, 3, 3, 0, 0)), &store);
 }
 
 #[test]
@@ -263,6 +274,7 @@ fn test_unhash_nested_slots() {
         }
     });
 
-    let inputs = vec![Ptr::num(Fr::from_u64(42)), Ptr::char('c')];
-    synthesize_test_helper(&lem, inputs, SlotsCounter::new((4, 4, 4, 0, 0)));
+    let store = Store::default();
+    let inputs = vec![store.num(Fr::from_u64(42)), store.char('c')];
+    synthesize_test_helper(&lem, inputs, SlotsCounter::new((4, 4, 4, 0, 0)), &store);
 }

--- a/src/proof/tests/nova_tests_lem.rs
+++ b/src/proof/tests/nova_tests_lem.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, rc::Rc, sync::Arc};
 
 use crate::{
     eval::lang::{Coproc, Lang},
-    lem::{pointers::Ptr, store::Store, Tag},
+    lem::{store::Store, Tag},
     num::Num,
     proof::nova::C1LEM,
     state::user_sym,
@@ -19,13 +19,13 @@ type M1<'a, Fr> = C1LEM<'a, Fr, Coproc<Fr>>;
 fn test_prove_self_evaluating() {
     let s = &Store::<Fr>::default();
     let expr_num = "999";
-    let expt_num = Ptr::num_u64(999);
+    let expt_num = s.num_u64(999);
 
     let expr_u64 = "999u64";
-    let expt_u64 = Ptr::u64(999);
+    let expt_u64 = s.u64(999);
 
     let expr_char = "'a'";
-    let expt_char = Ptr::char('a');
+    let expt_char = s.char('a');
 
     let expr_str = "\"abc\"";
     let expt_str = s.intern_string("abc");
@@ -72,7 +72,7 @@ fn test_prove_self_evaluating() {
 #[test]
 fn test_prove_binop() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(3);
+    let expected = s.num_u64(3);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -92,7 +92,7 @@ fn test_prove_binop() {
 // the test should panic on an assertion failure.
 fn test_prove_binop_fail() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(2);
+    let expected = s.num_u64(2);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -110,7 +110,7 @@ fn test_prove_binop_fail() {
 #[ignore]
 fn test_prove_arithmetic_let() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(3);
+    let expected = s.num_u64(3);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -195,7 +195,7 @@ fn test_prove_invalid_num_equal() {
         &None,
     );
 
-    let expected = Ptr::num_u64(5);
+    let expected = s.num_u64(5);
     test_aux::<_, _, M1<'_, _>>(
         s,
         "(= nil 5)",
@@ -267,7 +267,7 @@ fn test_prove_quote_end_is_nil_error() {
 #[test]
 fn test_prove_if() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(5);
+    let expected = s.num_u64(5);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -280,7 +280,7 @@ fn test_prove_if() {
         &None,
     );
 
-    let expected = Ptr::num_u64(6);
+    let expected = s.num_u64(6);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -297,7 +297,7 @@ fn test_prove_if() {
 #[test]
 fn test_prove_if_end_is_nil_error() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(5);
+    let expected = s.num_u64(5);
     let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -315,7 +315,7 @@ fn test_prove_if_end_is_nil_error() {
 #[ignore]
 fn test_prove_if_fully_evaluates() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(10);
+    let expected = s.num_u64(10);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -333,7 +333,7 @@ fn test_prove_if_fully_evaluates() {
 #[ignore] // Skip expensive tests in CI for now. Do run these locally, please.
 fn test_prove_recursion1() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(25);
+    let expected = s.num_u64(25);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -356,7 +356,7 @@ fn test_prove_recursion1() {
 #[ignore] // Skip expensive tests in CI for now. Do run these locally, please.
 fn test_prove_recursion2() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(25);
+    let expected = s.num_u64(25);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -394,7 +394,7 @@ fn test_prove_unop_regression_aux(chunk_count: usize) {
         &None,
     );
 
-    let expected = Ptr::num_u64(1);
+    let expected = s.num_u64(1);
     nova_test_full_aux::<_, _, M1<'_, _>>(
         s,
         "(car '(1 . 2))",
@@ -409,7 +409,7 @@ fn test_prove_unop_regression_aux(chunk_count: usize) {
         &None,
     );
 
-    let expected = Ptr::num_u64(2);
+    let expected = s.num_u64(2);
     nova_test_full_aux::<_, _, M1<'_, _>>(
         s,
         "(cdr '(1 . 2))",
@@ -424,7 +424,7 @@ fn test_prove_unop_regression_aux(chunk_count: usize) {
         &None,
     );
 
-    let expected = Ptr::num_u64(123);
+    let expected = s.num_u64(123);
     nova_test_full_aux::<_, _, M1<'_, _>>(
         s,
         "(emit 123)",
@@ -454,7 +454,7 @@ fn test_prove_unop_regression() {
 #[ignore]
 fn test_prove_emit_output() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(123);
+    let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -472,7 +472,7 @@ fn test_prove_emit_output() {
 #[ignore]
 fn test_prove_evaluate() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(99);
+    let expected = s.num_u64(99);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -490,7 +490,7 @@ fn test_prove_evaluate() {
 #[ignore]
 fn test_prove_evaluate2() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(99);
+    let expected = s.num_u64(99);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -510,7 +510,7 @@ fn test_prove_evaluate2() {
 #[ignore]
 fn test_prove_evaluate3() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(999);
+    let expected = s.num_u64(999);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -533,7 +533,7 @@ fn test_prove_evaluate3() {
 #[ignore]
 fn test_prove_evaluate4() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(888);
+    let expected = s.num_u64(888);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -557,7 +557,7 @@ fn test_prove_evaluate4() {
 #[ignore]
 fn test_prove_evaluate5() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(999);
+    let expected = s.num_u64(999);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -578,7 +578,7 @@ fn test_prove_evaluate5() {
 #[ignore]
 fn test_prove_evaluate_sum() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(9);
+    let expected = s.num_u64(9);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -595,7 +595,7 @@ fn test_prove_evaluate_sum() {
 #[test]
 fn test_prove_binop_rest_is_nil() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(9);
+    let expected = s.num_u64(9);
     let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -669,7 +669,7 @@ fn test_prove_binop_syntax_error() {
 #[test]
 fn test_prove_diff() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(4);
+    let expected = s.num_u64(4);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -687,7 +687,7 @@ fn test_prove_diff() {
 #[ignore]
 fn test_prove_product() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(45);
+    let expected = s.num_u64(45);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -705,7 +705,7 @@ fn test_prove_product() {
 #[ignore]
 fn test_prove_quotient() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(7);
+    let expected = s.num_u64(7);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -722,7 +722,7 @@ fn test_prove_quotient() {
 #[test]
 fn test_prove_error_div_by_zero() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(0);
+    let expected = s.num_u64(0);
     let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -757,7 +757,7 @@ fn test_prove_error_invalid_type_and_not_cons() {
 #[ignore]
 fn test_prove_adder() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(5);
+    let expected = s.num_u64(5);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -813,7 +813,7 @@ fn test_prove_current_env_rest_is_nil_error() {
 #[ignore]
 fn test_prove_let_simple() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(1);
+    let expected = s.num_u64(1);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -966,7 +966,7 @@ fn test_prove_letrec_rest_body_is_nil_error() {
 #[ignore]
 fn test_prove_let_null_bindings() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(3);
+    let expected = s.num_u64(3);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -983,7 +983,7 @@ fn test_prove_let_null_bindings() {
 #[ignore]
 fn test_prove_letrec_null_bindings() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(3);
+    let expected = s.num_u64(3);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -1001,7 +1001,7 @@ fn test_prove_letrec_null_bindings() {
 #[ignore]
 fn test_prove_let() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(6);
+    let expected = s.num_u64(6);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -1022,7 +1022,7 @@ fn test_prove_let() {
 #[ignore]
 fn test_prove_arithmetic() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(20);
+    let expected = s.num_u64(20);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -1069,7 +1069,7 @@ fn test_prove_comparison() {
 #[ignore]
 fn test_prove_conditional() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(5);
+    let expected = s.num_u64(5);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -1098,7 +1098,7 @@ fn test_prove_conditional() {
 #[ignore]
 fn test_prove_conditional2() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(6);
+    let expected = s.num_u64(6);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -1127,7 +1127,7 @@ fn test_prove_conditional2() {
 #[ignore]
 fn test_prove_fundamental_conditional_bug() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(5);
+    let expected = s.num_u64(5);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -1153,7 +1153,7 @@ fn test_prove_fundamental_conditional_bug() {
 #[ignore]
 fn test_prove_fully_evaluates() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(10);
+    let expected = s.num_u64(10);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -1171,7 +1171,7 @@ fn test_prove_fully_evaluates() {
 #[ignore]
 fn test_prove_recursion() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(25);
+    let expected = s.num_u64(25);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -1194,7 +1194,7 @@ fn test_prove_recursion() {
 #[ignore]
 fn test_prove_recursion_multiarg() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(25);
+    let expected = s.num_u64(25);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -1216,7 +1216,7 @@ fn test_prove_recursion_multiarg() {
 #[ignore]
 fn test_prove_recursion_optimized() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(25);
+    let expected = s.num_u64(25);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -1241,7 +1241,7 @@ fn test_prove_recursion_optimized() {
 #[ignore]
 fn test_prove_tail_recursion() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(25);
+    let expected = s.num_u64(25);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -1265,7 +1265,7 @@ fn test_prove_tail_recursion() {
 #[ignore]
 fn test_prove_tail_recursion_somewhat_optimized() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(25);
+    let expected = s.num_u64(25);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -1341,7 +1341,7 @@ fn test_prove_no_mutual_recursion_error() {
 #[ignore]
 fn test_prove_cons1() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(1);
+    let expected = s.num_u64(1);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -1386,7 +1386,7 @@ fn test_prove_emit_end_is_nil_error() {
 #[test]
 fn test_prove_cons2() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(2);
+    let expected = s.num_u64(2);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -1403,7 +1403,7 @@ fn test_prove_cons2() {
 #[test]
 fn test_prove_zero_arg_lambda1() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(123);
+    let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -1420,7 +1420,7 @@ fn test_prove_zero_arg_lambda1() {
 #[test]
 fn test_prove_zero_arg_lambda2() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(10);
+    let expected = s.num_u64(10);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -1439,7 +1439,7 @@ fn test_prove_zero_arg_lambda3() {
     let s = &Store::<Fr>::default();
     let expected = {
         let arg = s.intern_user_symbol("x");
-        let num = Ptr::num_u64(123);
+        let num = s.num_u64(123);
         let body = s.list(vec![num]);
         let env = s.intern_nil();
         s.intern_fun(arg, body, env)
@@ -1496,7 +1496,7 @@ fn test_prove_zero_arg_lambda5() {
 #[test]
 fn test_prove_zero_arg_lambda6() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(123);
+    let expected = s.num_u64(123);
     let error = s.cont_error();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -1514,7 +1514,7 @@ fn test_prove_zero_arg_lambda6() {
 fn test_prove_nested_let_closure_regression() {
     let s = &Store::<Fr>::default();
     let terminal = s.cont_terminal();
-    let expected = Ptr::num_u64(6);
+    let expected = s.num_u64(6);
     let expr = "(let ((data-function (lambda () 123))
                       (x 6)
                       (data (data-function)))
@@ -1535,7 +1535,7 @@ fn test_prove_nested_let_closure_regression() {
 #[ignore]
 fn test_prove_minimal_tail_call() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(123);
+    let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -1558,7 +1558,7 @@ fn test_prove_minimal_tail_call() {
 #[ignore]
 fn test_prove_cons_in_function1() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(2);
+    let expected = s.num_u64(2);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -1580,7 +1580,7 @@ fn test_prove_cons_in_function1() {
 #[ignore]
 fn test_prove_cons_in_function2() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(3);
+    let expected = s.num_u64(3);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -1602,7 +1602,7 @@ fn test_prove_cons_in_function2() {
 #[ignore]
 fn test_prove_multiarg_eval_bug() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(2);
+    let expected = s.num_u64(2);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -1620,7 +1620,7 @@ fn test_prove_multiarg_eval_bug() {
 #[ignore]
 fn test_prove_multiple_letrec_bindings() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(123);
+    let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -1644,7 +1644,7 @@ fn test_prove_multiple_letrec_bindings() {
 #[ignore]
 fn test_prove_tail_call2() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(123);
+    let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -1668,7 +1668,7 @@ fn test_prove_tail_call2() {
 #[ignore]
 fn test_prove_multiple_letrecstar_bindings() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(13);
+    let expected = s.num_u64(13);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -1688,7 +1688,7 @@ fn test_prove_multiple_letrecstar_bindings() {
 #[ignore]
 fn test_prove_multiple_letrecstar_bindings_referencing() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(11);
+    let expected = s.num_u64(11);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -1708,7 +1708,7 @@ fn test_prove_multiple_letrecstar_bindings_referencing() {
 #[ignore]
 fn test_prove_multiple_letrecstar_bindings_recursive() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(33);
+    let expected = s.num_u64(33);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -1739,7 +1739,7 @@ fn test_prove_multiple_letrecstar_bindings_recursive() {
 #[ignore]
 fn test_prove_dont_discard_rest_env() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(18);
+    let expected = s.num_u64(18);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -1761,7 +1761,7 @@ fn test_prove_dont_discard_rest_env() {
 #[ignore]
 fn test_prove_fibonacci() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(1);
+    let expected = s.num_u64(1);
     let terminal = s.cont_terminal();
     nova_test_full_aux::<_, _, M1<'_, _>>(
         s,
@@ -1792,7 +1792,7 @@ fn test_prove_fibonacci() {
 #[ignore]
 fn test_one_folding() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(4);
+    let expected = s.num_u64(4);
     let terminal = s.cont_terminal();
     nova_test_full_aux::<_, _, M1<'_, _>>(
         s,
@@ -1868,8 +1868,8 @@ fn test_prove_begin_empty() {
 fn test_prove_begin_emit() {
     let s = &Store::<Fr>::default();
     let expr = "(begin (emit 1) (emit 2) (emit 3))";
-    let expected_expr = Ptr::num_u64(3);
-    let expected_emitted = vec![Ptr::num_u64(1), Ptr::num_u64(2), Ptr::num_u64(3)];
+    let expected_expr = s.num_u64(3);
+    let expected_emitted = vec![s.num_u64(1), s.num_u64(2), s.num_u64(3)];
     test_aux::<_, _, M1<'_, _>>(
         s,
         expr,
@@ -2051,8 +2051,8 @@ fn test_prove_car_cdr_invalid_tag_error_num() {
 #[test]
 fn test_prove_car_cdr_of_cons() {
     let s = &Store::<Fr>::default();
-    let res1 = Ptr::num_u64(1);
-    let res2 = Ptr::num_u64(2);
+    let res1 = s.num_u64(1);
+    let res2 = s.num_u64(2);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -2106,7 +2106,7 @@ fn test_prove_car_cdr_invalid_tag_error_lambda() {
 fn test_prove_hide_open() {
     let s = &Store::<Fr>::default();
     let expr = "(open (hide 123 456))";
-    let expected = Ptr::num_u64(456);
+    let expected = s.num_u64(456);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -2132,7 +2132,7 @@ fn test_prove_hide_wrong_secret_type() {
 fn test_prove_hide_secret() {
     let s = &Store::<Fr>::default();
     let expr = "(secret (hide 123 456))";
-    let expected = Ptr::num_u64(123);
+    let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -2168,7 +2168,7 @@ fn test_prove_commit_open_sym() {
 fn test_prove_commit_open() {
     let s = &Store::<Fr>::default();
     let expr = "(open (commit 123))";
-    let expected = Ptr::num_u64(123);
+    let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -2218,7 +2218,7 @@ fn test_prove_secret_wrong_type() {
 fn test_prove_commit_secret() {
     let s = &Store::<Fr>::default();
     let expr = "(secret (commit 123))";
-    let expected = Ptr::num_u64(0);
+    let expected = s.num_u64(0);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -2236,7 +2236,7 @@ fn test_prove_commit_secret() {
 fn test_prove_num() {
     let s = &Store::<Fr>::default();
     let expr = "(num 123)";
-    let expected = Ptr::num_u64(123);
+    let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -2254,7 +2254,7 @@ fn test_prove_num() {
 fn test_prove_num_char() {
     let s = &Store::<Fr>::default();
     let expr = r"(num #\a)";
-    let expected = Ptr::num_u64(97);
+    let expected = s.num_u64(97);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -2328,7 +2328,7 @@ fn test_prove_commit_num() {
 fn test_prove_hide_open_comm_num() {
     let s = &Store::<Fr>::default();
     let expr = "(open (comm (num (hide 123 456))))";
-    let expected = Ptr::num_u64(456);
+    let expected = s.num_u64(456);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -2346,7 +2346,7 @@ fn test_prove_hide_open_comm_num() {
 fn test_prove_hide_secret_comm_num() {
     let s = &Store::<Fr>::default();
     let expr = "(secret (comm (num (hide 123 456))))";
-    let expected = Ptr::num_u64(123);
+    let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -2364,7 +2364,7 @@ fn test_prove_hide_secret_comm_num() {
 fn test_prove_commit_open_comm_num() {
     let s = &Store::<Fr>::default();
     let expr = "(open (comm (num (commit 123))))";
-    let expected = Ptr::num_u64(123);
+    let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -2382,7 +2382,7 @@ fn test_prove_commit_open_comm_num() {
 fn test_prove_commit_secret_comm_num() {
     let s = &Store::<Fr>::default();
     let expr = "(secret (comm (num (commit 123))))";
-    let expected = Ptr::num_u64(0);
+    let expected = s.num_u64(0);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -2400,7 +2400,7 @@ fn test_prove_commit_secret_comm_num() {
 fn test_prove_commit_num_open() {
     let s = &Store::<Fr>::default();
     let expr = "(open (num (commit 123)))";
-    let expected = Ptr::num_u64(123);
+    let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -2745,8 +2745,8 @@ fn test_prove_test_eval() {
     let s = &Store::<Fr>::default();
     let expr = "(* 3 (eval  (cons '+ (cons 1 (cons 2 nil)))))";
     let expr2 = "(* 5 (eval '(+ 1 a) '((a . 3))))"; // two-arg eval, optional second arg is env.
-    let res = Ptr::num_u64(9);
-    let res2 = Ptr::num_u64(20);
+    let res = s.num_u64(9);
+    let res2 = s.num_u64(20);
     let terminal = s.cont_terminal();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, Some(res), None, Some(terminal), None, 17, &None);
@@ -2781,7 +2781,7 @@ fn test_prove_functional_commitment() {
     let expr = "(let ((f (commit (let ((num 9)) (lambda (f) (f num)))))
                       (inc (lambda (x) (+ x 1))))
                   ((open f) inc))";
-    let res = Ptr::num_u64(10);
+    let res = s.num_u64(10);
     let terminal = s.cont_terminal();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, Some(res), None, Some(terminal), None, 25, &None);
@@ -2802,7 +2802,7 @@ fn test_prove_complicated_functional_commitment() {
                            (sum nums)))))
 
                   ((open f) in))";
-    let res = Ptr::num_u64(6);
+    let res = s.num_u64(6);
     let terminal = s.cont_terminal();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, Some(res), None, Some(terminal), None, 108, &None);
@@ -2816,7 +2816,7 @@ fn test_prove_test_fold_cons_regression() {
                                      (fold op (op acc (car l)) (cdr l))
                                      acc))))
                   (fold (lambda (x y) (+ x y)) 0 '(1 2 3)))";
-    let res = Ptr::num_u64(6);
+    let res = s.num_u64(6);
     let terminal = s.cont_terminal();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, Some(res), None, Some(terminal), None, 152, &None);
@@ -2895,8 +2895,8 @@ fn test_prove_test_u64_mul() {
     let expr2 = "(* 18446744073709551615u64 2u64)";
     let expr3 = "(* (- 0u64 1u64) 2u64)";
     let expr4 = "(u64 18446744073709551617)";
-    let res = Ptr::u64(18446744073709551614);
-    let res2 = Ptr::u64(1);
+    let res = s.u64(18446744073709551614);
+    let res2 = s.u64(1);
     let terminal = s.cont_terminal();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, Some(res), None, Some(terminal), None, 7, &None);
@@ -2911,7 +2911,7 @@ fn test_prove_test_u64_add() {
 
     let expr = "(+ 18446744073709551615u64 2u64)";
     let expr2 = "(+ (- 0u64 1u64) 2u64)";
-    let res = Ptr::u64(1);
+    let res = s.u64(1);
     let terminal = s.cont_terminal();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, Some(res), None, Some(terminal), None, 3, &None);
@@ -2925,9 +2925,9 @@ fn test_prove_test_u64_sub() {
     let expr = "(- 2u64 1u64)";
     let expr2 = "(- 0u64 1u64)";
     let expr3 = "(+ 1u64 (- 0u64 1u64))";
-    let res = Ptr::u64(1);
-    let res2 = Ptr::u64(18446744073709551615);
-    let res3 = Ptr::u64(0);
+    let res = s.u64(1);
+    let res2 = s.u64(18446744073709551615);
+    let res3 = s.u64(0);
     let terminal = s.cont_terminal();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, Some(res), None, Some(terminal), None, 3, &None);
@@ -2940,10 +2940,10 @@ fn test_prove_test_u64_div() {
     let s = &Store::<Fr>::default();
 
     let expr = "(/ 100u64 2u64)";
-    let res = Ptr::u64(50);
+    let res = s.u64(50);
 
     let expr2 = "(/ 100u64 3u64)";
-    let res2 = Ptr::u64(33);
+    let res2 = s.u64(33);
 
     let expr3 = "(/ 100u64 0u64)";
 
@@ -2960,10 +2960,10 @@ fn test_prove_test_u64_mod() {
     let s = &Store::<Fr>::default();
 
     let expr = "(% 100u64 2u64)";
-    let res = Ptr::u64(0);
+    let res = s.u64(0);
 
     let expr2 = "(% 100u64 3u64)";
-    let res2 = Ptr::u64(1);
+    let res2 = s.u64(1);
 
     let expr3 = "(% 100u64 0u64)";
 
@@ -3033,9 +3033,9 @@ fn test_prove_test_u64_conversion() {
     let expr2 = "(num 1u64)";
     let expr3 = "(+ 1 1u64)";
     let expr4 = "(u64 (+ 1 1))";
-    let res = Ptr::num_u64(1);
-    let res2 = Ptr::num_u64(2);
-    let res3 = Ptr::u64(2);
+    let res = s.num_u64(1);
+    let res2 = s.num_u64(2);
+    let res3 = s.u64(2);
     let terminal = s.cont_terminal();
 
     test_aux::<_, _, M1<'_, _>>(s, expr, Some(res), None, Some(terminal), None, 3, &None);
@@ -3108,9 +3108,9 @@ fn test_prove_call_literal_fun() {
     let arg = s.intern_user_symbol("x");
     let body = s.read_with_default_state("((+ x 1))").unwrap();
     let fun = s.intern_3_ptrs(Tag::Expr(ExprTag::Fun), arg, body, empty_env);
-    let input = Ptr::num_u64(9);
+    let input = s.num_u64(9);
     let expr = s.list(vec![fun, input]);
-    let res = Ptr::num_u64(10);
+    let res = s.num_u64(10);
     let terminal = s.cont_terminal();
     let lang: Arc<Lang<Fr, Coproc<Fr>>> = Arc::new(Lang::new());
 
@@ -3271,11 +3271,11 @@ fn test_dumb_lang() {
     let expr6_ = "(cproc-dumb 'x' 'y')";
     let expr7 = "(cproc-dumb 0 'y')";
 
-    let res = Ptr::num_u64(89);
-    let error4 = s.list(vec![Ptr::num_u64(123), Ptr::num_u64(8), Ptr::num_u64(9)]);
-    let error5 = s.list(vec![Ptr::num_u64(9)]);
-    let error6 = Ptr::char('x');
-    let error7 = Ptr::char('y');
+    let res = s.num_u64(89);
+    let error4 = s.list(vec![s.num_u64(123), s.num_u64(8), s.num_u64(9)]);
+    let error5 = s.list(vec![s.num_u64(9)]);
+    let error6 = s.char('x');
+    let error7 = s.char('y');
 
     let error = s.cont_error();
     let terminal = s.cont_terminal();
@@ -3430,7 +3430,7 @@ fn test_trie_lang() {
     let expr2 =
         "(.lurk.trie.lookup 0x1cc5b90039db85fd519af975afa1de9d2b92960a585a546637b653b115bc3b53 123)";
     let expr2 = s.read(state.clone(), expr2).unwrap();
-    let res2 = Ptr::comm(Fr::zero());
+    let res2 = s.comm(Fr::zero());
     nova_test_full_aux2::<_, _, C1LEM<'_, _, TrieCoproc<_>>>(
         s,
         expr2,
@@ -3470,7 +3470,7 @@ fn test_trie_lang() {
     let expr4 =
         "(.lurk.trie.lookup 0x1b22dc5a394231c34e4529af674dc56a736fbd07508acfd1d12c0e67c8b4de27 123)";
     let expr4 = s.read(state.clone(), expr4).unwrap();
-    let res4 = Ptr::comm(Fr::from(456));
+    let res4 = s.comm(Fr::from(456));
     nova_test_full_aux2::<_, _, C1LEM<'_, _, TrieCoproc<_>>>(
         s,
         expr4,
@@ -3486,11 +3486,12 @@ fn test_trie_lang() {
     );
 
     let s = &Store::<Fr>::default();
+    let terminal = s.cont_terminal();
     let expr5 = "(let ((trie (.lurk.trie.new))
                        (found (.lurk.trie.lookup trie 123)))
                       found)";
     let expr5 = s.read(state.clone(), expr5).unwrap();
-    let res5 = Ptr::comm(Fr::zero());
+    let res5 = s.comm(Fr::zero());
     nova_test_full_aux2::<_, _, C1LEM<'_, _, TrieCoproc<_>>>(
         s,
         expr5,
@@ -3509,7 +3510,7 @@ fn test_trie_lang() {
                        (found (.lurk.trie.lookup trie 123)))
                       found)";
     let expr6 = s.read(state.clone(), expr6).unwrap();
-    let res6 = Ptr::comm(Fr::from(456));
+    let res6 = s.comm(Fr::from(456));
     nova_test_full_aux2::<_, _, C1LEM<'_, _, TrieCoproc<_>>>(
         s,
         expr6,
@@ -3547,7 +3548,7 @@ fn test_prove_lambda_body_nil() {
 #[test]
 fn test_letrec_let_nesting() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(2);
+    let expected = s.num_u64(2);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -3563,7 +3564,7 @@ fn test_letrec_let_nesting() {
 #[test]
 fn test_let_sequencing() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(1);
+    let expected = s.num_u64(1);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,
@@ -3579,7 +3580,7 @@ fn test_let_sequencing() {
 #[test]
 fn test_letrec_sequencing() {
     let s = &Store::<Fr>::default();
-    let expected = Ptr::num_u64(3);
+    let expected = s.num_u64(3);
     let terminal = s.cont_terminal();
     test_aux::<_, _, M1<'_, _>>(
         s,


### PR DESCRIPTION
This PR aims to lower memory usage burden with a more compact encoding for `Ptr`, which holds the index to a cached element of the finite field instead of the element itself.

Evaluating the following expression
```lisp
(letrec ((loop (lambda (x) (if (= x 0) nil (loop (- x 1)))))) (loop 100000))
```
Consumes 5.1Gb on `main` and 2.7Gb on this branch.

This difference is important for proving because there are two places in our pipeline where we duplicate the entire sequence of frames (which hold multiple pointers):
https://github.com/lurk-lab/lurk-rs/blob/fc61cf105423828733938034c7c5c0d59f32398d/src/lem/multiframe.rs#L522
https://github.com/lurk-lab/lurk-rs/blob/fc61cf105423828733938034c7c5c0d59f32398d/src/proof/nova.rs#L354

So this change impacts on allocation costs for those clones.