### PR TITLE
Remove uneeded bounds on structs

### DIFF
--- a/src/cli/field_data.rs
+++ b/src/cli/field_data.rs
@@ -83,7 +83,7 @@ mod tests {
     use super::{de, ser, HasFieldModulus};
 
     #[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
-    struct Struct<F: LurkField> {
+    struct Struct<F> {
         str: String,
         int: i32,
         ff: F,

--- a/src/coprocessor/circom.rs
+++ b/src/coprocessor/circom.rs
@@ -86,7 +86,7 @@ Then run `lurk coprocessor --name {name} <{}_FOLDER>` to instantiate a new gadge
     /// }
     /// ```
     #[derive(Debug)]
-    pub struct CircomCoprocessor<F: LurkField, C: CircomGadget<F>> {
+    pub struct CircomCoprocessor<F: LurkField, C> {
         gadget: C,
         config: CircomConfig<F>,
     }

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -119,7 +119,7 @@ pub(crate) mod test {
 
     /// A dumb Coprocessor for testing.
     #[derive(Clone, Debug, Serialize, Deserialize)]
-    pub(crate) struct DumbCoprocessor<F: LurkField> {
+    pub(crate) struct DumbCoprocessor<F> {
         pub(crate) _p: PhantomData<F>,
     }
 
@@ -235,7 +235,7 @@ pub(crate) mod test {
 
     /// A coprocessor that simply halts the CEK machine, for testing purposes
     #[derive(Clone, Debug, Serialize, Deserialize)]
-    pub(crate) struct Terminator<F: LurkField> {
+    pub(crate) struct Terminator<F> {
         _p: PhantomData<F>,
     }
 

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -58,7 +58,7 @@ pub enum TrieCoproc<F: LurkField> {
 }
 
 #[derive(Clone, Debug, Serialize, Default, Deserialize)]
-pub struct NewCoprocessor<F: LurkField> {
+pub struct NewCoprocessor<F> {
     _p: PhantomData<F>,
 }
 
@@ -104,7 +104,7 @@ impl<F: LurkField> CoCircuit<F> for NewCoprocessor<F> {
 }
 
 #[derive(Clone, Debug, Serialize, Default, Deserialize)]
-pub struct LookupCoprocessor<F: LurkField> {
+pub struct LookupCoprocessor<F> {
     _p: PhantomData<F>,
 }
 
@@ -208,7 +208,7 @@ impl<F: LurkField> CoCircuit<F> for LookupCoprocessor<F> {
 }
 
 #[derive(Clone, Debug, Serialize, Default, Deserialize)]
-pub struct InsertCoprocessor<F: LurkField> {
+pub struct InsertCoprocessor<F> {
     _p: PhantomData<F>,
 }
 

--- a/src/eval/lang.rs
+++ b/src/eval/lang.rs
@@ -19,7 +19,7 @@ use crate::{
 /// This struct is an example of a coprocessor implementation that would extend the [`crate::coprocessor::Coprocessor`] trait.
 /// More implementations can be added without modifying the existing code, adhering to the open-closed principle.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct DummyCoprocessor<F: LurkField> {
+pub struct DummyCoprocessor<F> {
     pub(crate) _p: PhantomData<F>,
 }
 
@@ -38,7 +38,7 @@ impl<F: LurkField> Coprocessor<F> for DummyCoprocessor<F> {
 
 impl<F: LurkField> CoCircuit<F> for DummyCoprocessor<F> {}
 
-impl<F: LurkField> DummyCoprocessor<F> {
+impl<F> DummyCoprocessor<F> {
     #[allow(dead_code)]
     pub(crate) fn new() -> Self {
         Self {
@@ -73,13 +73,13 @@ pub enum Coproc<F: LurkField> {
 ///
 // TODO: Define a trait for the Hash and parameterize on that also.
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
-pub struct Lang<F: LurkField, C: Coprocessor<F>> {
+pub struct Lang<F, C> {
     /// An IndexMap that stores coprocessors with their associated `Sym` keys.
     coprocessors: IndexMap<Symbol, C>,
     _p: PhantomData<F>,
 }
 
-impl<F: LurkField, C: Coprocessor<F>> Lang<F, C> {
+impl<F: LurkField, C> Lang<F, C> {
     #[inline]
     pub fn new() -> Self {
         Self {
@@ -154,7 +154,7 @@ impl<F: LurkField, C: Coprocessor<F>> Lang<F, C> {
 /// A `Binding` associates a name (`Sym`) and `Coprocessor`. It facilitates modular construction of `Lang`s using
 /// `Coprocessor`s.
 #[derive(Debug)]
-pub struct Binding<F: LurkField, C: Coprocessor<F>> {
+pub struct Binding<F, C> {
     name: Symbol,
     coproc: C,
     _p: PhantomData<F>,
@@ -166,7 +166,7 @@ impl<F: LurkField, C: Coprocessor<F>, S: Into<Symbol>> From<(S, C)> for Binding<
     }
 }
 
-impl<F: LurkField, C: Coprocessor<F>> Binding<F, C> {
+impl<F: LurkField, C> Binding<F, C> {
     pub fn new<T: Into<C>, S: Into<Symbol>>(name: S, coproc: T) -> Self {
         Self {
             name: name.into(),

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -1,12 +1,10 @@
-use crate::field::LurkField;
-
 use std::cmp::PartialEq;
 use std::marker::PhantomData;
 
 pub mod lang;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct Frame<T: Copy, W: Copy, F: LurkField, C> {
+pub struct Frame<T: Copy, W: Copy, F, C> {
     pub input: T,
     pub output: T,
     pub i: usize,

--- a/src/field.rs
+++ b/src/field.rs
@@ -282,7 +282,7 @@ impl LurkField for GrumpkinScalar {
 // For working around the orphan trait impl rule
 /// Wrapper struct around a field element that implements additional traits
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct FWrap<F: LurkField>(pub F);
+pub struct FWrap<F>(pub F);
 
 impl<F: LurkField> Copy for FWrap<F> {}
 

--- a/src/lem/circuit.rs
+++ b/src/lem/circuit.rs
@@ -467,7 +467,7 @@ impl Block {
     }
 }
 
-struct RecursiveContext<'a, F: LurkField, C: Coprocessor<F>> {
+struct RecursiveContext<'a, F: LurkField, C> {
     lang: &'a Lang<F, C>,
     store: &'a Store<F>,
     global_allocator: &'a GlobalAllocator<F>,

--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -232,12 +232,12 @@ pub fn evaluate_simple<F: LurkField, C: Coprocessor<F>>(
     evaluate_simple_with_env(lang_setup, expr, store.intern_nil(), store, limit)
 }
 
-pub struct EvalConfig<'a, F: LurkField, C: Coprocessor<F>> {
+pub struct EvalConfig<'a, F, C> {
     lang: &'a Lang<F, C>,
     folding_mode: FoldingMode,
 }
 
-impl<'a, F: LurkField, C: Coprocessor<F>> EvalConfig<'a, F, C> {
+impl<'a, F, C> EvalConfig<'a, F, C> {
     #[inline]
     pub fn new_ivc(lang: &'a Lang<F, C>) -> Self {
         Self {

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -121,7 +121,6 @@ impl<'a, F: LurkField> fmt::Display for ParseError<Span<'a>, F> {
 impl<I: AsBytes, F: LurkField> nom::error::ParseError<I> for ParseError<I, F>
 where
     I: InputLength,
-    I: Clone,
 {
     fn from_error_kind(input: I, kind: ErrorKind) -> Self {
         ParseError::new(input, ParseErrorKind::Nom(kind))
@@ -155,7 +154,6 @@ where
 impl<I: AsBytes, F: LurkField> nom::error::ContextError<I> for ParseError<I, F>
 where
     I: InputLength,
-    I: Clone,
 {
     fn add_context(input: I, ctx: &'static str, other: Self) -> Self {
         match input.input_len().cmp(&other.input.input_len()) {

--- a/src/public_parameters/disk_cache.rs
+++ b/src/public_parameters/disk_cache.rs
@@ -24,7 +24,6 @@ pub(crate) struct DiskCache<'a, F, C, M>
 where
     F: CurveCycleEquipped,
     C: Coprocessor<F> + 'a,
-    M: MultiFrameTrait<'a, F, C>,
 {
     dir: Utf8PathBuf,
     _t: PhantomData<(&'a (), F, C, M)>,


### PR DESCRIPTION
Bounds on structs are generally not preferable (see e.g. [ref](https://stackoverflow.com/questions/49229332/should-trait-bounds-be-duplicated-in-struct-and-impl)), yet they're present in many places in the code base, even on structs which operation is purely parametric in their contents. This is in part because trait bounds on structs are viral (they force any super-structure that reuses the struct to replicate them).

This PR removes some unneeded instances.