### PR TITLE
ci: Fix `workflow_dispatch` output and `issue_comment` env load

### DIFF
--- a/.github/workflows/bench-pr-comment.yml
+++ b/.github/workflows/bench-pr-comment.yml
@@ -80,14 +80,11 @@ jobs:
       # Install dependencies
       - uses: actions-rs/toolchain@v1
       - uses: Swatinem/rust-cache@v2
-      - name: Load env vars
-        run: |
-          set -a
-          source bench.env
-          set +a
-          echo "LURK_BENCH_OUTPUT=pr-comment" >> $GITHUB_ENV
-          env | grep -E 'LURK|EC_GPU|CUDA'
-        working-directory: ${{ github.workspace }}/benches
+      - name: Set output type
+        run: echo "LURK_BENCH_OUTPUT=pr-comment" >> $GITHUB_ENV
+      - uses: cardinalby/export-env-action@v2
+        with:
+          envFile: 'benches/bench.env'
       # Run the comparative benchmark and comment output on the PR
       - uses: boa-dev/criterion-compare-action@v3
         with:

--- a/.github/workflows/gpu-bench-workflow-dispatch.yml
+++ b/.github/workflows/gpu-bench-workflow-dispatch.yml
@@ -33,7 +33,9 @@ jobs:
       - name: Set bench output format type
         run: echo "LURK_BENCH_OUTPUT=commit-comment" | tee -a $GITHUB_ENV
       - name: Run GPU bench on branch
-        run: just --dotenv-filename bench.env gpu-bench fibonacci
+        run: |
+          just --dotenv-filename bench.env gpu-bench fibonacci
+          cp ${{ github.sha }}.json ..
         working-directory: ${{ github.workspace }}/benches
       - name: copy the benchmark template and prepare it with data
         run: |
@@ -53,6 +55,7 @@ jobs:
       # Create a `criterion-table` and write in commit comment
       - name: Run `criterion-table`
         run: cat ${{ github.sha }}.json | criterion-table > BENCHMARKS.md
+        working-directory: ${{ github.workspace }}
       - name: Write bench on commit comment
         uses: peter-evans/commit-comment@v3
         with:


### PR DESCRIPTION
- Fixes an issue where the manual `workflow_dispatch` action wasn't finding the benchmark output for `criterion-table` in e.g. https://github.com/lurk-lab/lurk-rs/commit/4bc6fa197eeb5c7b82ce246ebccd0895e424acc3#commitcomment-133745609 due to the `justfile` changes of #907 
- Fixes an issue where the PR comment benchmark wasn't loading the `bench.env` file correctly, thus always using the default `rc=100` value in e.g. https://github.com/lurk-lab/lurk-rs/pull/927#issuecomment-1830868519. It should now be possible for PR authors to configure which RC's they want the benchmark to run on by committing the `bench.env` with different `LURK_RC` values.