### PR TITLE
Refactor: fix asymmetries between Nova and SuperNova APIs

### DIFF
--- a/benches/end2end.rs
+++ b/benches/end2end.rs
@@ -345,12 +345,12 @@ fn verify_benchmark(c: &mut Criterion) {
             let ptr = go_base(&store, state.clone(), s.0, s.1);
             let prover = NovaProver::new(reduction_count, lang_pallas_rc.clone());
             let (frames, _) = evaluate::<Fq, Coproc<Fq>>(None, ptr, &store, limit).unwrap();
-            let (proof, z0, zi, num_steps) = prover.prove(&pp, &frames, &store).unwrap();
+            let (proof, z0, zi, _num_steps) = prover.prove(&pp, &frames, &store).unwrap();
 
             b.iter_batched(
                 || z0.clone(),
                 |z0| {
-                    let result = proof.verify(&pp, &z0, &zi[..], num_steps).unwrap();
+                    let result = proof.verify(&pp, &z0, &zi[..]).unwrap();
                     black_box(result);
                 },
                 BatchSize::LargeInput,
@@ -397,16 +397,14 @@ fn verify_compressed_benchmark(c: &mut Criterion) {
             let ptr = go_base(&store, state.clone(), s.0, s.1);
             let prover = NovaProver::new(reduction_count, lang_pallas_rc.clone());
             let (frames, _) = evaluate::<Fq, Coproc<Fq>>(None, ptr, &store, limit).unwrap();
-            let (proof, z0, zi, num_steps) = prover.prove(&pp, &frames, &store).unwrap();
+            let (proof, z0, zi, _num_steps) = prover.prove(&pp, &frames, &store).unwrap();
 
             let compressed_proof = proof.compress(&pp).unwrap();
 
             b.iter_batched(
                 || z0.clone(),
                 |z0| {
-                    let result = compressed_proof
-                        .verify(&pp, &z0, &zi[..], num_steps)
-                        .unwrap();
+                    let result = compressed_proof.verify(&pp, &z0, &zi[..]).unwrap();
                     black_box(result);
                 },
                 BatchSize::LargeInput,

--- a/examples/circom.rs
+++ b/examples/circom.rs
@@ -127,7 +127,7 @@ fn main() {
     println!("Beginning proof step...");
 
     let proof_start = Instant::now();
-    let (proof, z0, zi, num_steps) = nova_prover
+    let (proof, z0, zi, _num_steps) = nova_prover
         .evaluate_and_prove(&pp, ptr, store.intern_nil(), store, 10000)
         .unwrap();
     let proof_end = proof_start.elapsed();
@@ -137,7 +137,7 @@ fn main() {
     println!("Verifying proof...");
 
     let verify_start = Instant::now();
-    let res = proof.verify(&pp, &z0, &zi, num_steps).unwrap();
+    let res = proof.verify(&pp, &z0, &zi).unwrap();
     let verify_end = verify_start.elapsed();
 
     println!("Verify took {verify_end:?}");

--- a/examples/sha256_ivc.rs
+++ b/examples/sha256_ivc.rs
@@ -87,7 +87,7 @@ fn main() {
 
     println!("Beginning proof step...");
     let proof_start = Instant::now();
-    let (proof, z0, zi, num_steps) = tracing_texray::examine(tracing::info_span!("bang!"))
+    let (proof, z0, zi, _num_steps) = tracing_texray::examine(tracing::info_span!("bang!"))
         .in_scope(|| {
             nova_prover
                 .evaluate_and_prove(&pp, call, store.intern_nil(), store, 10000)
@@ -100,7 +100,7 @@ fn main() {
     println!("Verifying proof...");
 
     let verify_start = Instant::now();
-    assert!(proof.verify(&pp, &z0, &zi, num_steps).unwrap());
+    assert!(proof.verify(&pp, &z0, &zi).unwrap());
     let verify_end = verify_start.elapsed();
 
     println!("Verify took {:?}", verify_end);
@@ -113,7 +113,7 @@ fn main() {
     println!("Compression took {:?}", compress_end);
 
     let compressed_verify_start = Instant::now();
-    let res = compressed_proof.verify(&pp, &z0, &zi, num_steps).unwrap();
+    let res = compressed_proof.verify(&pp, &z0, &zi).unwrap();
     let compressed_verify_end = compressed_verify_start.elapsed();
 
     println!("Final verification took {:?}", compressed_verify_end);

--- a/examples/sha256_nivc.rs
+++ b/examples/sha256_nivc.rs
@@ -95,9 +95,8 @@ fn main() {
 
     println!("Beginning proof step...");
     let proof_start = Instant::now();
-    let ((proof, last_circuit_index), z0, zi, _num_steps) =
-        tracing_texray::examine(tracing::info_span!("bang!"))
-            .in_scope(|| supernova_prover.prove(&pp, &frames, store).unwrap());
+    let (proof, z0, zi, _num_steps) = tracing_texray::examine(tracing::info_span!("bang!"))
+        .in_scope(|| supernova_prover.prove(&pp, &frames, store).unwrap());
     let proof_end = proof_start.elapsed();
 
     println!("Proofs took {:?}", proof_end);
@@ -105,7 +104,7 @@ fn main() {
     println!("Verifying proof...");
 
     let verify_start = Instant::now();
-    assert!(proof.verify(&pp, &z0, &zi, last_circuit_index).unwrap());
+    assert!(proof.verify(&pp, &z0, &zi).unwrap());
     let verify_end = verify_start.elapsed();
 
     println!("Verify took {:?}", verify_end);
@@ -118,9 +117,7 @@ fn main() {
     println!("Compression took {:?}", compress_end);
 
     let compressed_verify_start = Instant::now();
-    let res = compressed_proof
-        .verify(&pp, &z0, &zi, last_circuit_index)
-        .unwrap();
+    let res = compressed_proof.verify(&pp, &z0, &zi).unwrap();
     let compressed_verify_end = compressed_verify_start.elapsed();
 
     println!("Final verification took {:?}", compressed_verify_end);

--- a/src/cli/lurk_proof.rs
+++ b/src/cli/lurk_proof.rs
@@ -139,7 +139,6 @@ pub(crate) enum LurkProof<
         proof: nova::Proof<'a, F, C, M>,
         public_inputs: Vec<F>,
         public_outputs: Vec<F>,
-        num_steps: usize,
         rc: usize,
         lang: Lang<F, C>,
     },
@@ -209,7 +208,6 @@ where
                 proof,
                 public_inputs,
                 public_outputs,
-                num_steps,
                 rc,
                 lang,
             } => {
@@ -217,7 +215,7 @@ where
                 let instance =
                     Instance::new(*rc, Arc::new(lang.clone()), true, Kind::NovaPublicParams);
                 let pp = public_params(&instance)?;
-                Ok(proof.verify(&pp, public_inputs, public_outputs, *num_steps)?)
+                Ok(proof.verify(&pp, public_inputs, public_outputs)?)
             }
         }
     }

--- a/src/cli/repl/meta_cmd.rs
+++ b/src/cli/repl/meta_cmd.rs
@@ -860,7 +860,6 @@ enum ProtocolProof<
     Nova {
         args: LurkData<F>,
         proof: nova::Proof<'a, F, C, M>,
-        num_steps: usize,
     },
 }
 
@@ -1074,21 +1073,8 @@ impl MetaCmd<F> {
             match load::<LurkProof<'_, _, _, MultiFrame<'_, _, Coproc<F>>>>(&proof_path(
                 &proof_key,
             ))? {
-                LurkProof::Nova {
-                    proof,
-                    public_inputs: _,
-                    public_outputs: _,
-                    num_steps,
-                    ..
-                } => {
-                    dump(
-                        ProtocolProof::Nova {
-                            args,
-                            proof,
-                            num_steps,
-                        },
-                        &path,
-                    )?;
+                LurkProof::Nova { proof, .. } => {
+                    dump(ProtocolProof::Nova { args, proof }, &path)?;
                     println!("Protocol proof saved at {path}");
                     Ok(())
                 }
@@ -1122,7 +1108,6 @@ impl MetaCmd<F> {
                 ProtocolProof::Nova {
                     args: LurkData { z_ptr, z_dag },
                     proof,
-                    num_steps,
                 } => {
                     let args =
                         z_dag.populate_store(&z_ptr, &repl.store, &mut Default::default())?;
@@ -1141,7 +1126,6 @@ impl MetaCmd<F> {
                         &pp,
                         &repl.store.to_scalar_vector(&cek_io[..3]),
                         &repl.store.to_scalar_vector(&cek_io[3..]),
-                        num_steps,
                     )? {
                         bail!("Proof verification failed")
                     }

--- a/src/cli/repl/mod.rs
+++ b/src/cli/repl/mod.rs
@@ -317,13 +317,12 @@ impl Repl<F> {
                     info!("Compressing proof");
                     let proof = proof.compress(&pp)?;
                     assert_eq!(self.rc * num_steps, pad(n_frames, self.rc));
-                    assert!(proof.verify(&pp, &public_inputs, &public_outputs, num_steps)?);
+                    assert!(proof.verify(&pp, &public_inputs, &public_outputs)?);
 
                     let lurk_proof = LurkProof::Nova {
                         proof,
                         public_inputs,
                         public_outputs,
-                        num_steps,
                         rc: self.rc,
                         lang: (*self.lang).clone(),
                     };

--- a/src/proof/tests/mod.rs
+++ b/src/proof/tests/mod.rs
@@ -139,16 +139,16 @@ where
 
     if check_nova {
         let pp = public_params::<_, _, M>(reduction_count, lang.clone());
-        let (proof, z0, zi, num_steps) = nova_prover.prove(&pp, &frames, s).unwrap();
+        let (proof, z0, zi, _num_steps) = nova_prover.prove(&pp, &frames, s).unwrap();
 
-        let res = proof.verify(&pp, &z0, &zi, num_steps);
+        let res = proof.verify(&pp, &z0, &zi);
         if res.is_err() {
             tracing::debug!("{:?}", &res);
         }
         assert!(res.unwrap());
 
         let compressed = proof.compress(&pp).unwrap();
-        let res2 = compressed.verify(&pp, &z0, &zi, num_steps);
+        let res2 = compressed.verify(&pp, &z0, &zi);
 
         assert!(res2.unwrap());
     }


### PR DESCRIPTION
* Include the number of steps in the Nova proof type so it can be used for verification
* Remove the need to pass an extra input for `RecursiveSNARKTrait::verify`
* `RecursiveSNARKTrait` no longer needs an arbitrary `ProofOutput` since the index of the last circuit is no longer needed for SuperNova proof verification

Closes #954