### PR TITLE
Simplified `Func` and `Cproc` call

### DIFF
--- a/src/lem/var_map.rs
+++ b/src/lem/var_map.rs
@@ -13,6 +13,12 @@ use super::Var;
 #[derive(Clone, Debug)]
 pub struct VarMap<V>(FxHashMap<Var, V>);
 
+impl<V> Default for VarMap<V> {
+    fn default() -> VarMap<V> {
+        VarMap(FxHashMap::default())
+    }
+}
+
 impl<V> VarMap<V> {
     /// Creates an empty `VarMap`
     #[inline]


### PR DESCRIPTION
This PR simplifies how call hints work. A bindings field is added, which is not the full binding, but only the necessary bindings for call and cproc. This field can be used by all sorts of operations that needs to save values. I'm planning on adding another call operation, for extern calls, so this is important