### PR TITLE
Remove `Ptr::dummy` API

### DIFF
--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -1805,7 +1805,7 @@ mod tests {
     fn test_counts() {
         let store = Store::default();
         let func = eval_step();
-        let frame = Frame::blank(func, 0);
+        let frame = Frame::blank(func, 0, &store);
         let mut cs = TestConstraintSystem::<Fr>::new();
         let lang: Lang<Fr, Coproc<Fr>> = Lang::new();
         let _ = func.synthesize_frame_aux(&mut cs, &store, &frame, &lang);

--- a/src/lem/interpreter.rs
+++ b/src/lem/interpreter.rs
@@ -120,9 +120,9 @@ pub struct Frame {
 }
 
 impl Frame {
-    pub fn blank(func: &Func, pc: usize) -> Frame {
-        let input = vec![Ptr::dummy(); func.input_params.len()];
-        let output = vec![Ptr::dummy(); func.output_size];
+    pub fn blank<F: LurkField>(func: &Func, pc: usize, store: &Store<F>) -> Frame {
+        let input = vec![store.dummy(); func.input_params.len()];
+        let output = vec![store.dummy(); func.output_size];
         let hints = Hints::blank(func);
         Frame {
             input,

--- a/src/lem/multiframe.rs
+++ b/src/lem/multiframe.rs
@@ -780,7 +780,7 @@ impl<'a, F: LurkField, C: Coprocessor<F>> Circuit<F> for MultiFrame<'a, F, C> {
                 assert!(self.frames.is_none());
                 let store = Store::default();
                 let dummy_io = [store.dummy(); 3];
-                let blank_frame = Frame::blank(self.get_func(), self.pc);
+                let blank_frame = Frame::blank(self.get_func(), self.pc, &store);
                 let frames = vec![blank_frame; self.num_frames];
                 synth(&store, &frames, &dummy_io, &dummy_io)
             }
@@ -869,7 +869,7 @@ impl<'a, F: LurkField, C: Coprocessor<F>> nova::traits::circuit::StepCircuit<F>
             None => {
                 assert!(self.store.is_none());
                 let store = Store::default();
-                let blank_frame = Frame::blank(self.get_func(), self.pc);
+                let blank_frame = Frame::blank(self.get_func(), self.pc, &store);
                 let frames = vec![blank_frame; self.num_frames];
                 let g = self.lurk_step.alloc_globals(cs, &store)?;
                 self.synthesize_frames(cs, &store, input, &frames, &g)?

--- a/src/lem/pointers.rs
+++ b/src/lem/pointers.rs
@@ -121,11 +121,6 @@ impl Ptr {
             _ => None,
         }
     }
-
-    #[inline]
-    pub fn dummy() -> Self {
-        Ptr::Atom(Tag::Expr(Nil), 0)
-    }
 }
 
 /// A `ZPtr` is the result of "hydrating" a `Ptr`. This process is better


### PR DESCRIPTION
Remove misleading vestigial `Ptr::dummy` API.

We should use `Store::dummy` instead.