### PR TITLE
refactor: revamp `GlobalAllocator`

### DIFF
--- a/src/coprocessor/circom.rs
+++ b/src/coprocessor/circom.rs
@@ -118,7 +118,7 @@ Then run `lurk coprocessor --name {name} <{}_FOLDER>` to instantiate a new gadge
                     SynthesisError::Unsatisfiable
                 })?;
             let output = circom_scotia::synthesize(cs, self.config.r1cs.clone(), Some(witness))?;
-            let num_tag = g.get_tag(&crate::tag::ExprTag::Num)?;
+            let num_tag = g.alloc_tag(cs, &crate::tag::ExprTag::Num);
             let res = AllocatedPtr::from_parts(num_tag.clone(), output);
 
             Ok(res)

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -187,9 +187,9 @@ pub(crate) mod test {
             input_env: &AllocatedPtr<F>,
             input_cont: &AllocatedPtr<F>,
         ) -> Result<Vec<AllocatedPtr<F>>, SynthesisError> {
-            let num_tag = g.get_tag(&ExprTag::Num)?;
+            let num_tag = g.alloc_tag(cs, &ExprTag::Num);
 
-            let cont_err = g.get_allocated_ptr_from_ptr(&s.cont_error(), s)?;
+            let cont_err = g.alloc_ptr(cs, &s.cont_error(), s);
 
             let (expr, env, cont) =
                 self.synthesize_aux(cs, input_exprs, input_env, input_cont, num_tag, &cont_err)?;
@@ -246,7 +246,7 @@ pub(crate) mod test {
 
         fn synthesize<CS: ConstraintSystem<F>>(
             &self,
-            _cs: &mut CS,
+            cs: &mut CS,
             g: &GlobalAllocator<F>,
             s: &Store<F>,
             _not_dummy: &Boolean,
@@ -254,8 +254,8 @@ pub(crate) mod test {
             env: &AllocatedPtr<F>,
             _cont: &AllocatedPtr<F>,
         ) -> Result<Vec<AllocatedPtr<F>>, SynthesisError> {
-            let nil = g.get_allocated_ptr_from_ptr(&s.intern_nil(), s)?;
-            let term = g.get_allocated_ptr_from_ptr(&s.cont_terminal(), s)?;
+            let nil = g.alloc_ptr(cs, &s.intern_nil(), s);
+            let term = g.alloc_ptr(cs, &s.cont_terminal(), s);
             Ok(vec![nil, env.clone(), term])
         }
     }

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -198,7 +198,7 @@ impl<F: LurkField> CoCircuit<F> for LookupCoprocessor<F> {
             &s.inverse_poseidon_cache,
         )?;
 
-        let comm_tag = g.get_tag(&ExprTag::Comm)?;
+        let comm_tag = g.alloc_tag(cs, &ExprTag::Comm);
 
         Ok(AllocatedPtr::from_parts(
             comm_tag.clone(),
@@ -309,7 +309,7 @@ impl<F: LurkField> CoCircuit<F> for InsertCoprocessor<F> {
             &s.inverse_poseidon_cache,
         )?;
 
-        let num_tag = g.get_tag(&ExprTag::Num)?;
+        let num_tag = g.alloc_tag(cs, &ExprTag::Num);
         Ok(AllocatedPtr::from_parts(num_tag.clone(), new_root_val))
     }
 }

--- a/src/lem/multiframe.rs
+++ b/src/lem/multiframe.rs
@@ -742,7 +742,7 @@ impl<'a, F: LurkField, C: Coprocessor<F>> Circuit<F> for MultiFrame<'a, F, C> {
                 allocated_output.push(AllocatedPtr::from_parts(allocated_tag, allocated_hash));
             }
 
-            let g = self.lurk_step.alloc_globals(cs, store)?;
+            let g = self.lurk_step.alloc_consts(cs, store);
 
             let allocated_output_result =
                 self.synthesize_frames(cs, store, allocated_input, frames, &g)?;
@@ -859,14 +859,14 @@ impl<'a, F: LurkField, C: Coprocessor<F>> nova::traits::circuit::StepCircuit<F>
                 assert_eq!(frames.len(), 1);
             }
             let store = self.store.expect("store missing");
-            let g = self.lurk_step.alloc_globals(cs, store)?;
+            let g = self.lurk_step.alloc_consts(cs, store);
             self.synthesize_frames(cs, store, input, frames, &g)?
         } else {
             assert!(self.store.is_none());
             let store = Store::default();
             let blank_frame = Frame::blank(self.get_func(), self.pc, &store);
             let frames = vec![blank_frame; self.num_frames];
-            let g = self.lurk_step.alloc_globals(cs, &store)?;
+            let g = self.lurk_step.alloc_consts(cs, &store);
             self.synthesize_frames(cs, &store, input, &frames, &g)?
         };
 
@@ -1037,7 +1037,7 @@ mod tests {
                 }
             }
         }
-        let g = lurk_step.alloc_globals(&mut cs, &store).unwrap();
+        let g = lurk_step.alloc_consts(&mut cs, &store);
 
         // asserting equality of frames witnesses
         let frame = frames.first().unwrap();


### PR DESCRIPTION
* Make `GlobalAllocator` use a `FrozenMap` instead of a `HashMap` so we never need a mutable reference to it
* Allocations now happen in-place if not memoized

Closes #980