### PR TITLE
Actually use precomputed cached witness

### DIFF
--- a/src/lem/multiframe.rs
+++ b/src/lem/multiframe.rs
@@ -838,6 +838,8 @@ impl<'a, F: LurkField, C: Coprocessor<F>> nova::traits::circuit::StepCircuit<F>
 
         if cs.is_witness_generator() {
             if let Some(w) = &self.cached_witness {
+                assert_eq!(cs.inputs_slice().len(), 1);
+                assert!(cs.aux_slice().is_empty());
                 let aux = w.aux_slice();
                 let end = aux.len() - z.len();
                 let inputs = &w.inputs_slice()[1..];

--- a/src/lem/multiframe.rs
+++ b/src/lem/multiframe.rs
@@ -836,6 +836,27 @@ impl<'a, F: LurkField, C: Coprocessor<F>> nova::traits::circuit::StepCircuit<F>
     {
         assert_eq!(self.arity(), z.len());
 
+        if cs.is_witness_generator() {
+            if let Some(w) = &self.cached_witness {
+                let aux = w.aux_slice();
+                let end = aux.len() - z.len();
+                let inputs = &w.inputs_slice()[1..];
+
+                cs.extend_aux(aux);
+                cs.extend_inputs(inputs);
+
+                let scalars = &aux[end..];
+
+                let mut bogus_cs = WitnessCS::new();
+                let allocated = scalars
+                    .iter()
+                    .map(|scalar| AllocatedNum::alloc_infallible(&mut bogus_cs, || *scalar))
+                    .collect();
+
+                return Ok(allocated);
+            }
+        };
+
         let n_ptrs = self.arity() / 2;
         let mut input = Vec::with_capacity(n_ptrs);
         for i in 0..n_ptrs {


### PR DESCRIPTION
This PR recovers a mechanic from Alpha's witness generation that wasn't integrated in LEM (my bad)