### PR TITLE
Chore: generalize the REPL's Lang

### DIFF
--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -18,7 +18,7 @@ use lurk::{
     eval::lang::Lang,
     field::LurkField,
     lem::{
-        eval::{evaluate, make_eval_step_from_config, EvalConfig},
+        eval::{evaluate, make_cprocs_funcs_from_lang, make_eval_step_from_config, EvalConfig},
         multiframe::MultiFrame,
         pointers::Ptr,
         store::Store,
@@ -134,7 +134,7 @@ fn sha256_ivc_prove<M: measurement::Measurement>(
 
             let prover = NovaProver::new(prove_params.reduction_count, lang_rc.clone());
 
-            let frames = &evaluate(Some((&lurk_step, &lang)), ptr, store, limit).unwrap();
+            let frames = &evaluate(Some((&lurk_step, &[], &lang)), ptr, store, limit).unwrap();
 
             b.iter_batched(
                 || frames,
@@ -215,7 +215,7 @@ fn sha256_ivc_prove_compressed<M: measurement::Measurement>(
 
             let prover = NovaProver::new(prove_params.reduction_count, lang_rc.clone());
 
-            let frames = &evaluate(Some((&lurk_step, &lang)), ptr, store, limit).unwrap();
+            let frames = &evaluate(Some((&lurk_step, &[], &lang)), ptr, store, limit).unwrap();
 
             b.iter_batched(
                 || frames,
@@ -274,6 +274,7 @@ fn sha256_nivc_prove<M: measurement::Measurement>(
     let lang_rc = Arc::new(lang.clone());
 
     let lurk_step = make_eval_step_from_config(&EvalConfig::new_ivc(&lang));
+    let cprocs = make_cprocs_funcs_from_lang(&lang);
 
     // use cached public params
     let instance = Instance::new(
@@ -298,7 +299,7 @@ fn sha256_nivc_prove<M: measurement::Measurement>(
 
             let prover = SuperNovaProver::new(prove_params.reduction_count, lang_rc.clone());
 
-            let frames = &evaluate(Some((&lurk_step, &lang)), ptr, store, limit).unwrap();
+            let frames = &evaluate(Some((&lurk_step, &cprocs, &lang)), ptr, store, limit).unwrap();
 
             b.iter_batched(
                 || frames,

--- a/examples/sha256_nivc.rs
+++ b/examples/sha256_nivc.rs
@@ -8,7 +8,7 @@ use lurk::{
     eval::lang::Lang,
     field::LurkField,
     lem::{
-        eval::{evaluate, make_eval_step_from_config, EvalConfig},
+        eval::{evaluate, make_cprocs_funcs_from_lang, make_eval_step_from_config, EvalConfig},
         multiframe::MultiFrame,
         pointers::Ptr,
         store::Store,
@@ -77,7 +77,8 @@ fn main() {
     let lang_rc = Arc::new(lang.clone());
 
     let lurk_step = make_eval_step_from_config(&EvalConfig::new_nivc(&lang));
-    let frames = evaluate(Some((&lurk_step, &lang)), call, store, 1000).unwrap();
+    let cprocs = make_cprocs_funcs_from_lang(&lang);
+    let frames = evaluate(Some((&lurk_step, &cprocs, &lang)), call, store, 1000).unwrap();
 
     let supernova_prover = SuperNovaProver::<Fr, Sha256Coproc<Fr>, MultiFrame<'_, _, _>>::new(
         REDUCTION_COUNT,

--- a/src/lem/tests/eval_tests.rs
+++ b/src/lem/tests/eval_tests.rs
@@ -6,7 +6,9 @@ use crate::{
     coprocessor::Coprocessor,
     eval::lang::{Coproc, Lang},
     lem::{
-        eval::{evaluate_simple, make_eval_step_from_config, EvalConfig},
+        eval::{
+            evaluate_simple, make_cprocs_funcs_from_lang, make_eval_step_from_config, EvalConfig,
+        },
         pointers::Ptr,
         store::Store,
         Tag,
@@ -114,7 +116,8 @@ fn do_test<C: Coprocessor<Fr>>(
         evaluate_simple::<Fr, C>(None, *expr, s, limit).unwrap()
     } else {
         let func = make_eval_step_from_config(&EvalConfig::new_ivc(lang));
-        evaluate_simple(Some((&func, lang)), *expr, s, limit).unwrap()
+        let cprocs = make_cprocs_funcs_from_lang(lang);
+        evaluate_simple(Some((&func, &cprocs, lang)), *expr, s, limit).unwrap()
     };
     let new_expr = output[0];
     let new_env = output[1];

--- a/src/lem/tests/nivc_steps.rs
+++ b/src/lem/tests/nivc_steps.rs
@@ -31,7 +31,7 @@ fn test_nivc_steps() {
     // 9^2 + 8 = 89
     let expr = store.read_with_default_state("(cproc-dumb 9 8)").unwrap();
 
-    let frames = evaluate(Some((&lurk_step, &lang)), expr, &store, 10).unwrap();
+    let frames = evaluate(Some((&lurk_step, &cprocs, &lang)), expr, &store, 10).unwrap();
 
     // Iteration 1: evaluate first argument
     // Iteration 2: evaluate second argument


### PR DESCRIPTION
* Remove hardcoded Coproc occurrences from the REPL implementation
* Use Coproc on the top-level call
* Fix a non-generalized leftover from #1017

Addresses the third item of #533