### PR TITLE
chore: Update halo2curves and other dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,12 +129,12 @@ clap = "4.3.17"
 ff = "0.13"
 metrics = "0.21.1"
 neptune = { git = "https://github.com/lurk-lab/neptune", branch = "dev", features = ["abomonation"] }
-nova = { git = "https://github.com/huitseeker/arecibo", branch = "upgrade_halo2curves", package = "arecibo" }
+nova = { git = "https://github.com/lurk-lab/arecibo", branch = "dev", package = "arecibo" }
 once_cell = "1.18.0"
 pairing = { version = "0.23" }
 pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch = "dev" }
 pasta-msm = { git = "https://github.com/lurk-lab/pasta-msm", branch = "dev" }
-grumpkin-msm = { git = "https://github.com/huitseeker/grumpkin-msm", branch = "upgrade_halo2curves" }
+grumpkin-msm = { git = "https://github.com/lurk-lab/grumpkin-msm", branch = "dev" }
 proptest = "1.2.0"
 proptest-derive = "0.3"
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ tracing-texray = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 elsa = { version = "1.9.0", git = "https://github.com/lurk-lab/elsa", branch = "sync_frozen", features = ["indexmap"] }
 arc-swap = "1.6.0"
+halo2curves = { version = "0.6.0", features = ["bits", "derive_serde"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 memmap = { version = "0.5.10", package = "memmap2" }
@@ -82,12 +83,10 @@ rustyline = { version = "13.0", features = [
     "with-file-history",
 ], default-features = false }
 home = "0.5.5"
-halo2curves = { version = "0.5.0", features = ["bits", "derive_serde"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
 rustyline = { version = "13.0", features = ["derive"], default-features = false }
-halo2curves = { version = "0.5.0", default-features = false, features = ["bits", "derive_serde"] }
 
 [features]
 default = []
@@ -130,12 +129,12 @@ clap = "4.3.17"
 ff = "0.13"
 metrics = "0.21.1"
 neptune = { git = "https://github.com/lurk-lab/neptune", branch = "dev", features = ["abomonation"] }
-nova = { git = "https://github.com/lurk-lab/arecibo", branch = "dev", package = "arecibo" }
+nova = { git = "https://github.com/huitseeker/arecibo", branch = "upgrade_halo2curves", package = "arecibo" }
 once_cell = "1.18.0"
 pairing = { version = "0.23" }
 pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch = "dev" }
 pasta-msm = { git = "https://github.com/lurk-lab/pasta-msm", branch = "dev" }
-grumpkin-msm = { git = "https://github.com/lurk-lab/grumpkin-msm", branch = "dev", features = ["dont-implement-sort"] }
+grumpkin-msm = { git = "https://github.com/huitseeker/grumpkin-msm", branch = "upgrade_halo2curves" }
 proptest = "1.2.0"
 proptest-derive = "0.3"
 rand = "0.8"


### PR DESCRIPTION
- The `halo2curves` dependency has been upgraded to version `0.6.0`.

Companion PR of
- https://github.com/lurk-lab/arecibo/pull/250
- https://github.com/lurk-lab/grumpkin-msm/pull/11