### PR TITLE
Remove parallel acquirement of locks for `MultiFrame` witness caching

### DIFF
--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -16,7 +16,6 @@ use nova::{
     CircuitShape, CompressedSNARK, ProverKey, RecursiveSNARK, VerifierKey,
 };
 use pasta_curves::pallas;
-use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::{
     marker::PhantomData,
@@ -280,7 +279,7 @@ where
                 s.spawn(|_| {
                     // Skip the very first circuit's witness, so `prove_step` can begin immediately.
                     // That circuit's witness will not be cached and will just be computed on-demand.
-                    cc.par_iter().skip(1).for_each(|mf| {
+                    cc.iter().skip(1).for_each(|mf| {
                         mf.lock()
                             .unwrap()
                             .cache_witness(store)


### PR DESCRIPTION
This PR decreases the likelihood of the folding steps having to wait for `MultiFrame` locks to be released, making CPU and GPU work better in parallel. This effect is arguably more relevant for longer computations, but we can also notice improvements on shorter ones. The following tables show adjusted throughput up to 3 folding steps:

**Before**
```text
┌────────────┬──────────────┬─────────────┬─────────────┐
│ rc\n_folds │ 1            │ 2           │ 3           │
├────────────┼──────────────┼─────────────┼─────────────┤
│        100 │ 584.62±10.91 │ 549.11±4.67 │ 545.78±4.78 │
│        300 │  714.55±6.30 │ 657.31±1.24 │ 654.20±1.34 │
│        500 │  672.40±2.13 │ 622.96±2.73 │ 620.16±1.55 │
│        700 │  608.16±2.49 │ 571.52±2.55 │ 565.46±1.13 │
│        900 │  617.39±3.31 │ 585.92±2.35 │ 568.13±0.90 │
│       1100 │  624.99±2.23 │ 591.08±1.86 │ 588.61±1.28 │
└────────────┴──────────────┴─────────────┴─────────────┘
```

**After**
```text
┌────────────┬─────────────┬─────────────┬─────────────┐
│ rc\n_folds │ 1           │ 2           │ 3           │
├────────────┼─────────────┼─────────────┼─────────────┤
│        100 │ 590.37±7.78 │ 561.27±3.25 │ 558.02±2.74 │
│        300 │ 722.79±3.80 │ 664.64±1.91 │ 665.04±1.63 │
│        500 │ 678.70±3.91 │ 632.35±1.53 │ 627.78±1.62 │
│        700 │ 609.94±3.66 │ 576.82±1.12 │ 568.01±1.82 │
│        900 │ 614.62±0.89 │ 586.17±1.51 │ 565.22±1.44 │
│       1100 │ 625.58±2.24 │ 592.20±1.03 │ 590.49±0.65 │
└────────────┴─────────────┴─────────────┴─────────────┘
```

This change also points to a potentially preferred solution for #937.