### PR TITLE
chore: Refine git source permissions

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -261,7 +261,7 @@ skip-tree = [
 unknown-registry = "warn"
 # Lint level for what to happen when a crate from a git repository that is not
 # in the allow list is encountered
-unknown-git = "warn"
+unknown-git = "deny"
 # List of URLs for allowed crate registries. Defaults to the crates.io index
 # if not specified. If it is specified but empty, no registries are allowed.
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
@@ -270,8 +270,8 @@ allow-git = []
 
 [sources.allow-org]
 # 1 or more github.com organizations to allow git sources for
-github = [""]
+github = ["lurk-lab"]
 # 1 or more gitlab.com organizations to allow git sources for
-gitlab = [""]
+# gitlab = [""]
 # 1 or more bitbucket.org organizations to allow git sources for
-bitbucket = [""]
+# bitbucket = [""]


### PR DESCRIPTION
- Update the `unknown-git` setting to enforce strict rules
- Add "lurk-lab" as a new allowed organization on Github
- disable the gitlab and bitbucket organization permissions

rationale: we had incidents of depending on personal forks before.