### PR TITLE
New application

### DIFF
--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -38,7 +38,7 @@ fn fib<F: LurkField>(store: &Store<F>, state: Rc<RefCell<State>>, _a: u64) -> Pt
 // nth Fibonacci number to `a`.
 // means of computing it.]
 fn fib_frame(n: usize) -> usize {
-    11 + 16 * n
+    11 + 10 * n
 }
 
 // Set the limit so the last step will be filled exactly, since Lurk currently only pads terminal/error continuations.

--- a/examples/fibonacci.rs
+++ b/examples/fibonacci.rs
@@ -18,7 +18,7 @@ fn fib_expr<F: LurkField>(store: &Store<F>) -> Ptr {
 // The env output in the `fib_frame`th frame of the above, infinite Fibonacci computation contains a binding of the
 // nth Fibonacci number to `a`.
 fn fib_frame(n: usize) -> usize {
-    11 + 16 * n
+    11 + 10 * n
 }
 
 // Set the limit so the last step will be filled exactly, since Lurk currently only pads terminal/error continuations.

--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -674,20 +674,6 @@ fn reduce(cprocs: &[(&Symbol, usize)]) -> Func {
         let env: Expr::Cons = cons2(smaller_rec_env, smaller_env);
         return (env)
     });
-    let extract_arg = func!(extract_arg(args): 2 => {
-        match args.tag {
-            Expr::Nil => {
-                let dummy = Symbol("dummy");
-                let nil = Symbol("nil");
-                let nil = cast(nil, Expr::Nil);
-                return (dummy, nil)
-            }
-            Expr::Cons => {
-                let (arg, rest) = decons2(args);
-                return (arg, rest)
-            }
-        }
-    });
     let expand_bindings = func!(expand_bindings(head, body, body1, rest_bindings): 1 => {
         match rest_bindings.tag {
             Expr::Nil => {
@@ -991,22 +977,23 @@ fn reduce(cprocs: &[(&Symbol, usize)]) -> Func {
                         }
                         match symbol head {
                             "lambda" => {
-                                let (args, body) = car_cdr(rest);
-                                let (arg, cdr_args) = extract_arg(args);
-
-                                match arg.tag {
-                                    Expr::Sym => {
-                                        match cdr_args.tag {
+                                let (vars, rest) = car_cdr(rest);
+                                match rest.tag {
+                                    Expr::Cons => {
+                                        let (body, end) = decons2(rest);
+                                        match end.tag {
                                             Expr::Nil => {
-                                                let function: Expr::Fun = cons3(arg, body, env);
-                                                return (function, env, cont, apply)
+                                                let vars_is_cons = eq_tag(vars, cons);
+                                                let vars_is_nil = eq_tag(vars, nil);
+                                                let vars_is_cons_or_nil = or(vars_is_cons, vars_is_nil);
+                                                if vars_is_cons_or_nil {
+                                                    let fun: Expr::Fun = cons3(vars, body, env);
+                                                    return (fun, env, cont, apply)
+                                                }
+                                                return (expr, env, err, errctrl)
                                             }
                                         };
-                                        let inner: Expr::Cons = cons2(cdr_args, body);
-                                        let l: Expr::Cons = cons2(head, inner);
-                                        let inner_body: Expr::Cons = cons2(l, nil);
-                                        let function: Expr::Fun = cons3(arg, inner_body, env);
-                                        return (function, env, cont, apply)
+                                        return (expr, env, err, errctrl)
                                     }
                                 };
                                 return (expr, env, err, errctrl)
@@ -1251,32 +1238,32 @@ fn apply_cont(cprocs: &[(&Symbol, usize)], ivc: bool) -> Func {
                         match result.tag {
                             Expr::Fun => {
                                 let (args, args_env, continuation, _foo) = decons4(cont);
+                                let (vars, body, fun_env) = decons3(result);
                                 match args.tag {
                                     Expr::Cons => {
-                                        let (arg, rest_args) = decons2(args);
-                                        let newer_cont: Cont::Call2 = cons4(result, rest_args, args_env, continuation);
-                                        return (arg, args_env, newer_cont, ret)
-                                    }
-                                    Expr::Nil => {
-                                        let (var, body, fun_env) = decons3(result);
-                                        match symbol var {
-                                            "dummy" => {
-                                                match body.tag {
-                                                    Expr::Nil => {
-                                                        return (result, env, err, errctrl)
-                                                    }
-                                                };
-                                                let (body_form, end) = decons2(body);
-                                                match end.tag {
-                                                    Expr::Nil => {
-                                                        return (body_form, fun_env, continuation, ret)
-                                                    }
-                                                };
+                                        match vars.tag {
+                                            Expr::Nil => {
+                                                // Cannot apply non-zero number of arguments to a zero argument function
                                                 return (result, env, err, errctrl)
                                             }
-                                        };
-                                        // TODO should this be an error or should we return the function?
-                                        return (result, env, continuation, ret)
+                                            Expr::Cons => {
+                                                let (arg, rest_args) = decons2(args);
+                                                let newer_cont: Cont::Call2 = cons4(result, rest_args, args_env, continuation);
+                                                return (arg, args_env, newer_cont, ret)
+                                            }
+                                        }
+                                    }
+                                    Expr::Nil => {
+                                        match vars.tag {
+                                            Expr::Nil => {
+                                                return (body, fun_env, continuation, ret)
+                                            }
+                                            Expr::Cons => {
+                                                // TODO should we not fail here in an analogous way to the non-zero application
+                                                // on a zero argument function case?
+                                                return (result, env, continuation, ret)
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -1287,29 +1274,31 @@ fn apply_cont(cprocs: &[(&Symbol, usize)], ivc: bool) -> Func {
                         let (function, args, args_env, continuation) = decons4(cont);
                         match function.tag {
                             Expr::Fun => {
-                                let (var, body, fun_env) = decons3(function);
-                                match symbol var {
-                                    "dummy" => {
-                                        return (result, env, err, errctrl)
-                                    }
-                                };
-                                match body.tag {
-                                    Expr::Nil => {
-                                        return (result, env, err, errctrl)
-                                    }
-                                };
-                                let (body_form, end) = decons2(body);
-                                match end.tag {
-                                    Expr::Nil => {
+                                let (vars, body, fun_env) = decons3(function);
+                                // vars must be non-empty, so:
+                                let (var, rest_vars) = decons2(vars);
+                                match var.tag {
+                                    Expr::Sym => {
                                         let binding: Expr::Cons = cons2(var, result);
-                                        let newer_env: Expr::Cons = cons2(binding, fun_env);
-                                        match args.tag {
-                                            Expr::Nil => {
-                                                return (body_form, newer_env, continuation, ret)
+                                        let ext_env: Expr::Cons = cons2(binding, fun_env);
+                                        let rest_vars_empty = eq_tag(rest_vars, nil);
+                                        let args_empty = eq_tag(args, nil);
+                                        if rest_vars_empty {
+                                            if args_empty {
+                                                return (body, ext_env, continuation, ret)
                                             }
-                                        };
-                                        let cont: Cont::Call = cons4(args, args_env, continuation, foo);
-                                        return (body_form, newer_env, cont, ret)
+                                            // Oversaturated call
+                                            let cont: Cont::Call = cons4(args, args_env, continuation, foo);
+                                            return (body, ext_env, cont, ret)
+                                        }
+                                        let ext_function: Expr::Fun = cons3(rest_vars, body, ext_env);
+                                        if args_empty {
+                                            // Undersaturated call
+                                            return (ext_function, ext_env, continuation, ret)
+                                        }
+                                        let (arg, rest_args) = decons2(args);
+                                        let cont: Cont::Call2 = cons4(ext_function, rest_args, args_env, continuation);
+                                        return (arg, args_env, cont, ret)
                                     }
                                 };
                                 return (result, env, err, errctrl)
@@ -1759,7 +1748,7 @@ mod tests {
             func.slots_count,
             SlotsCounter {
                 hash4: 14,
-                hash6: 3,
+                hash6: 4,
                 hash8: 3,
                 commitment: 1,
                 bit_decomp: 3,
@@ -1769,8 +1758,8 @@ mod tests {
             expected.assert_eq(&computed.to_string());
         };
         expect_eq(cs.num_inputs(), expect!["1"]);
-        expect_eq(cs.aux().len(), expect!["8653"]);
-        expect_eq(cs.num_constraints(), expect!["10432"]);
+        expect_eq(cs.aux().len(), expect!["8992"]);
+        expect_eq(cs.num_constraints(), expect!["10750"]);
         assert_eq!(func.num_constraints(&store), cs.num_constraints());
     }
 }

--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -906,10 +906,10 @@ fn reduce(cprocs: &[(&Symbol, usize)]) -> Func {
                             match val2.tag {
                                 Expr::Fun => {
                                     // if `val2` is a closure, then extend its environment
-                                    let (arg, body, closed_env) = decons3(val2);
+                                    let (arg, body, closed_env, _foo) = decons4(val2);
                                     let extended: Expr::Cons = cons2(binding, closed_env);
                                     // and return the extended closure
-                                    let fun: Expr::Fun = cons3(arg, body, extended);
+                                    let fun: Expr::Fun = cons4(arg, body, extended, foo);
                                     return (fun, env, cont, apply)
                                 }
                             };
@@ -987,7 +987,7 @@ fn reduce(cprocs: &[(&Symbol, usize)]) -> Func {
                                                 let vars_is_nil = eq_tag(vars, nil);
                                                 let vars_is_cons_or_nil = or(vars_is_cons, vars_is_nil);
                                                 if vars_is_cons_or_nil {
-                                                    let fun: Expr::Fun = cons3(vars, body, env);
+                                                    let fun: Expr::Fun = cons4(vars, body, env, foo);
                                                     return (fun, env, cont, apply)
                                                 }
                                                 return (expr, env, err, errctrl)
@@ -1238,7 +1238,7 @@ fn apply_cont(cprocs: &[(&Symbol, usize)], ivc: bool) -> Func {
                         match result.tag {
                             Expr::Fun => {
                                 let (args, args_env, continuation, _foo) = decons4(cont);
-                                let (vars, body, fun_env) = decons3(result);
+                                let (vars, body, fun_env, _foo) = decons4(result);
                                 match args.tag {
                                     Expr::Cons => {
                                         match vars.tag {
@@ -1274,7 +1274,7 @@ fn apply_cont(cprocs: &[(&Symbol, usize)], ivc: bool) -> Func {
                         let (function, args, args_env, continuation) = decons4(cont);
                         match function.tag {
                             Expr::Fun => {
-                                let (vars, body, fun_env) = decons3(function);
+                                let (vars, body, fun_env, _foo) = decons4(function);
                                 // vars must be non-empty, so:
                                 let (var, rest_vars) = decons2(vars);
                                 match var.tag {
@@ -1291,7 +1291,7 @@ fn apply_cont(cprocs: &[(&Symbol, usize)], ivc: bool) -> Func {
                                             let cont: Cont::Call = cons4(args, args_env, continuation, foo);
                                             return (body, ext_env, cont, ret)
                                         }
-                                        let ext_function: Expr::Fun = cons3(rest_vars, body, ext_env);
+                                        let ext_function: Expr::Fun = cons4(rest_vars, body, ext_env, foo);
                                         if args_empty {
                                             // Undersaturated call
                                             return (ext_function, ext_env, continuation, ret)
@@ -1748,8 +1748,8 @@ mod tests {
             func.slots_count,
             SlotsCounter {
                 hash4: 14,
-                hash6: 4,
-                hash8: 3,
+                hash6: 0,
+                hash8: 6,
                 commitment: 1,
                 bit_decomp: 3,
             }
@@ -1758,8 +1758,8 @@ mod tests {
             expected.assert_eq(&computed.to_string());
         };
         expect_eq(cs.num_inputs(), expect!["1"]);
-        expect_eq(cs.aux().len(), expect!["8992"]);
-        expect_eq(cs.num_constraints(), expect!["10750"]);
+        expect_eq(cs.aux().len(), expect!["8808"]);
+        expect_eq(cs.num_constraints(), expect!["10572"]);
         assert_eq!(func.num_constraints(&store), cs.num_constraints());
     }
 }

--- a/src/lem/store.rs
+++ b/src/lem/store.rs
@@ -1010,29 +1010,17 @@ impl Ptr {
                 Fun => match self.get_index3() {
                     None => "<Malformed Fun>".into(),
                     Some(idx) => {
-                        if let Some((arg, bod, _)) = store.fetch_3_ptrs(idx) {
-                            match bod.tag() {
+                        if let Some((vars, body, ..)) = store.fetch_3_ptrs(idx) {
+                            match vars.tag() {
                                 Tag::Expr(Nil) => {
-                                    format!(
-                                        "<FUNCTION ({}) {}>",
-                                        arg.fmt_to_string(store, state),
-                                        bod.fmt_to_string(store, state)
-                                    )
+                                    format!("<FUNCTION () {}>", body.fmt_to_string(store, state))
                                 }
                                 Tag::Expr(Cons) => {
-                                    if let Some(idx) = bod.get_index2() {
-                                        if let Some((bod, _)) = store.fetch_2_ptrs(idx) {
-                                            format!(
-                                                "<FUNCTION ({}) {}>",
-                                                arg.fmt_to_string(store, state),
-                                                bod.fmt_to_string(store, state)
-                                            )
-                                        } else {
-                                            "<Opaque Fun>".into()
-                                        }
-                                    } else {
-                                        "<Malformed Fun>".into()
-                                    }
+                                    format!(
+                                        "<FUNCTION {} {}>",
+                                        vars.fmt_to_string(store, state),
+                                        body.fmt_to_string(store, state)
+                                    )
                                 }
                                 _ => "<Malformed Fun>".into(),
                             }

--- a/src/lem/store.rs
+++ b/src/lem/store.rs
@@ -535,7 +535,7 @@ impl<F: LurkField> Store<F> {
 
     #[inline]
     pub fn intern_fun(&self, arg: Ptr, body: Ptr, env: Ptr) -> Ptr {
-        self.intern_3_ptrs(Tag::Expr(Fun), arg, body, env)
+        self.intern_4_ptrs(Tag::Expr(Fun), arg, body, env, self.dummy())
     }
 
     #[inline]
@@ -1007,10 +1007,10 @@ impl Ptr {
                         "<Malformed U64>".into()
                     }
                 }
-                Fun => match self.get_index3() {
+                Fun => match self.get_index4() {
                     None => "<Malformed Fun>".into(),
                     Some(idx) => {
-                        if let Some((vars, body, ..)) = store.fetch_3_ptrs(idx) {
+                        if let Some((vars, body, ..)) = store.fetch_4_ptrs(idx) {
                             match vars.tag() {
                                 Tag::Expr(Nil) => {
                                     format!("<FUNCTION () {}>", body.fmt_to_string(store, state))

--- a/src/lem/tests/eval_tests.rs
+++ b/src/lem/tests/eval_tests.rs
@@ -278,7 +278,7 @@ fn evaluate_lambda2() {
         None,
         Some(terminal),
         None,
-        &expect!["9"],
+        &expect!["8"],
         &None,
     );
 }
@@ -339,7 +339,7 @@ fn evaluate_lambda5() {
         None,
         Some(terminal),
         None,
-        &expect!["13"],
+        &expect!["11"],
         &None,
     );
 }
@@ -481,7 +481,7 @@ fn evaluate_adder1() {
         None,
         Some(terminal),
         None,
-        &expect!["13"],
+        &expect!["10"],
         &None,
     );
 }
@@ -502,7 +502,7 @@ fn evaluate_adder2() {
         None,
         Some(terminal),
         None,
-        &expect!["15"],
+        &expect!["12"],
         &None,
     );
 }
@@ -561,7 +561,7 @@ fn evaluate_let() {
         None,
         Some(terminal),
         None,
-        &expect!["10"],
+        &expect!["8"],
         &None,
     );
 }
@@ -658,7 +658,7 @@ fn evaluate_arithmetic_let() {
         Some(new_env),
         Some(terminal),
         None,
-        &expect!["18"],
+        &expect!["15"],
         &None,
     );
 }
@@ -689,7 +689,7 @@ fn evaluate_fundamental_conditional() {
             None,
             Some(terminal),
             None,
-            &expect!["35"],
+            &expect!["28"],
             &None,
         );
     }
@@ -716,7 +716,7 @@ fn evaluate_fundamental_conditional() {
             None,
             Some(terminal),
             None,
-            &expect!["32"],
+            &expect!["26"],
             &None,
         );
     }
@@ -800,7 +800,7 @@ fn evaluate_recursion1() {
         None,
         Some(terminal),
         None,
-        &expect!["91"],
+        &expect!["76"],
         &None,
     );
 }
@@ -825,7 +825,7 @@ fn evaluate_recursion2() {
         None,
         Some(terminal),
         None,
-        &expect!["201"],
+        &expect!["163"],
         &None,
     );
 }
@@ -848,7 +848,7 @@ fn evaluate_recursion_multiarg() {
         None,
         Some(terminal),
         None,
-        &expect!["95"],
+        &expect!["68"],
         &None,
     );
 }
@@ -874,7 +874,7 @@ fn evaluate_recursion_optimized() {
         None,
         Some(terminal),
         None,
-        &expect!["75"],
+        &expect!["66"],
         &None,
     );
 }
@@ -899,7 +899,7 @@ fn evaluate_tail_recursion() {
         None,
         Some(terminal),
         None,
-        &expect!["129"],
+        &expect!["105"],
         &None,
     );
 }
@@ -927,7 +927,7 @@ fn evaluate_tail_recursion_somewhat_optimized() {
         None,
         Some(terminal),
         None,
-        &expect!["110"],
+        &expect!["92"],
         &None,
     );
 }
@@ -948,7 +948,7 @@ fn evaluate_multiple_letrec_bindings() {
         None,
         Some(terminal),
         None,
-        &expect!["22"],
+        &expect!["20"],
         &None,
     );
 }
@@ -969,7 +969,7 @@ fn evaluate_multiple_letrec_bindings_referencing() {
         None,
         Some(terminal),
         None,
-        &expect!["31"],
+        &expect!["28"],
         &None,
     );
 }
@@ -1001,7 +1001,7 @@ fn evaluate_multiple_letrec_bindings_recursive() {
         None,
         Some(terminal),
         None,
-        &expect!["242"],
+        &expect!["175"],
         &None,
     );
 }
@@ -1025,7 +1025,7 @@ fn nested_let_closure_regression() {
             None,
             Some(terminal),
             None,
-            &expect!["13"],
+            &expect!["11"],
             &None,
         );
     }
@@ -1042,7 +1042,7 @@ fn nested_let_closure_regression() {
             None,
             Some(terminal),
             None,
-            &expect!["14"],
+            &expect!["11"],
             &None,
         );
     }
@@ -1172,7 +1172,7 @@ fn evaluate_zero_arg_lambda() {
             None,
             Some(terminal),
             None,
-            &expect!["12"],
+            &expect!["10"],
             &None,
         );
     }
@@ -1185,7 +1185,7 @@ fn evaluate_zero_arg_lambda_variants() {
         let expr = "((lambda () 123) 1)";
 
         let error = s.cont_error();
-        test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, &expect!["3"], &None);
+        test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, &expect!["2"], &None);
     }
     {
         let s = &Store::<Fr>::default();
@@ -1235,7 +1235,7 @@ fn evaluate_make_tree() {
             None,
             Some(terminal),
             None,
-            &expect!["493"],
+            &expect!["445"],
             &None,
         );
     }
@@ -1281,7 +1281,7 @@ fn evaluate_map_tree_bug() {
             None,
             Some(terminal),
             None,
-            &expect!["170"],
+            &expect!["125"],
             &None,
         );
     }
@@ -1308,7 +1308,7 @@ fn evaluate_map_tree_numequal_bug() {
             None,
             Some(error),
             None,
-            &expect!["169"],
+            &expect!["125"],
             &None,
         );
     }
@@ -1343,7 +1343,7 @@ fn env_lost_bug() {
             None,
             Some(terminal),
             None,
-            &expect!["25"],
+            &expect!["22"],
             &None,
         );
     }
@@ -1368,7 +1368,7 @@ fn dont_discard_rest_env() {
             None,
             Some(terminal),
             None,
-            &expect!["22"],
+            &expect!["20"],
             &None,
         );
     }
@@ -1674,7 +1674,7 @@ fn go_translate() {
         None,
         None,
         None,
-        &expect!["1114"],
+        &expect!["840"],
         &None,
     );
 }
@@ -2388,7 +2388,7 @@ fn test_relational_edge_case_identity() {
             None,
             Some(terminal),
             None,
-            &expect!["19"],
+            &expect!["17"],
             &None,
         );
     }
@@ -2407,7 +2407,7 @@ fn test_relational_edge_case_identity() {
             None,
             Some(terminal),
             None,
-            &expect!["24"],
+            &expect!["22"],
             &None,
         );
     }
@@ -2431,7 +2431,7 @@ fn test_num_syntax_implications() {
             None,
             Some(terminal),
             None,
-            &expect!["10"],
+            &expect!["8"],
             &None,
         );
     }
@@ -2564,7 +2564,7 @@ fn test_quoted_symbols() {
         None,
         Some(terminal),
         None,
-        &expect!["13"],
+        &expect!["11"],
         &None,
     );
 }
@@ -3337,7 +3337,7 @@ fn test_fold_cons_regression() {
         None,
         Some(terminal),
         None,
-        &expect!["152"],
+        &expect!["92"],
         &None,
     );
 }
@@ -3550,7 +3550,7 @@ fn test_eval_lambda_body_syntax() {
         None,
         Some(error),
         None,
-        &expect!["3"],
+        &expect!["2"],
         &None,
     );
     test_aux::<Coproc<Fr>>(
@@ -3560,7 +3560,7 @@ fn test_eval_lambda_body_syntax() {
         None,
         Some(error),
         None,
-        &expect!["3"],
+        &expect!["2"],
         &None,
     );
 }
@@ -3670,7 +3670,7 @@ fn test_dumb_lang() {
         None,
         Some(terminal),
         None,
-        &expect!["6"],
+        &expect!["5"],
         &Some(&lang),
     );
     test_aux(

--- a/src/lem/tests/eval_tests.rs
+++ b/src/lem/tests/eval_tests.rs
@@ -1142,11 +1142,10 @@ fn evaluate_zero_arg_lambda() {
     }
     {
         let expected = {
-            let arg = s.intern_user_symbol("x");
+            let args = s.list(vec![s.intern_user_symbol("x")]);
             let num = s.num_u64(123);
-            let body = s.list(vec![num]);
             let env = s.intern_nil();
-            s.intern_fun(arg, body, env)
+            s.intern_fun(args, num, env)
         };
 
         // One arg expected but zero supplied.

--- a/src/proof/tests/nova_tests_lem.rs
+++ b/src/proof/tests/nova_tests_lem.rs
@@ -1542,11 +1542,10 @@ fn test_prove_zero_arg_lambda2() {
 fn test_prove_zero_arg_lambda3() {
     let s = &Store::<Fr>::default();
     let expected = {
-        let arg = s.intern_user_symbol("x");
+        let args = s.list(vec![s.intern_user_symbol("x")]);
         let num = s.num_u64(123);
-        let body = s.list(vec![num]);
         let env = s.intern_nil();
-        s.intern_fun(arg, body, env)
+        s.intern_fun(args, num, env)
     };
     let terminal = s.cont_terminal();
     nova_test_full_aux::<_, _, M1<'_, _>>(
@@ -3785,9 +3784,9 @@ fn test_prove_dotted_syntax_error() {
 fn test_prove_call_literal_fun() {
     let s = &Store::<Fr>::default();
     let empty_env = s.intern_nil();
-    let arg = s.intern_user_symbol("x");
-    let body = s.read_with_default_state("((+ x 1))").unwrap();
-    let fun = s.intern_3_ptrs(Tag::Expr(ExprTag::Fun), arg, body, empty_env);
+    let args = s.list(vec![s.intern_user_symbol("x")]);
+    let body = s.read_with_default_state("(+ x 1)").unwrap();
+    let fun = s.intern_4_ptrs(Tag::Expr(ExprTag::Fun), args, body, empty_env, s.dummy());
     let input = s.num_u64(9);
     let expr = s.list(vec![fun, input]);
     let res = s.num_u64(10);

--- a/src/proof/tests/nova_tests_lem.rs
+++ b/src/proof/tests/nova_tests_lem.rs
@@ -123,7 +123,7 @@ fn test_prove_arithmetic_let() {
         None,
         Some(terminal),
         None,
-        &expect!["18"],
+        &expect!["15"],
         &None,
     );
 }
@@ -357,7 +357,7 @@ fn test_prove_recursion1() {
         None,
         Some(terminal),
         None,
-        &expect!["66"],
+        &expect!["55"],
         &None,
     );
 }
@@ -381,7 +381,7 @@ fn test_prove_recursion2() {
         None,
         Some(terminal),
         None,
-        &expect!["93"],
+        &expect!["76"],
         &None,
     );
 }
@@ -511,7 +511,7 @@ fn test_prove_evaluate2() {
         None,
         Some(terminal),
         None,
-        &expect!["9"],
+        &expect!["8"],
         &None,
     );
 }
@@ -579,7 +579,7 @@ fn test_prove_evaluate5() {
         None,
         Some(terminal),
         None,
-        &expect!["13"],
+        &expect!["11"],
         &None,
     );
 }
@@ -811,7 +811,7 @@ fn test_prove_adder() {
         None,
         Some(terminal),
         None,
-        &expect!["13"],
+        &expect!["10"],
         &None,
     );
 }
@@ -912,7 +912,7 @@ fn test_prove_lambda_empty_error() {
         None,
         Some(error),
         None,
-        &expect!["3"],
+        &expect!["2"],
         &None,
     );
 }
@@ -1081,7 +1081,7 @@ fn test_prove_let() {
         None,
         Some(terminal),
         None,
-        &expect!["18"],
+        &expect!["15"],
         &None,
     );
 }
@@ -1106,7 +1106,7 @@ fn test_prove_arithmetic() {
         None,
         Some(terminal),
         None,
-        &expect!["23"],
+        &expect!["18"],
         &None,
     );
 }
@@ -1128,7 +1128,7 @@ fn test_prove_comparison() {
         None,
         Some(terminal),
         None,
-        &expect!["21"],
+        &expect!["18"],
         &None,
     );
 }
@@ -1157,7 +1157,7 @@ fn test_prove_conditional() {
         None,
         Some(terminal),
         None,
-        &expect!["35"],
+        &expect!["28"],
         &None,
     );
 }
@@ -1186,7 +1186,7 @@ fn test_prove_conditional2() {
         None,
         Some(terminal),
         None,
-        &expect!["32"],
+        &expect!["26"],
         &None,
     );
 }
@@ -1212,7 +1212,7 @@ fn test_prove_fundamental_conditional_bug() {
         None,
         Some(terminal),
         None,
-        &expect!["32"],
+        &expect!["25"],
         &None,
     );
 }
@@ -1253,7 +1253,7 @@ fn test_prove_recursion() {
         None,
         Some(terminal),
         None,
-        &expect!["66"],
+        &expect!["55"],
         &None,
     );
 }
@@ -1275,7 +1275,7 @@ fn test_prove_recursion_multiarg() {
         None,
         Some(terminal),
         None,
-        &expect!["69"],
+        &expect!["49"],
         &None,
     );
 }
@@ -1300,7 +1300,7 @@ fn test_prove_recursion_optimized() {
         None,
         Some(terminal),
         None,
-        &expect!["56"],
+        &expect!["49"],
         &None,
     );
 }
@@ -1324,7 +1324,7 @@ fn test_prove_tail_recursion() {
         None,
         Some(terminal),
         None,
-        &expect!["93"],
+        &expect!["76"],
         &None,
     );
 }
@@ -1350,7 +1350,7 @@ fn test_prove_tail_recursion_somewhat_optimized() {
         None,
         Some(terminal),
         None,
-        &expect!["81"], &None
+        &expect!["68"], &None
     );
 }
 
@@ -1375,7 +1375,7 @@ fn test_prove_no_mutual_recursion() {
         None,
         Some(terminal),
         None,
-        &expect!["22"],
+        &expect!["21"],
         &None,
     );
 }
@@ -1400,7 +1400,7 @@ fn test_prove_no_mutual_recursion_error() {
         None,
         Some(error),
         None,
-        &expect!["25"],
+        &expect!["24"],
         &None,
     );
 }
@@ -1533,7 +1533,7 @@ fn test_prove_zero_arg_lambda2() {
         None,
         Some(terminal),
         None,
-        &expect!["10"],
+        &expect!["9"],
         &None,
     );
 }
@@ -1574,7 +1574,7 @@ fn test_prove_zero_arg_lambda4() {
         None,
         Some(error),
         None,
-        &expect!["3"],
+        &expect!["2"],
         &None,
     );
 }
@@ -1629,7 +1629,7 @@ fn test_prove_nested_let_closure_regression() {
         None,
         Some(terminal),
         None,
-        &expect!["14"],
+        &expect!["11"],
         &None,
     );
 }
@@ -1652,7 +1652,7 @@ fn test_prove_minimal_tail_call() {
         None,
         Some(terminal),
         None,
-        &expect!["50"],
+        &expect!["47"],
         &None,
     );
 }
@@ -1674,7 +1674,7 @@ fn test_prove_cons_in_function1() {
         None,
         Some(terminal),
         None,
-        &expect!["15"],
+        &expect!["12"],
         &None,
     );
 }
@@ -1696,7 +1696,7 @@ fn test_prove_cons_in_function2() {
         None,
         Some(terminal),
         None,
-        &expect!["15"],
+        &expect!["12"],
         &None,
     );
 }
@@ -1738,7 +1738,7 @@ fn test_prove_multiple_letrec_bindings() {
         None,
         Some(terminal),
         None,
-        &expect!["78"],
+        &expect!["73"],
         &None,
     );
 }
@@ -1762,7 +1762,7 @@ fn test_prove_tail_call2() {
         None,
         Some(terminal),
         None,
-        &expect!["84"],
+        &expect!["78"],
         &None,
     );
 }
@@ -1782,7 +1782,7 @@ fn test_prove_multiple_letrecstar_bindings() {
         None,
         Some(terminal),
         None,
-        &expect!["22"],
+        &expect!["20"],
         &None,
     );
 }
@@ -1802,7 +1802,7 @@ fn test_prove_multiple_letrecstar_bindings_referencing() {
         None,
         Some(terminal),
         None,
-        &expect!["31"],
+        &expect!["28"],
         &None,
     );
 }
@@ -1833,7 +1833,7 @@ fn test_prove_multiple_letrecstar_bindings_recursive() {
         None,
         Some(terminal),
         None,
-        &expect!["242"],
+        &expect!["175"],
         &None,
     );
 }
@@ -1855,7 +1855,7 @@ fn test_prove_dont_discard_rest_env() {
         None,
         Some(terminal),
         None,
-        &expect!["22"],
+        &expect!["20"],
         &None,
     );
 }
@@ -1881,7 +1881,7 @@ fn test_prove_fibonacci() {
         None,
         Some(terminal),
         None,
-        &expect!["89"],
+        &expect!["60"],
         5,
         false,
         None,
@@ -1924,7 +1924,7 @@ fn test_prove_terminal_continuation_regression() {
         None,
         Some(terminal),
         None,
-        &expect!["9"],
+        &expect!["8"],
         &None,
     );
 }
@@ -1945,7 +1945,7 @@ fn test_prove_chained_functional_commitment() {
         None,
         Some(terminal),
         None,
-        &expect!["39"],
+        &expect!["30"],
         &None,
     );
 }
@@ -3000,7 +3000,7 @@ fn test_relational_edge_case_identity() {
         None,
         Some(terminal),
         None,
-        &expect!["19"],
+        &expect!["17"],
         &None,
     );
 }
@@ -3101,7 +3101,7 @@ fn test_prove_functional_commitment() {
         None,
         Some(terminal),
         None,
-        &expect!["25"],
+        &expect!["21"],
         &None,
     );
 }
@@ -3131,7 +3131,7 @@ fn test_prove_complicated_functional_commitment() {
         None,
         Some(terminal),
         None,
-        &expect!["108"],
+        &expect!["83"],
         &None,
     );
 }
@@ -3154,7 +3154,7 @@ fn test_prove_test_fold_cons_regression() {
         None,
         Some(terminal),
         None,
-        &expect!["152"],
+        &expect!["92"],
         &None,
     );
 }
@@ -3800,7 +3800,7 @@ fn test_prove_call_literal_fun() {
         None,
         Some(terminal),
         None,
-        &expect!["7"],
+        &expect!["6"],
         DEFAULT_REDUCTION_COUNT,
         false,
         None,
@@ -3840,7 +3840,7 @@ fn test_prove_lambda_body_syntax() {
         None,
         Some(error),
         None,
-        &expect!["3"],
+        &expect!["2"],
         &None,
     );
     test_aux::<_, _, M1<'_, _>>(
@@ -3850,7 +3850,7 @@ fn test_prove_lambda_body_syntax() {
         None,
         Some(error),
         None,
-        &expect!["3"],
+        &expect!["2"],
         &None,
     );
 }
@@ -4076,7 +4076,7 @@ fn test_dumb_lang() {
         None,
         Some(terminal),
         None,
-        &expect!["6"],
+        &expect!["5"],
         &Some(lang.clone()),
     );
     test_aux::<_, _, C1LEM<'_, _, DumbCoprocessor<_>>>(
@@ -4335,7 +4335,7 @@ fn test_letrec_let_nesting() {
         None,
         Some(terminal),
         None,
-        &expect!["6"],
+        &expect!["5"],
         &None,
     );
 }
@@ -4367,7 +4367,7 @@ fn test_letrec_sequencing() {
         None,
         Some(terminal),
         None,
-        &expect!["8"],
+        &expect!["7"],
         &None,
     );
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -215,7 +215,7 @@ const LURK_PACKAGE_SYMBOL_NAME: &str = "lurk";
 const USER_PACKAGE_SYMBOL_NAME: &str = "user";
 const META_PACKAGE_SYMBOL_NAME: &str = "meta";
 
-const LURK_PACKAGE_SYMBOLS_NAMES: [&str; 36] = [
+const LURK_PACKAGE_SYMBOLS_NAMES: [&str; 35] = [
     "atom",
     "begin",
     "car",
@@ -251,7 +251,6 @@ const LURK_PACKAGE_SYMBOLS_NAMES: [&str; 36] = [
     ">",
     "<=",
     ">=",
-    "_",
 ];
 
 const META_PACKAGE_SYMBOLS_NAMES: [&str; 28] = [


### PR DESCRIPTION
This PR changes the way application and environments work.

First, the most important: the environments. The way Lurk used to work is that every time an operation changed an environment, you'd have to push a continuation that would recover the unchanged environment. This was an invariant that absolutely had to be followed, because we would not save the environment for the argument of the function, instead relying on the environment that was returned. That is, it was the responsibility of whoever modified the environment to recover it after reducing the expression, not the responsibility of the whoever must save expressions to the continuation to also save the running environment. This was quite unusual, so I decided to go with the more common approach, of saving environments in continuations. Here are the benefits, and some caveat:

1 - I've removed both lookup and tail continuations, which were in fact identical (these were the continuations responsible for retrieving the environment). This removed a `hash8` slot in `make_thunk`.
2 - I was able to save all necessary environments on continuations without using reusing slots. Saving the environment for the coprocessor was a bit tricky since its continuation already used the 4 slots, so I had to use a hash2 to combine two elements, but it was a reused slot, so no extra slots were required
3 - It made lookup take less iterations since there's no need to waste one step retrieving the environment. This saved about 100+ iterations for `(fib 20)`
4 - This change fixes #687 
5 - Since no one has the responsibility of cleaning up after modifying an environment, the environment that results after you finished reducing the expression is considered garbage, so it must be discarded. That's why `apply_continuation` won't use the input environment at all
6 - Also because of 5, `eval` would leak possibly sensitive information after reducing, since it would return the modified environment. So, primarily for privacy reasons, the last step (when you go from outermost to terminal), the environment is discarded and a `nil` is returned instead. You might protest at first, because now any `(expr, env, outermost)` will return `(val, nil, terminal)`, and not `(val, env, terminal)`. But this behaviour, I think, is more elegant. Here's the reason: if you start with `(expr, env, outermost)`, you can think of it as a shortcut to the evaluation of the top-level `((let ((x a) ...) expr), nil, outermost)`, for a `let` expression that builds `env`. In fact, if you start from such a triple, you will inevitably pass through the state `(expr, env, outermost)`, which was not the case before (you would pass through a similar triple, but the continuation would be a `tail` continuation).

If I've convinced everyone of this change, I will now explain the apply change, which saved another 200+ iterations on `(fib 20)`. The way Lurk used to work, is that an expression such as `(f a b c)` would first spend time rewriting it to `(((f a) b) c)`, to only then start reducing. Now, we push `(a b c)` list to a continuation (called `Call`), evaluate `f`, which should return a function (or we fail). The second change is that functions can have multiple arguments. So, when we apply `Call`, we check 4 cases:

1 - If the function parameters and the call arguments are both empty (nil), we enter the body of the function
2 - If the function parameters is not empty, but the call arguments are, we return the function as is, exactly like current Lurk works
3 - If the function parameters is empty and the call arguments are not empty, we fail, like Lurk
4 - If both are not empty, we start evaluating the first argument, and push a `Call2` continuation with function and rest of arguments

The way `Call2` works:
1 - If the function has exactly one parameter, we enter body of the function, with the call argument added to the environment. If the rest of the call argument is non-nil, we also push a `Call` continuation (this is the oversaturated case)
2 - If the function has more than one parameter, we create a new function with one less parameter and an extended environment. If the rest of the call argument is nil, we return this function, otherwise we push this function to a `Call2` continuation with the tail of the rest, evaluating the argument



Minor change: because of multi-argument functions, one more `hash6` was added, so we would go from `hash6 = 3` and `hash8 = 4` to `hash6 = 4` and `hash8 = 3` (from the environment change). However, making functions `hash8` will reuse one slot, so in the end we've reached `hash6 = 0` and `hash8 = 6` 