### PR TITLE
Actually use precomputed witness

### DIFF
--- a/src/lem/multiframe.rs
+++ b/src/lem/multiframe.rs
@@ -48,7 +48,7 @@ pub struct MultiFrame<'a, F: LurkField, C: Coprocessor<F>> {
     input: Option<Vec<Ptr>>,
     output: Option<Vec<Ptr>>,
     frames: Option<Vec<Frame>>,
-    cached_witness: Option<WitnessCS<F>>,
+    cached_witness: Option<(WitnessCS<F>, Vec<AllocatedNum<F>>)>,
     num_frames: usize,
     folding_config: Arc<FoldingConfig<F, C>>,
     pc: usize,
@@ -403,7 +403,10 @@ impl<'a, F: LurkField, C: Coprocessor<F> + 'a> MultiFrameTrait<'a, F, C> for Mul
         store.to_scalar_vector(io)
     }
 
-    fn compute_witness(&self, s: &Store<F>) -> WitnessCS<F> {
+    fn compute_witness(
+        &self,
+        s: &Store<F>,
+    ) -> Result<(WitnessCS<F>, Vec<AllocatedNum<F>>), SynthesisError> {
         let mut wcs = WitnessCS::new();
 
         let z_scalar = s.to_scalar_vector(self.input.as_ref().unwrap());
@@ -414,12 +417,12 @@ impl<'a, F: LurkField, C: Coprocessor<F> + 'a> MultiFrameTrait<'a, F, C> for Mul
             .map(|x| AllocatedNum::alloc(&mut bogus_cs, || Ok(*x)).unwrap())
             .collect::<Vec<_>>();
 
-        let _ = nova::traits::circuit::StepCircuit::synthesize(self, &mut wcs, z.as_slice());
+        let output = nova::traits::circuit::StepCircuit::synthesize(self, &mut wcs, z.as_slice())?;
 
-        wcs
+        Ok((wcs, output))
     }
 
-    fn cached_witness(&mut self) -> &mut Option<WitnessCS<F>> {
+    fn cached_witness(&mut self) -> &mut Option<(WitnessCS<F>, Vec<AllocatedNum<F>>)> {
         &mut self.cached_witness
     }
 
@@ -835,7 +838,16 @@ impl<'a, F: LurkField, C: Coprocessor<F>> nova::traits::circuit::StepCircuit<F>
     {
         assert_eq!(self.arity(), z.len());
 
-        let n_ptrs = self.arity() / 2;
+        if cs.is_witness_generator() {
+            if let Some((w, output)) = &self.cached_witness {
+                // skip the first (F::ONE) input
+                cs.extend_inputs(&w.inputs_slice()[1..]);
+                cs.extend_aux(w.aux_slice());
+                return Ok(output.clone());
+            }
+        };
+
+        let n_ptrs = z.len() / 2;
         let mut input = Vec::with_capacity(n_ptrs);
         for i in 0..n_ptrs {
             input.push(AllocatedPtr::from_parts(
@@ -863,7 +875,7 @@ impl<'a, F: LurkField, C: Coprocessor<F>> nova::traits::circuit::StepCircuit<F>
             }
         };
 
-        let mut output = Vec::with_capacity(self.arity());
+        let mut output = Vec::with_capacity(z.len());
         for ptr in output_ptrs {
             output.push(ptr.tag().clone());
             output.push(ptr.hash().clone());

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -17,7 +17,9 @@ mod tests;
 
 use ::nova::traits::{circuit::StepCircuit, Engine};
 use bellpepper::util_cs::witness_cs::WitnessCS;
-use bellpepper_core::{test_cs::TestConstraintSystem, Circuit, ConstraintSystem, SynthesisError};
+use bellpepper_core::{
+    num::AllocatedNum, test_cs::TestConstraintSystem, Circuit, ConstraintSystem, SynthesisError,
+};
 use std::sync::Arc;
 
 use crate::{
@@ -120,11 +122,14 @@ pub trait MultiFrameTrait<'a, F: LurkField, C: Coprocessor<F> + 'a>:
     /// Returns true if the supplied instance directly precedes this one in a sequential computation trace.
     fn precedes(&self, maybe_next: &Self) -> bool;
 
-    /// Populates a WitnessCS with the witness values for the given store.
-    fn compute_witness(&self, s: &Self::Store) -> WitnessCS<F>;
+    /// Populates a WitnessCS with the witness values for the given store, also returning the allocated output.
+    fn compute_witness(
+        &self,
+        s: &Self::Store,
+    ) -> Result<(WitnessCS<F>, Vec<AllocatedNum<F>>), SynthesisError>;
 
     /// Returns a reference to the cached witness values
-    fn cached_witness(&mut self) -> &mut Option<WitnessCS<F>>;
+    fn cached_witness(&mut self) -> &mut Option<(WitnessCS<F>, Vec<AllocatedNum<F>>)>;
 
     /// The output of the last frame
     fn output(&self) -> &Option<<Self::EvalFrame as FrameLike<Self::Ptr, Self::ContPtr>>::FrameIO>;

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -16,10 +16,7 @@ pub mod supernova;
 mod tests;
 
 use ::nova::traits::{circuit::StepCircuit, Engine};
-use bellpepper::util_cs::witness_cs::WitnessCS;
-use bellpepper_core::{
-    num::AllocatedNum, test_cs::TestConstraintSystem, Circuit, ConstraintSystem, SynthesisError,
-};
+use bellpepper_core::{test_cs::TestConstraintSystem, Circuit, ConstraintSystem, SynthesisError};
 use std::sync::Arc;
 
 use crate::{
@@ -122,14 +119,10 @@ pub trait MultiFrameTrait<'a, F: LurkField, C: Coprocessor<F> + 'a>:
     /// Returns true if the supplied instance directly precedes this one in a sequential computation trace.
     fn precedes(&self, maybe_next: &Self) -> bool;
 
-    /// Populates a WitnessCS with the witness values for the given store, also returning the allocated output.
-    fn compute_witness(
-        &self,
-        s: &Self::Store,
-    ) -> Result<(WitnessCS<F>, Vec<AllocatedNum<F>>), SynthesisError>;
-
-    /// Returns a reference to the cached witness values
-    fn cached_witness(&mut self) -> &mut Option<(WitnessCS<F>, Vec<AllocatedNum<F>>)>;
+    /// Cache the witness internally, which can be used later during synthesis.
+    /// This function can be called in parallel to speed up the witness generation
+    /// for a series of `MultiFrameTrait` instances.
+    fn cache_witness(&mut self, s: &Self::Store) -> Result<(), SynthesisError>;
 
     /// The output of the last frame
     fn output(&self) -> &Option<<Self::EvalFrame as FrameLike<Self::Ptr, Self::ContPtr>>::FrameIO>;

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -281,14 +281,10 @@ where
                     // Skip the very first circuit's witness, so `prove_step` can begin immediately.
                     // That circuit's witness will not be cached and will just be computed on-demand.
                     cc.par_iter().skip(1).for_each(|mf| {
-                        let witness = {
-                            let mf1 = mf.lock().unwrap();
-                            mf1.compute_witness(store)
-                                .expect("witness computation failure")
-                        };
-                        let mut mf2 = mf.lock().unwrap();
-
-                        *mf2.cached_witness() = Some(witness);
+                        mf.lock()
+                            .unwrap()
+                            .cache_witness(store)
+                            .expect("witness caching failed");
                     });
                 });
 

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -284,6 +284,7 @@ where
                         let witness = {
                             let mf1 = mf.lock().unwrap();
                             mf1.compute_witness(store)
+                                .expect("witness computation failure")
                         };
                         let mut mf2 = mf.lock().unwrap();
 


### PR DESCRIPTION
This PR is a second attempt after the failure of #928 (reverted in #931).

#928 was returning the wrong output because LEM doesn't allocate the output at the end.

So this PR allows `MultiFrameTrait` implementers to cache their witnesses internally, using whichever data format they want. LEM's `MultiFrame` does so by caching the `WitnessCS` and the output (the vector of allocated numbers).

With that available, LEM can now make proper use of cached witnesses.