### PR TITLE
chore: Repair fibonacci bench

### DIFF
--- a/benches/bench.env
+++ b/benches/bench.env
@@ -1,3 +1,6 @@
+# cargo config
+PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
+
 # Lurk config
 LURK_PERF=max-parallel-simple
 LURK_RC=100,600


### PR DESCRIPTION
- dtolnay/rust-toolchain adds cargo to the GITHUB_PATH, which isn't carried to the justfile environment apparently: https://github.com/dtolnay/rust-toolchain/blob/be73d7920c329f220ce78e0234b8f96b7ae60248/action.yml#L66C16-L66C49
- Added PATH settings to the bench environment file to improve its usability

Closes #1001