### PR TITLE
Chore: folding in parallel with witness generation for NIVC

### DIFF
--- a/src/lem/multiframe.rs
+++ b/src/lem/multiframe.rs
@@ -367,6 +367,10 @@ impl<'a, F: LurkField, C: Coprocessor<F>> MultiFrame<'a, F, C> {
             .skip_while(|f| f.input == f.output && stop_cond(&f.output))
             .count()
     }
+
+    pub fn program_counter(&self) -> usize {
+        self.pc
+    }
 }
 
 impl CEKState<Ptr> for Vec<Ptr> {

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -1,5 +1,3 @@
-#![allow(non_snake_case)]
-
 use abomonation::Abomonation;
 use bellpepper_core::{num::AllocatedNum, ConstraintSystem};
 use ff::PrimeField;


### PR DESCRIPTION
* MultiFrames with PC=0 have their witnesses cached just like in the IVC pipeline
* MultiFrames with PC!=0 have their witnesses cached in parallel due to limited size
  (agnostic to RC) and poor internal parallelism

These are the times (in milliseconds) of proving when running `cargo run --release --example sha256_nivc`:
* `main`: 871, 882, 883 and 892
* this branch: 864, 859, 852 and 878

Closes #937