### PR TITLE
Request review from `lurk-eval` for changes in `src/lem/eval.rs`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,3 +15,6 @@
 # Circuit
 /src/circuit/** @lurk-lab/lurk-circuit
 /src/lem/circuit.rs @lurk-lab/lurk-circuit
+
+# Evaluation model
+/src/lem/eval.rs @lurk-lab/lurk-lem


### PR DESCRIPTION
~~This PR needs the [`lurk-lem`](https://github.com/orgs/lurk-lab/teams/lurk-lem) team to be renamed to `lurk-eval`. Its description should be "Review approval for lem/eval.rs"~~