### PR TITLE
Environment optimization

### DIFF
--- a/benches/common/fib.rs
+++ b/benches/common/fib.rs
@@ -56,14 +56,18 @@ fn lurk_fib<F: LurkField>(store: &Store<F>, n: usize) -> Ptr {
     //               saved_env: (((.lurk.user.next . <FUNCTION (.lurk.user.a .lurk.user.b) (.lurk.user.next .lurk.user.b (+ .lurk.user.a .lurk.user.b))>))),
     //               body: (.lurk.user.fib), continuation: Outermost }
 
-    let (_, rest_bindings) = store.car_cdr(target_env).unwrap();
-    let (second_binding, _) = store.car_cdr(&rest_bindings).unwrap();
-    store.car_cdr(&second_binding).unwrap().1
+    let [_, _, rest_bindings] = store.pop_binding(*target_env).unwrap();
+    let [_, val, _] = store.pop_binding(rest_bindings).unwrap();
+    val
 }
 
 // Returns the linear and angular coefficients for the iteration count of fib
 fn compute_coeffs<F: LurkField>(store: &Store<F>) -> (usize, usize) {
-    let mut input = vec![fib_expr(store), store.intern_nil(), store.cont_outermost()];
+    let mut input = vec![
+        fib_expr(store),
+        store.intern_empty_env(),
+        store.cont_outermost(),
+    ];
     let lang: Lang<F, Coproc<F>> = Lang::new();
     let mut coef_lin = 0;
     let coef_ang;

--- a/demo/bank.lurk
+++ b/demo/bank.lurk
@@ -192,7 +192,7 @@ ledger2
 
 ;; Now we can open the committed ledger transfer function on a transaction.
 
-!(call 0x3be53fdb5946af9449e4f7063fd8d60a6acc7ccdea8da8b575facedcb2b1291d '(1 0 2))
+!(call 0x348a2e97903fff808be52461d19c3192b6868830598be397b361a21bfc8a45f9 '(1 0 2))
 
 ;; And the record reflects that Church sent one unit to Satoshi.
 
@@ -202,7 +202,7 @@ ledger2
 
 ;; We can verify the proof..
 
-!(verify "Nova_Pallas_10_0bac4e49ef06a34fd1a6a18d6d7bff8770e6acbf6a4624783af29ad8cd780b14")
+!(verify "Nova_Pallas_10_398a87b5f99157b86abde88a67754791f72fed93ccd8db68d693bc9f7e26738c")
 
 ;; Unfortunately, this functional commitment doesn't let us maintain state.
 ;; Let's turn our single-transaction function into a chained function.
@@ -219,24 +219,24 @@ ledger2
 
 ;; Now we can transfer one unit from Church to Satoshi like before.
 
-!(chain 0x01ad5587273aed89dca2527f7a9a235e1ee74ba2519d39adc7b4c521c66f9dbb '(1 0 2))
+!(chain 0x0e484bf02f72ad529ebb9ded8fc2f4c2b1519a758e0f0238973bf0cd8dd97f72 '(1 0 2))
 
 !(prove)
 
-!(verify "Nova_Pallas_10_2def0d8894789eda3fdbafe6216b9d38c1d73c39964780fff407596dca93535a")
+!(verify "Nova_Pallas_10_11df37aff14b2fc8c1fea85fcc07ebececa4ef3e974764c73c49a2ce64eeb8f1")
 
 ;; Then we can transfer 5 more, proceeding from the new head of the chain.
 
-!(chain 0x07172fda01948387c25038beb5738a12bf88cfb3317180cf5894319c16276c78 '(5 0 2))
+!(chain 0x3cb56c66573d29a478b62ff6d59df557dd2e6a924ff408644e61e31c3847a9cd '(5 0 2))
 
 !(prove)
 
-!(verify "Nova_Pallas_10_2def0d8894789eda3fdbafe6216b9d38c1d73c39964780fff407596dca93535a")
+!(verify "Nova_Pallas_10_3541178de43221c6d12f82ff6da37807971079d11ced58e3564ba2f34e77cfc4")
 
 ;; And once more, this time we'll transfer 20 from Turing to Church.
 
-!(chain 0x261e0afd81be78f88bc638c79d6530f341517ff5fdb368e575407bd701c712cc '(20 1 0))
+!(chain 0x38172b9b6212b557d94b9896ea569e77fa35ac979700bedcc97f711322169905 '(20 1 0))
 
 !(prove)
 
-!(verify "Nova_Pallas_10_2d3c73be45dce3971cf9208a6ec538238fc4a01328342d2b3aa501e5709ea2c5")
+!(verify "Nova_Pallas_10_2dd41df4b593c4f8b4a0a058d94b8dbcded8343f829d1aaf2765f0b8e0eda03b")

--- a/demo/chained-functional-commitment.lurk
+++ b/demo/chained-functional-commitment.lurk
@@ -9,7 +9,7 @@
 
 ;; We chain a next commitment by applying the committed function to a value of 9.
 
-!(chain 0x07978f48203798156497b7fdef995301644c10b16de71c98a9c3c5d5c80e5cb9 9)
+!(chain 0x3e47de9fb674019306d566345ab360d92f955e29e015432b10ecb58476f42f01 9)
 
 ;; The new counter value is 9, and the function returns a new functional commitment.
 
@@ -21,11 +21,11 @@
 
 ;; We can verify the proof.
 
-!(verify "Nova_Pallas_10_29077a93c626166dfe527acb4665eeaa0a2945965db1d984d111fdb04d7f6cb4")
+!(verify "Nova_Pallas_10_1b894ae4e13a74970afb9ff982fd0e9c4dc439a8317ac85eeaf97ab6c3d8f35e")
 
 ;; Now let's chain another call to the new head, adding 12 to the counter.
 
-!(chain 0x09d46102bcc9faaf2d8dbfabe72b5142a1788538129e4826e0e30015f594e035 12)
+!(chain 0x17165f98bc83b64b47c4e030ae621c94edcb10cc3bd68e9dcc5c796283bda34c 12)
 
 ;; Now the counter is 21, and we have a new head commitment.
 
@@ -35,11 +35,11 @@
 
 ;; And verify.
 
-!(verify "Nova_Pallas_10_18beccbc88887d27b074b782525d2c3d5cfafb7f553877513b167b8bb45017e4")
+!(verify "Nova_Pallas_10_29a1a6b7ceca05a40f92883dc7d3c11dd8e7cca698665bc7a9faaaa96cdde96a")
 
 ;; One more time, we'll add 14 to the head commitment's internal state.
 
-!(chain 0x3b0ed1000667da8ce73779a52e4dfe17638f359fcb77f0aad1a6322c1fcef599 14)
+!(chain 0x2c4c9d86f79bb575a1427ead9c14cb5226b79a6339dd1f8f8dc00354da677bfa 14)
 
 ;; 21 + 14 = 35, as expected.
 
@@ -49,7 +49,7 @@
 
 ;; Verify.
 
-!(verify "Nova_Pallas_10_034258d4a0c61bc5fff43cc2e912a88f341abca00c4149c0ed85ab02b33d45dc")
+!(verify "Nova_Pallas_10_13f092af20ac415822a0528d41e5c1f5565bfa6d0ec376445e677f411eb3ddd4")
 
 ;; Repeat indefinitely.
 

--- a/demo/functional-commitment.lurk
+++ b/demo/functional-commitment.lurk
@@ -10,7 +10,7 @@
 
 ;; We open the functional commitment on input 5: Evaluate f(5).
 
-!(call 0x3636a3820b53c834ce46a2d608c3b732681ccbc343b5154862f11f989d1a41e5 5)
+!(call 0x05adecdb07d3d8d4a9d8027c163a70ef66c18ec311abc8381c2df92c58e216b5 5)
 
 ;; We can prove the functional-commitment opening.
 
@@ -18,12 +18,12 @@
 
 ;; We can inspect the input/output expressions of the proof.
 
-!(inspect "Nova_Pallas_10_2f90a649f3a2a7861fdf6499309edc0c8e72b61ff3f40f2a11bd027749df4b04")
+!(inspect "Nova_Pallas_10_1c3654a2491282df9c31cba2d104649a496b3d1bac4bb5352004a21c94554027")
 
 ;; Or the full proof claim
 
-!(inspect-full "Nova_Pallas_10_2f90a649f3a2a7861fdf6499309edc0c8e72b61ff3f40f2a11bd027749df4b04")
+!(inspect-full "Nova_Pallas_10_1c3654a2491282df9c31cba2d104649a496b3d1bac4bb5352004a21c94554027")
 
 ;; Finally, and most importantly, we can verify the proof.
 
-!(verify "Nova_Pallas_10_2f90a649f3a2a7861fdf6499309edc0c8e72b61ff3f40f2a11bd027749df4b04")
+!(verify "Nova_Pallas_10_1c3654a2491282df9c31cba2d104649a496b3d1bac4bb5352004a21c94554027")

--- a/demo/protocol.lurk
+++ b/demo/protocol.lurk
@@ -6,7 +6,7 @@
         (mk-open-expr (lambda (hash) (cons 'open (cons hash nil)))))
     (cons
       (if (= (+ (car pair) (cdr pair)) 30)
-        (list6 (mk-open-expr hash) nil :outermost pair nil :terminal)
+        (list6 (mk-open-expr hash) (empty-env) :outermost pair (empty-env) :terminal)
         nil)
       (lambda () (> (car pair) 10))))
   :rc 10

--- a/demo/vdf.lurk
+++ b/demo/vdf.lurk
@@ -51,7 +51,7 @@
 
 !(prove)
 
-!(verify "Nova_Pallas_10_04ebf402c8345327dbb271b393325f4d360372784e4d1e625e707235a8736dad")
+!(verify "Nova_Pallas_10_3d385361e08449cad361ccbe45d4c41685bcee7ece87b33c47b8953309002f64")
 
 !(def timelock-encrypt (lambda (secret-key plaintext rounds)
                           (let ((ciphertext (+ secret-key plaintext))

--- a/src/cli/repl/mod.rs
+++ b/src/cli/repl/mod.rs
@@ -185,7 +185,7 @@ where
         let current_dir = std::env::current_dir().expect("couldn't capture current directory");
         let pwd_path =
             Utf8PathBuf::from_path_buf(current_dir).expect("path contains invalid Unicode");
-        let env = store.intern_nil();
+        let env = store.intern_empty_env();
         let lurk_step = make_eval_step_from_config(&EvalConfig::new_ivc(&lang));
         let cprocs = make_cprocs_funcs_from_lang(&lang);
         Repl {

--- a/src/cli/repl/mod.rs
+++ b/src/cli/repl/mod.rs
@@ -224,7 +224,7 @@ where
                 )
                 .unwrap();
             let (io, ..) = self
-                .eval_expr_with_env(ptr, self.store.intern_nil())
+                .eval_expr_with_env(ptr, self.store.intern_empty_env())
                 .unwrap();
             io[0]
         })

--- a/src/lem/circuit.rs
+++ b/src/lem/circuit.rs
@@ -260,11 +260,11 @@ pub(crate) fn allocate_slot<F: LurkField, CS: ConstraintSystem<F>>(
                         || *z_ptr.value(),
                     ));
                 }
-                Val::Num(f) => {
-                    let f = store.expect_f(*f);
+                Val::Num(raw) => {
+                    let f = store.hash_raw_ptr(raw).0;
                     preallocated_preimg.push(AllocatedNum::alloc_infallible(
                         cs.namespace(|| format!("component {component_idx} slot {slot}")),
-                        || *f,
+                        || f,
                     ));
                 }
                 Val::Boolean(b) => {

--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -1034,6 +1034,15 @@ fn reduce(cprocs: &[(&Symbol, usize)]) -> Func {
                                 let cont: Cont::If = cons4(more, env, cont, foo);
                                 return (condition, env, cont, ret)
                             }
+                            "empty-env" => {
+                                match rest.tag {
+                                    Expr::Nil => {
+                                        let empty_env: Expr::Env;
+                                        return (empty_env, env, cont, apply)
+                                    }
+                                };
+                                return (expr, env, err, errctrl)
+                            }
                             "current-env" => {
                                 match rest.tag {
                                     Expr::Nil => {
@@ -1730,8 +1739,8 @@ mod tests {
         expect_eq(func.slots_count.commitment, expect!["1"]);
         expect_eq(func.slots_count.bit_decomp, expect!["3"]);
         expect_eq(cs.num_inputs(), expect!["1"]);
-        expect_eq(cs.aux().len(), expect!["8938"]);
-        expect_eq(cs.num_constraints(), expect!["10897"]);
+        expect_eq(cs.aux().len(), expect!["8943"]);
+        expect_eq(cs.num_constraints(), expect!["10921"]);
         assert_eq!(func.num_constraints(&store), cs.num_constraints());
     }
 }

--- a/src/lem/interpreter.rs
+++ b/src/lem/interpreter.rs
@@ -284,13 +284,13 @@ impl Block {
                         let g = *store.expect_f(g_idx);
                         let diff = f - g;
                         hints.bit_decomp.push(Some(SlotData {
-                            vals: vec![Val::Num(store.intern_f(f + f).0)],
+                            vals: vec![Val::Num(RawPtr::Atom(store.intern_f(f + f).0))],
                         }));
                         hints.bit_decomp.push(Some(SlotData {
-                            vals: vec![Val::Num(store.intern_f(g + g).0)],
+                            vals: vec![Val::Num(RawPtr::Atom(store.intern_f(g + g).0))],
                         }));
                         hints.bit_decomp.push(Some(SlotData {
-                            vals: vec![Val::Num(store.intern_f(diff + diff).0)],
+                            vals: vec![Val::Num(RawPtr::Atom(store.intern_f(diff + diff).0))],
                         }));
                         let f = BaseNum::Scalar(f);
                         let g = BaseNum::Scalar(g);
@@ -306,7 +306,7 @@ impl Block {
                     let c = if let RawPtr::Atom(f_idx) = a {
                         let f = *store.expect_f(f_idx);
                         hints.bit_decomp.push(Some(SlotData {
-                            vals: vec![Val::Num(f_idx)],
+                            vals: vec![Val::Num(RawPtr::Atom(f_idx))],
                         }));
                         let b = if *n < 64 { (1 << *n) - 1 } else { u64::MAX };
                         store.intern_atom(Tag::Expr(Num), F::from_u64(f.to_u64_unchecked() & b))
@@ -419,7 +419,7 @@ impl Block {
                     };
                     let secret = *store.expect_f(*secret_idx);
                     let tgt_ptr = store.hide(secret, src_ptr);
-                    let vals = vec![Val::Num(*secret_idx), Val::Pointer(src_ptr)];
+                    let vals = vec![Val::Num(RawPtr::Atom(*secret_idx)), Val::Pointer(src_ptr)];
                     hints.commitment.push(Some(SlotData { vals }));
                     bindings.insert_ptr(tgt.clone(), tgt_ptr);
                 }
@@ -438,7 +438,7 @@ impl Block {
                         store.intern_atom(Tag::Expr(Num), *secret),
                     );
                     let secret_idx = store.intern_f(*secret).0;
-                    let vals = vec![Val::Num(secret_idx), Val::Pointer(*ptr)];
+                    let vals = vec![Val::Num(RawPtr::Atom(secret_idx)), Val::Pointer(*ptr)];
                     hints.commitment.push(Some(SlotData { vals }));
                 }
                 Op::Unit(f) => f(),

--- a/src/lem/macros.rs
+++ b/src/lem/macros.rs
@@ -195,6 +195,15 @@ macro_rules! op {
             $crate::var!($src),
         )
     };
+    ( let $tgt:ident = push_binding($src1:ident, $src2:ident, $src3:ident) ) => {
+        $crate::lem::Op::PushBinding(
+            $crate::var!($tgt),
+            $crate::vars!($src1, $src2, $src3),
+        )
+    };
+    ( let ($tgt1:ident, $tgt2:ident, $tgt3:ident) = pop_binding($src:ident) ) => {
+        $crate::lem::Op::PopBinding($crate::vars!($tgt1, $tgt2, $tgt3), $crate::var!($src))
+    };
     ( let $tgt:ident = hide($sec:ident, $src:ident) ) => {
         $crate::lem::Op::Hide($crate::var!($tgt), $crate::var!($sec), $crate::var!($src))
     };
@@ -570,6 +579,26 @@ macro_rules! block {
             {
                 $($limbs)*
                 $crate::op!(let ($tgt1, $tgt2, $tgt3, $tgt4) = decons4($src) )
+            },
+            $($tail)*
+        )
+    };
+    (@seq {$($limbs:expr)*}, let $tgt:ident = push_binding($src1:ident, $src2:ident, $src3:ident) ; $($tail:tt)*) => {
+        $crate::block! (
+            @seq
+            {
+                $($limbs)*
+                $crate::op!(let $tgt = push_binding($src1, $src2, $src3) )
+            },
+            $($tail)*
+        )
+    };
+    (@seq {$($limbs:expr)*}, let ($tgt1:ident, $tgt2:ident, $tgt3:ident) = pop_binding($src:ident) ; $($tail:tt)*) => {
+        $crate::block! (
+            @seq
+            {
+                $($limbs)*
+                $crate::op!(let ($tgt1, $tgt2, $tgt3) = pop_binding($src) )
             },
             $($tail)*
         )

--- a/src/lem/multiframe.rs
+++ b/src/lem/multiframe.rs
@@ -404,7 +404,7 @@ impl<F: LurkField> EvaluationStore for Store<F> {
     }
 
     fn initial_empty_env(&self) -> Self::Ptr {
-        self.intern_nil()
+        self.intern_empty_env()
     }
 
     fn get_cont_terminal(&self) -> Self::Ptr {
@@ -1085,7 +1085,7 @@ mod tests {
 
         let mut frame = frames.pop().unwrap();
         // faking a trivial evaluation frame
-        frame.output = vec![expr, store.intern_nil(), store.cont_terminal()];
+        frame.output = vec![expr, store.intern_empty_env(), store.cont_terminal()];
 
         let mut cs = TestConstraintSystem::<Fq>::new();
 

--- a/src/lem/slot.rs
+++ b/src/lem/slot.rs
@@ -103,7 +103,10 @@
 //! STEP 2 will need as many iterations as it takes to evaluate the Lurk
 //! expression and so will STEP 3.
 
-use super::{pointers::Ptr, Block, Ctrl, Op};
+use super::{
+    pointers::{Ptr, RawPtr},
+    Block, Ctrl, Op,
+};
 
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SlotsCounter {
@@ -234,12 +237,12 @@ impl Block {
 }
 
 #[derive(Clone, Debug)]
-/// The values a variable can take. `Num`s are pure field elements, much like `Ptr::Atom`,
-/// but missing the tag. `Boolean`s are also field elements, but they are guaranteed to be
-/// constrained to take only 0 or 1 values.
+/// The values a variable can take. `Num`s represent pure field elements, with no tags.
+/// `Boolean`s are also field elements, but they are guaranteed to be constrained to
+/// take only 0 or 1 values.
 pub enum Val {
     Pointer(Ptr),
-    Num(usize),
+    Num(RawPtr),
     Boolean(bool),
 }
 

--- a/src/lem/slot.rs
+++ b/src/lem/slot.rs
@@ -198,7 +198,9 @@ impl Block {
     pub fn count_slots(&self) -> SlotsCounter {
         let ops_slots = self.ops.iter().fold(SlotsCounter::default(), |acc, op| {
             let val = match op {
-                Op::Cons2(..) | Op::Decons2(..) => SlotsCounter::new((1, 0, 0, 0, 0)),
+                Op::Cons2(..) | Op::Decons2(..) | Op::PushBinding(..) | Op::PopBinding(..) => {
+                    SlotsCounter::new((1, 0, 0, 0, 0))
+                }
                 Op::Cons3(..) | Op::Decons3(..) => SlotsCounter::new((0, 1, 0, 0, 0)),
                 Op::Cons4(..) | Op::Decons4(..) => SlotsCounter::new((0, 0, 1, 0, 0)),
                 Op::Hide(..) | Op::Open(..) => SlotsCounter::new((0, 0, 0, 1, 0)),

--- a/src/lem/store.rs
+++ b/src/lem/store.rs
@@ -23,7 +23,7 @@ use crate::{
         self, Binop, Binop2, Call, Call0, Call2, Dummy, Emit, If, Let, LetRec, Lookup, Outermost,
         Tail, Terminal, Unop,
     },
-    tag::ExprTag::{Char, Comm, Cons, Cproc, Fun, Key, Nil, Num, RecVar, Str, Sym, Thunk, U64},
+    tag::ExprTag::{Char, Comm, Cons, Cproc, Fun, Key, Nil, Num, Str, Sym, Thunk, U64},
 };
 
 use super::pointers::{Ptr, RawPtr, ZPtr};
@@ -1002,13 +1002,6 @@ impl Ptr {
                         state.fmt_to_string(&sym.into())
                     } else {
                         "<Opaque Sym>".into()
-                    }
-                }
-                RecVar => {
-                    if let Some(sym) = store.fetch_sym(&self.cast(Tag::Expr(Sym))) {
-                        state.fmt_to_string(&sym.into())
-                    } else {
-                        "<Opaque RecVar>".into()
                     }
                 }
                 Key => {

--- a/src/lem/store.rs
+++ b/src/lem/store.rs
@@ -375,6 +375,27 @@ impl<F: LurkField> Store<F> {
     }
 
     #[inline]
+    pub fn push_binding(&self, sym: Ptr, val: Ptr, env: Ptr) -> Ptr {
+        assert_eq!(*sym.tag(), Tag::Expr(Sym));
+        assert_eq!(*env.tag(), Tag::Expr(Env));
+        let raw =
+            self.intern_raw_ptrs::<4>([*sym.raw(), self.tag(*val.tag()), *val.raw(), *env.raw()]);
+        Ptr::new(Tag::Expr(Env), raw)
+    }
+
+    #[inline]
+    pub fn pop_binding(&self, env: Ptr) -> Option<[Ptr; 3]> {
+        assert_eq!(*env.tag(), Tag::Expr(Env));
+        let idx = env.get_index2()?;
+        let [sym_pay, val_tag, val_pay, env_pay] = self.fetch_raw_ptrs::<4>(idx)?;
+        let val_tag = self.fetch_tag(val_tag)?;
+        let sym = Ptr::new(Tag::Expr(Sym), *sym_pay);
+        let val = Ptr::new(val_tag, *val_pay);
+        let env = Ptr::new(Tag::Expr(Env), *env_pay);
+        Some([sym, val, env])
+    }
+
+    #[inline]
     pub fn intern_empty_env(&self) -> Ptr {
         self.intern_atom(Tag::Expr(Env), F::ZERO)
     }

--- a/src/lem/tests/eval_tests.rs
+++ b/src/lem/tests/eval_tests.rs
@@ -828,7 +828,7 @@ fn evaluate_recursion2() {
         None,
         Some(terminal),
         None,
-        &expect!["122"],
+        &expect!["117"],
         &None,
     );
 }
@@ -902,7 +902,7 @@ fn evaluate_tail_recursion() {
         None,
         Some(terminal),
         None,
-        &expect!["80"],
+        &expect!["77"],
         &None,
     );
 }
@@ -930,7 +930,7 @@ fn evaluate_tail_recursion_somewhat_optimized() {
         None,
         Some(terminal),
         None,
-        &expect!["73"],
+        &expect!["70"],
         &None,
     );
 }
@@ -1371,7 +1371,7 @@ fn dont_discard_rest_env() {
             None,
             Some(terminal),
             None,
-            &expect!["15"],
+            &expect!["14"],
             &None,
         );
     }
@@ -1677,7 +1677,7 @@ fn go_translate() {
         None,
         None,
         None,
-        &expect!["509"],
+        &expect!["443"],
         &None,
     );
 }
@@ -3340,7 +3340,7 @@ fn test_fold_cons_regression() {
         None,
         Some(terminal),
         None,
-        &expect!["67"],
+        &expect!["64"],
         &None,
     );
 }
@@ -3370,7 +3370,7 @@ fn test_eval_bad_form() {
     let expr = "(* 5 (eval '(+ 1 a) '((0 . 3))))"; // two-arg eval, optional second arg is env.
     let error = s.cont_error();
 
-    test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, &expect!["8"], &None);
+    test_aux::<Coproc<Fr>>(s, expr, None, None, Some(error), None, &expect!["5"], &None);
 }
 
 #[test]

--- a/src/lem/tests/eval_tests.rs
+++ b/src/lem/tests/eval_tests.rs
@@ -652,7 +652,7 @@ fn evaluate_arithmetic_let() {
                    (/ (+ a b) c))";
 
     let expected = s.num_u64(3);
-    let new_env = s.intern_nil();
+    let new_env = s.intern_empty_env();
     let terminal = s.cont_terminal();
     test_aux::<Coproc<Fr>>(
         s,
@@ -1147,7 +1147,7 @@ fn evaluate_zero_arg_lambda() {
         let expected = {
             let args = s.list(vec![s.intern_user_symbol("x")]);
             let num = s.num_u64(123);
-            let env = s.intern_nil();
+            let env = s.intern_empty_env();
             s.intern_fun(args, num, env)
         };
 
@@ -1687,7 +1687,7 @@ fn begin_current_env() {
     {
         let s = &Store::<Fr>::default();
         let expr = "(begin (current-env))";
-        let expected = s.intern_nil();
+        let expected = s.intern_empty_env();
         test_aux::<Coproc<Fr>>(
             s,
             expr,
@@ -1728,8 +1728,8 @@ fn begin_current_env1() {
                        (begin 123 (current-env)))";
         let a = s.intern_user_symbol("a");
         let one = s.num_u64(1);
-        let binding = s.cons(a, one);
-        let expected = s.list(vec![binding]);
+        let env = s.intern_empty_env();
+        let expected = s.push_binding(a, one, env);
         test_aux::<Coproc<Fr>>(
             s,
             expr,
@@ -2576,7 +2576,7 @@ fn test_quoted_symbols() {
 fn test_eval() {
     let s = &Store::<Fr>::default();
     let expr = "(* 3 (eval (cons '+ (cons 1 (cons 2 nil)))))";
-    let expr2 = "(* 5 (eval '(+ 1 a) '((a . 3))))"; // two-arg eval, optional second arg is env.
+    let expr2 = "(* 5 (eval '(+ 1 a) (let ((a 3)) (current-env))))"; // two-arg eval, optional second arg is env.
     let res = s.num_u64(9);
     let res2 = s.num_u64(20);
     let terminal = s.cont_terminal();
@@ -2598,7 +2598,7 @@ fn test_eval() {
         None,
         Some(terminal),
         None,
-        &expect!["9"],
+        &expect!["11"],
         &None,
     );
 }

--- a/src/proof/tests/nova_tests_lem.rs
+++ b/src/proof/tests/nova_tests_lem.rs
@@ -819,7 +819,7 @@ fn test_prove_adder() {
 #[test]
 fn test_prove_current_env_simple() {
     let s = &Store::<Fr>::default();
-    let expected = s.intern_nil();
+    let expected = s.intern_empty_env();
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
         s,
@@ -1544,7 +1544,7 @@ fn test_prove_zero_arg_lambda3() {
     let expected = {
         let args = s.list(vec![s.intern_user_symbol("x")]);
         let num = s.num_u64(123);
-        let env = s.intern_nil();
+        let env = s.intern_empty_env();
         s.intern_fun(args, num, env)
     };
     let terminal = s.cont_terminal();
@@ -3009,7 +3009,7 @@ fn test_relational_edge_case_identity() {
 fn test_prove_test_eval() {
     let s = &Store::<Fr>::default();
     let expr = "(* 3 (eval  (cons '+ (cons 1 (cons 2 nil)))))";
-    let expr2 = "(* 5 (eval '(+ 1 a) '((a . 3))))"; // two-arg eval, optional second arg is env.
+    let expr2 = "(* 5 (eval '(+ 1 a) (let ((a 3)) (current-env))))"; // two-arg eval, optional second arg is env.
     let res = s.num_u64(9);
     let res2 = s.num_u64(20);
     let terminal = s.cont_terminal();
@@ -3031,7 +3031,7 @@ fn test_prove_test_eval() {
         None,
         Some(terminal),
         None,
-        &expect!["9"],
+        &expect!["11"],
         &None,
     );
 }
@@ -3783,7 +3783,7 @@ fn test_prove_dotted_syntax_error() {
 #[test]
 fn test_prove_call_literal_fun() {
     let s = &Store::<Fr>::default();
-    let empty_env = s.intern_nil();
+    let empty_env = s.intern_empty_env();
     let args = s.list(vec![s.intern_user_symbol("x")]);
     let body = s.read_with_default_state("(+ x 1)").unwrap();
     let fun = intern_ptrs!(s, Tag::Expr(ExprTag::Fun), args, body, empty_env, s.dummy());

--- a/src/proof/tests/nova_tests_lem.rs
+++ b/src/proof/tests/nova_tests_lem.rs
@@ -381,7 +381,7 @@ fn test_prove_recursion2() {
         None,
         Some(terminal),
         None,
-        &expect!["59"],
+        &expect!["57"],
         &None,
     );
 }
@@ -1324,7 +1324,7 @@ fn test_prove_tail_recursion() {
         None,
         Some(terminal),
         None,
-        &expect!["59"],
+        &expect!["57"],
         &None,
     );
 }
@@ -1350,7 +1350,7 @@ fn test_prove_tail_recursion_somewhat_optimized() {
         None,
         Some(terminal),
         None,
-        &expect!["55"], &None
+        &expect!["53"], &None
     );
 }
 
@@ -1855,7 +1855,7 @@ fn test_prove_dont_discard_rest_env() {
         None,
         Some(terminal),
         None,
-        &expect!["15"],
+        &expect!["14"],
         &None,
     );
 }
@@ -1881,7 +1881,7 @@ fn test_prove_fibonacci() {
         None,
         Some(terminal),
         None,
-        &expect!["40"],
+        &expect!["35"],
         5,
         false,
         None,
@@ -1945,7 +1945,7 @@ fn test_prove_chained_functional_commitment() {
         None,
         Some(terminal),
         None,
-        &expect!["24"],
+        &expect!["22"],
         &None,
     );
 }
@@ -3131,7 +3131,7 @@ fn test_prove_complicated_functional_commitment() {
         None,
         Some(terminal),
         None,
-        &expect!["69"],
+        &expect!["68"],
         &None,
     );
 }
@@ -3154,7 +3154,7 @@ fn test_prove_test_fold_cons_regression() {
         None,
         Some(terminal),
         None,
-        &expect!["67"],
+        &expect!["64"],
         &None,
     );
 }
@@ -3185,7 +3185,7 @@ fn test_prove_reduce_sym_contradiction_regression() {
     let expr = "(eval 'a '(nil))";
     let error = s.cont_error();
 
-    test_aux::<_, Coproc<_>>(s, expr, None, None, Some(error), None, &expect!["4"], &None);
+    test_aux::<_, Coproc<_>>(s, expr, None, None, Some(error), None, &expect!["3"], &None);
 }
 
 #[test]
@@ -3248,7 +3248,7 @@ fn test_prove_test_eval_bad_form() {
     let expr = "(* 5 (eval '(+ 1 a) '((0 . 3))))"; // two-arg eval, optional second arg is env. This tests for error on malformed env.
     let error = s.cont_error();
 
-    test_aux::<_, Coproc<_>>(s, expr, None, None, Some(error), None, &expect!["8"], &None);
+    test_aux::<_, Coproc<_>>(s, expr, None, None, Some(error), None, &expect!["5"], &None);
 }
 
 #[test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -215,7 +215,7 @@ const LURK_PACKAGE_SYMBOL_NAME: &str = "lurk";
 const USER_PACKAGE_SYMBOL_NAME: &str = "user";
 const META_PACKAGE_SYMBOL_NAME: &str = "meta";
 
-const LURK_PACKAGE_SYMBOLS_NAMES: [&str; 35] = [
+const LURK_PACKAGE_SYMBOLS_NAMES: [&str; 36] = [
     "atom",
     "begin",
     "car",
@@ -226,6 +226,7 @@ const LURK_PACKAGE_SYMBOLS_NAMES: [&str; 35] = [
     "cons",
     "current-env",
     "emit",
+    "empty-env",
     "eval",
     "eq",
     "hide",

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -51,7 +51,6 @@ pub enum ExprTag {
     U64,
     Key,
     Cproc,
-    RecVar,
 }
 
 impl From<ExprTag> for u16 {
@@ -81,7 +80,6 @@ impl fmt::Display for ExprTag {
             ExprTag::Comm => write!(f, "comm#"),
             ExprTag::U64 => write!(f, "u64#"),
             ExprTag::Cproc => write!(f, "cproc#"),
-            ExprTag::RecVar => write!(f, "rec_var#"),
         }
     }
 }

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -52,6 +52,7 @@ pub enum ExprTag {
     Key,
     Cproc,
     Env,
+    Rec,
 }
 
 impl From<ExprTag> for u16 {
@@ -82,6 +83,7 @@ impl fmt::Display for ExprTag {
             ExprTag::U64 => write!(f, "u64#"),
             ExprTag::Cproc => write!(f, "cproc#"),
             ExprTag::Env => write!(f, "env#"),
+            ExprTag::Rec => write!(f, "rec#"),
         }
     }
 }

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -51,6 +51,7 @@ pub enum ExprTag {
     U64,
     Key,
     Cproc,
+    Env,
 }
 
 impl From<ExprTag> for u16 {
@@ -80,6 +81,7 @@ impl fmt::Display for ExprTag {
             ExprTag::Comm => write!(f, "comm#"),
             ExprTag::U64 => write!(f, "u64#"),
             ExprTag::Cproc => write!(f, "cproc#"),
+            ExprTag::Env => write!(f, "env#"),
         }
     }
 }

--- a/tests/lurk-cli-tests.rs
+++ b/tests/lurk-cli-tests.rs
@@ -55,7 +55,7 @@ fn test_prove_and_verify() {
 
     let mut file = File::create(lurk_file.clone()).unwrap();
     file.write_all(b"!(prove (+ 1 1))\n").unwrap();
-    file.write_all(b"!(verify \"Nova_Pallas_10_3f2526abf20fc9006dd93c0d3ff49954ef070ef52d2e88426974de42cc27bdb2\")\n").unwrap();
+    file.write_all(b"!(verify \"Nova_Pallas_10_090cee5a184bc9b76a965e59b87cd1a1eac30c2b0f243e7ee0232e51d14ebbf6\")\n").unwrap();
 
     let mut cmd = lurk_cmd();
     cmd.env("LURK_PERF", "max-parallel-simple");


### PR DESCRIPTION
This PR optimizes environments. Now, they're specialized data structures with its own tag `Env`. Empty environments are 0 valued environments, and otherwise they are a hash of size 4, the first element being the symbol payload, the second and third elements being the corresponding value's tag and payload, and the fourth element, the tail environment's payload. Doing this means lookups now take a single hash4, which allows us to do 8 lookups per step!

In the earlier PR, we simplified recursive envs by tagging symbols with a special tag to signal it came from a letrec. Now, because we don't have tags in symbols, some other strategy is needed. This is why I'm now tagging functions with a special recursive tag. It's important to note that this tag only appears in functions inside environment, as when you fetch them, it becomes a normal function with an extended environment. This is effectively the same behaviour as Lurk, although the internal representation is different

In earlier commits I gave another solution to letrecs which would solve issue #434 and actually give a proper letrec semantics, but the issue is that it would recompute recursive values and you'd end up with more iterations. This can only be solved with memoization, which will give the proper operational semantics to thunks, and can be solved after we've integrated the memoset into Lurk. Until then, we will have to settle on the other solution