### PR TITLE
fix: allow SuperNova compressed proof serialization and size computation

### DIFF
--- a/examples/sha256_ivc.rs
+++ b/examples/sha256_ivc.rs
@@ -112,6 +112,9 @@ fn main() {
 
     println!("Compression took {:?}", compress_end);
 
+    let buf = bincode::serialize(&compressed_proof).unwrap();
+    println!("proof size : {:}B", buf.len());
+
     let compressed_verify_start = Instant::now();
     let res = compressed_proof.verify(&pp, &z0, &zi).unwrap();
     let compressed_verify_end = compressed_verify_start.elapsed();

--- a/examples/sha256_nivc.rs
+++ b/examples/sha256_nivc.rs
@@ -116,6 +116,9 @@ fn main() {
 
     println!("Compression took {:?}", compress_end);
 
+    let buf = bincode::serialize(&compressed_proof).unwrap();
+    println!("proof size : {:}B", buf.len());
+
     let compressed_verify_start = Instant::now();
     let res = compressed_proof.verify(&pp, &z0, &zi).unwrap();
     let compressed_verify_end = compressed_verify_start.elapsed();

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -127,6 +127,7 @@ where
 
 /// An enum representing the two types of proofs that can be generated and verified.
 #[derive(Serialize, Deserialize)]
+#[serde(bound = "")]
 pub enum Proof<
     'a,
     F: CurveCycleEquipped,


### PR DESCRIPTION
- Added serialization for the compressed proof using bincode in `sha256_nivc.rs`
- Implemented computation and display of serialized compressed proof size
- Introduced `serde` bound attribute to the `Proof` enum in `supernova.rs`

Fixes #1006