### PR TITLE
Fix call to `supernova::RecursiveSNARK::verify`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ clap = "4.3.17"
 ff = "0.13"
 metrics = "0.21.1"
 neptune = { git = "https://github.com/lurk-lab/neptune", branch = "dev", features = ["abomonation"] }
-nova = { git = "https://github.com/mpenciak/arecibo", branch = "circuit_index_fix", package = "nova-snark" }
+nova = { git = "https://github.com/lurk-lab/arecibo", branch = "dev", package = "nova-snark" }
 once_cell = "1.18.0"
 pairing = { version = "0.23" }
 pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch = "dev" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ clap = "4.3.17"
 ff = "0.13"
 metrics = "0.21.1"
 neptune = { git = "https://github.com/lurk-lab/neptune", branch = "dev", features = ["abomonation"] }
-nova = { git = "https://github.com/lurk-lab/arecibo", branch = "dev", package = "nova-snark" }
+nova = { git = "https://github.com/mpenciak/arecibo", branch = "circuit_index_fix", package = "nova-snark" }
 once_cell = "1.18.0"
 pairing = { version = "0.23" }
 pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch = "dev" }

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -231,14 +231,14 @@ where
         pp: &Self::PublicParams,
         z0: &[F],
         zi: &[F],
-        last_circuit_idx: usize,
+        _last_circuit_idx: usize,
     ) -> Result<bool, Self::ErrorType> {
         let (z0_primary, zi_primary) = (z0, zi);
         let z0_secondary = Self::z0_secondary();
         let zi_secondary = &z0_secondary;
 
         let (zi_primary_verified, zi_secondary_verified) = match self {
-            Self::Recursive(p) => p.verify(&pp.pp, last_circuit_idx, z0_primary, &z0_secondary)?,
+            Self::Recursive(p) => p.verify(&pp.pp, z0_primary, &z0_secondary)?,
             Self::Compressed(_) => unimplemented!(),
         };
 


### PR DESCRIPTION
This is a companion PR to [arecibo#175](https://github.com/lurk-lab/arecibo/pull/175) which changes the `supernova::RecursiveSNARK::verify` interface by removing its dependence on `circuit_index`.

TODO before merge:
- after [arecibo#175](https://github.com/lurk-lab/arecibo/pull/175) merges, revert `Cargo.toml` change