### PR TITLE
Use Bn256/Grumpkin curves as a default setting

### DIFF
--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -15,5 +15,4 @@ concurrency:
 jobs:
   gpu-ci:
     name: Rust GPU tests
-    if: github.event_name != 'pull_request' || github.event.action == 'enqueued'
-    uses: lurk-lab/ci-workflows/.github/workflows/gpu-ci.yml@main
+    uses: lurk-lab/ci-workflows/.github/workflows/gpu-ci-cuda.yml@main

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -37,7 +37,7 @@ mod tests {
     use bellpepper_core::test_cs::TestConstraintSystem;
     use bellpepper_core::ConstraintSystem;
 
-    use pasta_curves::pallas::Scalar as Fr;
+    use halo2curves::bn256::Fr;
 
     #[test]
     fn test_enforce_popcount() {

--- a/src/circuit/gadgets/constraints.rs
+++ b/src/circuit/gadgets/constraints.rs
@@ -823,7 +823,7 @@ mod tests {
 
     use bellpepper_core::test_cs::TestConstraintSystem;
     use ff::Field;
-    use pasta_curves::pallas::Scalar as Fr;
+    use halo2curves::bn256::Fr;
     use proptest::prelude::*;
     use std::ops::{AddAssign, SubAssign};
 

--- a/src/coprocessor/gadgets.rs
+++ b/src/coprocessor/gadgets.rs
@@ -529,7 +529,7 @@ pub fn a_ptr_as_z_ptr<T: Tag, F: LurkField>(
 mod test {
     use bellpepper::util_cs::witness_cs::WitnessCS;
     use bellpepper_core::{boolean::Boolean, test_cs::TestConstraintSystem, ConstraintSystem};
-    use pasta_curves::Fq;
+    use halo2curves::bn256::Fr as Fq;
 
     use crate::{
         circuit::gadgets::pointer::AllocatedPtr,

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -617,10 +617,14 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
         cs: &mut CS,
         key: &AllocatedNum<F>,
     ) -> Result<Vec<Vec<Boolean>>, SynthesisError> {
+        let (arity_bits, bits_needed) = Self::path_bit_dimensions();
+
         let mut bits = key.to_bits_le_strict(&mut cs.namespace(|| "bits"))?;
+        for _ in 0..bits_needed - bits.len() {
+            bits.push(Boolean::Constant(false));
+        }
         bits.reverse();
 
-        let (arity_bits, bits_needed) = Self::path_bit_dimensions();
         // each chunk is reversed due to little-endian encoding
         let path = bits[bits.len() - bits_needed..]
             .chunks(arity_bits)

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -915,9 +915,9 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Default
 #[cfg(test)]
 mod test {
     use super::*;
-    use ff::PrimeField;
+    use expect_test::{expect, Expect};
+    use halo2curves::bn256::Fr;
     use once_cell::sync::OnceCell;
-    use pasta_curves::pallas::Scalar as Fr;
 
     static POSEIDON_CACHE: OnceCell<PoseidonCache<Fr>> = OnceCell::new();
     static INVERSE_POSEIDON_CACHE: OnceCell<InversePoseidonCache<Fr>> = OnceCell::new();
@@ -930,39 +930,28 @@ mod test {
         INVERSE_POSEIDON_CACHE.get_or_init(InversePoseidonCache::default)
     }
 
+    fn check(actual: Fr, expect: &Expect) {
+        let actual = format!("{:?}", actual);
+        expect.assert_eq(&actual);
+    }
+
     #[test]
     fn test_empty_roots() {
         let t: Trie<'_, Fr, 8, 3> =
             Trie::new_with_capacity(poseidon_cache(), inverse_poseidon_cache(), 512);
         assert_eq!(Fr::zero(), Trie::<'_, Fr, 8, 3>::empty_element());
         assert_eq!(Fr::zero(), t.empty_root_for_height(0));
-        assert_eq!(
-            scalar_from_u64s([
-                0xa81830c13a876b1c,
-                0x83b4610d346c2a33,
-                0x528056fe84bb9846,
-                0x0ef417527046e53c
-            ]),
-            t.empty_root_for_height(1)
+        check(
+            t.empty_root_for_height(1),
+            &expect!["0x1ca5b207085f3f0f324a2e0704b18fff1cda2e2d686aa85343fea91df77bf35b"],
         );
-
-        assert_eq!(
-            scalar_from_u64s([
-                0x33ff39660bc554aa,
-                0xd85d92c9279a65e7,
-                0x8e0f305f27de3d65,
-                0x089120e96e4b6dc5
-            ]),
-            t.empty_root_for_height(2)
+        check(
+            t.empty_root_for_height(2),
+            &expect!["0x0637ddaef5cd53ba6711c328952208d846222066701e10c34d3a6df7350de8aa"],
         );
-        assert_eq!(
-            scalar_from_u64s([
-                0xa52e7d0bbbee086b,
-                0x06e4ba3d56dbd7fa,
-                0xed7adffde497af73,
-                0x2fd6f6c5e5d21d60
-            ]),
-            t.empty_root_for_height(3)
+        check(
+            t.empty_root_for_height(3),
+            &expect!["0x08127a45502f5939273edd1957c8748ae39992e2a459d99f999992a842df99a5"],
         );
     }
 
@@ -998,72 +987,41 @@ mod test {
         }
     }
 
-    pub(crate) fn scalar_from_u64s(parts: [u64; 4]) -> Fr {
-        let mut le_bytes = [0u8; 32];
-        le_bytes[0..8].copy_from_slice(&parts[0].to_le_bytes());
-        le_bytes[8..16].copy_from_slice(&parts[1].to_le_bytes());
-        le_bytes[16..24].copy_from_slice(&parts[2].to_le_bytes());
-        le_bytes[24..32].copy_from_slice(&parts[3].to_le_bytes());
-        let mut repr = <Fr as PrimeField>::Repr::default();
-        repr.as_mut().copy_from_slice(&le_bytes[..]);
-        Fr::from_repr_vartime(repr).expect("u64s exceed scalar field modulus")
-    }
-
     #[test]
     fn test_hashes() {
         {
             let mut t0: Trie<'_, Fr, 8, 1> =
                 Trie::new_with_capacity(poseidon_cache(), inverse_poseidon_cache(), 8);
-            assert_eq!(
-                scalar_from_u64s([
-                    0xa81830c13a876b1c,
-                    0x83b4610d346c2a33,
-                    0x528056fe84bb9846,
-                    0x0ef417527046e53c
-                ]),
-                t0.empty_root()
+            check(
+                t0.empty_root(),
+                &expect!["0x1ca5b207085f3f0f324a2e0704b18fff1cda2e2d686aa85343fea91df77bf35b"],
             );
             assert_eq!(t0.empty_root(), t0.root());
         }
         {
             let mut t1: Trie<'_, Fr, 8, 2> =
                 Trie::new_with_capacity(poseidon_cache(), inverse_poseidon_cache(), 64);
-            assert_eq!(
-                scalar_from_u64s([
-                    0x33ff39660bc554aa,
-                    0xd85d92c9279a65e7,
-                    0x8e0f305f27de3d65,
-                    0x089120e96e4b6dc5
-                ]),
-                t1.empty_root()
+            check(
+                t1.empty_root(),
+                &expect!["0x0637ddaef5cd53ba6711c328952208d846222066701e10c34d3a6df7350de8aa"],
             );
             assert_eq!(t1.empty_root(), t1.root());
         }
         {
             let mut t2: Trie<'_, Fr, 8, 3> =
                 Trie::new_with_capacity(poseidon_cache(), inverse_poseidon_cache(), 512);
-            assert_eq!(
-                scalar_from_u64s([
-                    0xa52e7d0bbbee086b,
-                    0x06e4ba3d56dbd7fa,
-                    0xed7adffde497af73,
-                    0x2fd6f6c5e5d21d60
-                ]),
-                t2.empty_root()
+            check(
+                t2.empty_root(),
+                &expect!["0x08127a45502f5939273edd1957c8748ae39992e2a459d99f999992a842df99a5"],
             );
             assert_eq!(t2.empty_root(), t2.root());
         }
         {
             let mut t3: Trie<'_, Fr, 8, 4> =
                 Trie::new_with_capacity(poseidon_cache(), inverse_poseidon_cache(), 4096);
-            assert_eq!(
-                scalar_from_u64s([
-                    0xd95987b58e6c5852,
-                    0x261c08dca064c6c3,
-                    0x191320220a5d5d84,
-                    0x2cdb105f591c0e94
-                ]),
-                t3.empty_root()
+            check(
+                t3.empty_root(),
+                &expect!["0x12c2ef2ab5df25442fe23d8711bf985f02c39e83930517f7103d4bd4228c6cfb"],
             );
             assert_eq!(t3.empty_root(), t3.root());
         }

--- a/src/coroutine/memoset/demo.rs
+++ b/src/coroutine/memoset/demo.rs
@@ -94,6 +94,10 @@ impl<F: LurkField> Query<F> for DemoQuery<F> {
             _ => unreachable!(),
         }
     }
+
+    fn count() -> usize {
+        1
+    }
 }
 
 impl<F: LurkField> CircuitQuery<F> for DemoCircuitQuery<F> {
@@ -203,22 +207,20 @@ impl<F: LurkField> CircuitQuery<F> for DemoCircuitQuery<F> {
         }
     }
 
-    fn from_ptr<CS: ConstraintSystem<F>>(
-        cs: &mut CS,
-        s: &Store<F>,
-        ptr: &Ptr,
-    ) -> Result<Option<Self>, SynthesisError> {
+    fn from_ptr<CS: ConstraintSystem<F>>(cs: &mut CS, s: &Store<F>, ptr: &Ptr) -> Option<Self> {
         let query = DemoQuery::from_ptr(s, ptr);
-        Ok(if let Some(q) = query {
+        if let Some(q) = query {
             match q {
-                DemoQuery::Factorial(n) => Some(Self::Factorial(AllocatedPtr::alloc(cs, || {
-                    Ok(s.hash_ptr(&n))
-                })?)),
+                DemoQuery::Factorial(n) => {
+                    Some(Self::Factorial(AllocatedPtr::alloc_infallible(cs, || {
+                        s.hash_ptr(&n)
+                    })))
+                }
                 _ => unreachable!(),
             }
         } else {
             None
-        })
+        }
     }
 
     fn symbol(&self) -> Symbol {

--- a/src/coroutine/memoset/demo.rs
+++ b/src/coroutine/memoset/demo.rs
@@ -235,7 +235,7 @@ mod test {
     use super::*;
 
     use ff::Field;
-    use pasta_curves::pallas::Scalar as F;
+    use halo2curves::bn256::Fr as F;
 
     #[test]
     fn test_factorial() {

--- a/src/coroutine/memoset/mod.rs
+++ b/src/coroutine/memoset/mod.rs
@@ -774,7 +774,7 @@ mod test {
     use bellpepper_core::{test_cs::TestConstraintSystem, Comparable};
     use demo::DemoQuery;
     use expect_test::{expect, Expect};
-    use pasta_curves::pallas::Scalar as F;
+    use halo2curves::bn256::Fr as F;
     use std::default::Default;
 
     #[test]

--- a/src/coroutine/memoset/query.rs
+++ b/src/coroutine/memoset/query.rs
@@ -27,7 +27,10 @@ where
         s.intern_symbol(&self.symbol())
     }
 
+    /// What is this queries index? Used for ordering circuits and transcripts, grouped by query type.
     fn index(&self) -> usize;
+    /// How many types of query are provided?
+    fn count() -> usize;
 }
 
 pub trait CircuitQuery<F: LurkField>
@@ -50,9 +53,5 @@ where
         s.intern_symbol(&self.symbol())
     }
 
-    fn from_ptr<CS: ConstraintSystem<F>>(
-        cs: &mut CS,
-        s: &Store<F>,
-        ptr: &Ptr,
-    ) -> Result<Option<Self>, SynthesisError>;
+    fn from_ptr<CS: ConstraintSystem<F>>(cs: &mut CS, s: &Store<F>, ptr: &Ptr) -> Option<Self>;
 }

--- a/src/eval/lang.rs
+++ b/src/eval/lang.rs
@@ -181,7 +181,7 @@ pub(crate) mod test {
     use crate::sym;
 
     use super::*;
-    use halo2curves::bn256::Fr as Fr;
+    use halo2curves::bn256::Fr;
 
     #[test]
     fn lang() {

--- a/src/eval/lang.rs
+++ b/src/eval/lang.rs
@@ -181,7 +181,7 @@ pub(crate) mod test {
     use crate::sym;
 
     use super::*;
-    use pasta_curves::pallas::Scalar as Fr;
+    use halo2curves::bn256::Fr as Fr;
 
     #[test]
     fn lang() {

--- a/src/field.rs
+++ b/src/field.rs
@@ -346,8 +346,8 @@ impl<'de, F: LurkField> Deserialize<'de> for FWrap<F> {
 #[cfg(test)]
 pub mod tests {
     use crate::z_data::{from_z_data, to_z_data};
-    use pasta_curves::pallas::Scalar as Fr;
-    use pasta_curves::{pallas, vesta};
+    use halo2curves::bn256::Fr;
+    use halo2curves::{bn256, grumpkin};
 
     use super::*;
 
@@ -359,11 +359,11 @@ pub mod tests {
 
     proptest! {
       #[test]
-      fn prop_pallas_repr_bytes_consistency(f1 in any::<FWrap<pallas::Scalar>>()) {
+      fn prop_bn256_repr_bytes_consistency(f1 in any::<FWrap<bn256::Fr>>()) {
           repr_bytes_consistency(f1)
       }
       #[test]
-      fn prop_vesta_repr_bytes_consistency(f1 in any::<FWrap<vesta::Scalar>>()) {
+      fn prop_grumpkin_repr_bytes_consistency(f1 in any::<FWrap<grumpkin::Fr>>()) {
           repr_bytes_consistency(f1)
       }
     }
@@ -418,11 +418,11 @@ pub mod tests {
         repr_canonicity(f1)
       }
       #[test]
-      fn prop_pallas_repr_canonicity(f1 in any::<FWrap<pallas::Scalar>>()) {
+      fn prop_bn256_repr_canonicity(f1 in any::<FWrap<bn256::Fr>>()) {
           repr_canonicity(f1)
       }
       #[test]
-      fn prop_vesta_repr_canonicity(f1 in any::<FWrap<vesta::Scalar>>()) {
+      fn prop_grumpkin_repr_canonicity(f1 in any::<FWrap<grumpkin::Fr>>()) {
           repr_canonicity(f1)
       }
       #[test]
@@ -448,8 +448,8 @@ pub mod tests {
     // we use this library with.
     proptest! {
         #[test]
-        fn prop_pallas_tag_roundtrip(x in any::<u64>()){
-            let f1 = pallas::Scalar::from(x);
+        fn prop_bn256_tag_roundtrip(x in any::<u64>()){
+            let f1 = bn256::Fr::from(x);
             let bytes = f1.to_repr().as_ref().to_vec();
             let mut bytes_from_u64 = [0u8; 32];
             bytes_from_u64[..8].copy_from_slice(&x.to_le_bytes());
@@ -457,8 +457,8 @@ pub mod tests {
         }
 
         #[test]
-        fn prop_vesta_tag_roundtrip(x in any::<u64>()){
-            let f1 = vesta::Scalar::from(x);
+        fn prop_grumpkin_tag_roundtrip(x in any::<u64>()){
+            let f1 = grumpkin::Fr::from(x);
             let bytes = f1.to_repr().as_ref().to_vec();
             let mut bytes_from_u64 = [0u8; 32];
             bytes_from_u64[..8].copy_from_slice(&x.to_le_bytes());

--- a/src/lem/circuit.rs
+++ b/src/lem/circuit.rs
@@ -1680,6 +1680,8 @@ impl Func {
         let bit_decomp_cost = match F::FIELD {
             LanguageField::Pallas => 298,
             LanguageField::Vesta => 301,
+            // TODO: investigate how to properly compute this number, as it was obtained empirically
+            LanguageField::BN256 => 354,
             _ => todo!(),
         };
 

--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -1726,7 +1726,7 @@ mod tests {
     };
     use bellpepper_core::{test_cs::TestConstraintSystem, Comparable};
     use expect_test::{expect, Expect};
-    use pasta_curves::pallas::Scalar as Fr;
+    use halo2curves::bn256::Fr;
 
     #[test]
     fn test_counts() {
@@ -1745,8 +1745,8 @@ mod tests {
         expect_eq(func.slots_count.commitment, expect!["1"]);
         expect_eq(func.slots_count.bit_decomp, expect!["3"]);
         expect_eq(cs.num_inputs(), expect!["1"]);
-        expect_eq(cs.aux().len(), expect!["8927"]);
-        expect_eq(cs.num_constraints(), expect!["10857"]);
+        expect_eq(cs.aux().len(), expect!["9095"]);
+        expect_eq(cs.num_constraints(), expect!["11025"]);
         assert_eq!(func.num_constraints(&store), cs.num_constraints());
     }
 }

--- a/src/lem/multiframe.rs
+++ b/src/lem/multiframe.rs
@@ -968,12 +968,12 @@ mod tests {
     fn test_sequential_and_parallel_witnesses_equivalences() {
         let lurk_step = eval_step();
         let num_slots_per_frame = lurk_step.slots_count.total();
-        let store = Store::<Fq>::default();
+        let store = Store::<Bn>::default();
         let mut cs = WitnessCS::new();
 
         let expr = store.read_with_default_state("(if t (+ 5 5) 6)").unwrap();
 
-        let frames = evaluate::<Fq, Coproc<Fq>>(None, expr, &store, 10).unwrap();
+        let frames = evaluate::<Bn, Coproc<Bn>>(None, expr, &store, 10).unwrap();
 
         let sequential_slots_witnesses =
             generate_slots_witnesses(&store, &frames, num_slots_per_frame, false);
@@ -1038,7 +1038,7 @@ mod tests {
 
         let mut cs_clone = cs.clone();
 
-        let lang = Lang::<Fq, Coproc<Fq>>::new();
+        let lang = Lang::<Bn, Coproc<Bn>>::new();
 
         let output_sequential = synthesize_frames_sequential(
             &mut cs,
@@ -1074,20 +1074,20 @@ mod tests {
 
     #[test]
     fn non_self_evaluating() {
-        let store = Store::default();
+        let store = Store::<Bn>::default();
 
         // not self-evaluating
         let expr = store.read_with_default_state("(+ 1 2)").unwrap();
 
-        let lang = Arc::new(Lang::<Fq, Coproc<Fq>>::new());
-        let mut frames = evaluate::<Fq, Coproc<Fq>>(None, expr, &store, 1).unwrap();
+        let lang = Arc::new(Lang::<Bn, Coproc<Bn>>::new());
+        let mut frames = evaluate::<Bn, Coproc<Bn>>(None, expr, &store, 1).unwrap();
         assert_eq!(frames.len(), 1);
 
         let mut frame = frames.pop().unwrap();
         // faking a trivial evaluation frame
         frame.output = vec![expr, store.intern_empty_env(), store.cont_terminal()];
 
-        let mut cs = TestConstraintSystem::<Fq>::new();
+        let mut cs = TestConstraintSystem::<Bn>::new();
 
         let folding_config = Arc::new(FoldingConfig::new_ivc(lang.clone(), 1));
 

--- a/src/lem/store.rs
+++ b/src/lem/store.rs
@@ -1346,7 +1346,7 @@ impl Ptr {
 #[cfg(test)]
 mod tests {
     use ff::Field;
-    use pasta_curves::pallas::Scalar as Fr;
+    use halo2curves::bn256::Fr;
     use proptest::prelude::*;
 
     use crate::{

--- a/src/lem/tests/misc.rs
+++ b/src/lem/tests/misc.rs
@@ -1,6 +1,6 @@
 use bellpepper::util_cs::Comparable;
 use bellpepper_core::{test_cs::TestConstraintSystem, Delta};
-use pasta_curves::pallas::Scalar as Fr;
+use halo2curves::bn256::Fr;
 
 use crate::{
     eval::lang::{DummyCoprocessor, Lang},

--- a/src/lem/tests/nivc_steps.rs
+++ b/src/lem/tests/nivc_steps.rs
@@ -1,4 +1,4 @@
-use pasta_curves::pallas::Scalar as Fr;
+use halo2curves::bn256::Fr;
 
 use crate::{
     coprocessor::test::DumbCoprocessor,

--- a/src/num.rs
+++ b/src/num.rs
@@ -294,8 +294,8 @@ mod tests {
     use proptest::proptest;
 
     use ff::Field;
-    use pasta_curves::pallas::Scalar;
-    use pasta_curves::pallas::Scalar as Fr;
+    use halo2curves::bn256::Fr as Scalar;
+    use halo2curves::bn256::Fr;
 
     proptest! {
         #![proptest_config(ProptestConfig {

--- a/src/parser/base.rs
+++ b/src/parser/base.rs
@@ -184,8 +184,8 @@ pub fn parse_litbase_le_bytes<F: LurkField>(
 
 #[cfg(test)]
 pub mod tests {
+    use halo2curves::bn256::Fr;
     use nom::Parser;
-    use pasta_curves::pallas::Scalar as Fr;
 
     use super::*;
 

--- a/src/parser/string.rs
+++ b/src/parser/string.rs
@@ -200,8 +200,8 @@ pub fn parse_string<'a, F: LurkField>(
 }
 #[cfg(test)]
 pub mod tests {
+    use halo2curves::bn256::Fr;
     use nom::Parser;
-    use pasta_curves::pallas::Scalar as Fr;
 
     use super::*;
 

--- a/src/parser/syntax.rs
+++ b/src/parser/syntax.rs
@@ -418,8 +418,8 @@ pub fn parse_maybe_meta<F: LurkField>(
 
 #[cfg(test)]
 pub mod tests {
+    use halo2curves::bn256::Fr as Scalar;
     use nom::Parser;
-    use pasta_curves::pallas::Scalar;
     #[cfg(not(target_arch = "wasm32"))]
     use proptest::prelude::*;
 
@@ -845,7 +845,7 @@ pub mod tests {
         ));
         assert!(test(
             parse_num(),
-            "0x40000000000000000000000000000000224698fc0994a8dd8c46eb2100000000",
+            "0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000000",
             Some(Syntax::Num(
                 Pos::No,
                 Num::Scalar(<Scalar as ff::Field>::ZERO - Scalar::from(1u64))
@@ -853,7 +853,7 @@ pub mod tests {
         ));
         assert!(test(
             parse_num(),
-            "0x40000000000000000000000000000000224698fc0994a8dd8c46eb2100000001",
+            "0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001",
             None,
         ));
         assert!(test(parse_num(), "-0", Some(num!(0))));
@@ -869,9 +869,9 @@ pub mod tests {
     #[test]
     fn unit_parse_syntax_misc() {
         let vec: Vec<u8> = vec![
-            0x3e, 0x2e, 0x50, 0x55, 0xdc, 0xf6, 0x14, 0x86, 0xb0, 0x3b, 0xb8, 0x0e, 0xd2, 0xb3,
-            0xf1, 0xa3, 0x5c, 0x30, 0xe1, 0x22, 0xde, 0xfe, 0xba, 0xe8, 0x24, 0xfa, 0xe4, 0xed,
-            0x32, 0x40, 0x8e, 0x87,
+            0x19, 0x1d, 0x3d, 0x47, 0x43, 0xb4, 0xd1, 0xce, 0x39, 0x36, 0xa0, 0xa6, 0x68, 0xcf,
+            0x6f, 0x64, 0x50, 0x28, 0x45, 0x79, 0xdb, 0xe2, 0x66, 0xe3, 0x64, 0x5b, 0x67, 0x64,
+            0xcf, 0x24, 0xb9, 0x36,
         ]
         .into_iter()
         .rev()
@@ -886,7 +886,7 @@ pub mod tests {
         ));
         assert!(test(
             parse_syntax(state(), false, true),
-            "(0x3e2e5055dcf61486b03bb80ed2b3f1a35c30e122defebae824fae4ed32408e87)",
+            "(0x191d3d4743b4d1ce3936a0a668cf6f6450284579dbe266e3645b6764cf24b936)",
             Some(list!([num!(Num::Scalar(f_from_le_bytes(&vec)))])),
         ));
         assert!(test(

--- a/src/proof/tests/nova_tests_lem.rs
+++ b/src/proof/tests/nova_tests_lem.rs
@@ -1,5 +1,5 @@
 use expect_test::expect;
-use pasta_curves::pallas::Scalar as Fr;
+use halo2curves::bn256::Fr;
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 
 use crate::{
@@ -2473,12 +2473,12 @@ fn test_prove_char_num() {
 #[test]
 fn test_prove_char_coercion() {
     let s = &Store::<Fr>::default();
-    let expr = r#"(char (- 0 4294967200))"#;
-    let expr2 = r#"(char (- 0 4294967199))"#;
+    let expr = r#"(char (+ 4294967296 97))"#;
+    let expr2 = r#"(char (+ 4294967296 98))"#;
     let expected_a = s.read_with_default_state(r"#\a").unwrap();
     let expected_b = s.read_with_default_state(r"#\b").unwrap();
     let terminal = s.cont_terminal();
-    test_aux::<_, Coproc<_>>(
+    test_aux::<_, Coproc<Fr>>(
         s,
         expr,
         Some(expected_a),
@@ -4188,7 +4188,7 @@ fn test_trie_lang() {
     let expr = s.read(state.clone(), expr).unwrap();
     let res = s
         .read_with_default_state(
-            "0x1cc5b90039db85fd519af975afa1de9d2b92960a585a546637b653b115bc3b53",
+            "0x2bfc4f437d5ca652511d67e06201b4fdf95c314c85ea987988746a253071bed6",
         )
         .unwrap();
     nova_test_full_aux2::<_, TrieCoproc<_>>(
@@ -4206,7 +4206,7 @@ fn test_trie_lang() {
     );
 
     let expr2 =
-        "(.lurk.trie.lookup 0x1cc5b90039db85fd519af975afa1de9d2b92960a585a546637b653b115bc3b53 123)";
+        "(.lurk.trie.lookup 0x2bfc4f437d5ca652511d67e06201b4fdf95c314c85ea987988746a253071bed6 123)";
     let expr2 = s.read(state.clone(), expr2).unwrap();
     let res2 = s.comm(Fr::zero());
     nova_test_full_aux2::<_, TrieCoproc<_>>(
@@ -4224,11 +4224,11 @@ fn test_trie_lang() {
     );
 
     let expr3 =
-        "(.lurk.trie.insert 0x1cc5b90039db85fd519af975afa1de9d2b92960a585a546637b653b115bc3b53 123 456)";
+        "(.lurk.trie.insert 0x2bfc4f437d5ca652511d67e06201b4fdf95c314c85ea987988746a253071bed6 123 456)";
     let expr3 = s.read(state.clone(), expr3).unwrap();
     let res3 = s
         .read_with_default_state(
-            "0x1b22dc5a394231c34e4529af674dc56a736fbd07508acfd1d12c0e67c8b4de27",
+            "0x21ad1dd339f26bb824ab861dbcf110c1bcb3b7658eea4b5e84780a3b4958bf95",
         )
         .unwrap();
     nova_test_full_aux2::<_, TrieCoproc<_>>(
@@ -4246,7 +4246,7 @@ fn test_trie_lang() {
     );
 
     let expr4 =
-        "(.lurk.trie.lookup 0x1b22dc5a394231c34e4529af674dc56a736fbd07508acfd1d12c0e67c8b4de27 123)";
+        "(.lurk.trie.lookup 0x21ad1dd339f26bb824ab861dbcf110c1bcb3b7658eea4b5e84780a3b4958bf95 123)";
     let expr4 = s.read(state.clone(), expr4).unwrap();
     let res4 = s.comm(Fr::from(456));
     nova_test_full_aux2::<_, TrieCoproc<_>>(

--- a/src/public_parameters/mod.rs
+++ b/src/public_parameters/mod.rs
@@ -177,7 +177,7 @@ where
 mod tests {
     use super::{instance::Kind, *};
     use crate::eval::lang::{Coproc, Lang};
-    use pasta_curves::pallas::Scalar as S1;
+    use halo2curves::bn256::Fr as S1;
     use tempfile::Builder;
 
     #[test]

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -274,8 +274,8 @@ impl Symbol {
             Span,
         };
         use crate::syntax::Syntax;
+        use halo2curves::bn256::Fr as Scalar;
         use nom::{sequence::preceded, Parser};
-        use pasta_curves::pallas::Scalar;
         match preceded(
             parse_space::<Scalar>,
             parse_symbol(State::default().rccell(), true),

--- a/src/z_data/serde/mod.rs
+++ b/src/z_data/serde/mod.rs
@@ -30,7 +30,7 @@ impl serde::de::Error for SerdeError {
 mod tests {
     use crate::field::FWrap;
     use crate::z_data::{from_z_data, to_z_data};
-    use pasta_curves::pallas::Scalar;
+    use halo2curves::bn256::Fr as Scalar;
     use proptest::prelude::*;
     use serde::{Deserialize, Serialize};
     use std::collections::BTreeMap;

--- a/src/z_data/z_cont.rs
+++ b/src/z_data/z_cont.rs
@@ -15,7 +15,7 @@ use crate::z_ptr::{ZContPtr, ZExprPtr, ZPtr};
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(
     not(target_arch = "wasm32"),
-    serde_test(types(pasta_curves::pallas::Scalar), zdata(true))
+    serde_test(types(halo2curves::bn256::Fr), zdata(true))
 )]
 /// A `ZCont` is the content-addressed representation of a Lurk continuation, which enables
 /// efficient serialization and sharing of hashed Lurk data via associated `ZContPtr`s.

--- a/src/z_data/z_expr.rs
+++ b/src/z_data/z_expr.rs
@@ -16,7 +16,7 @@ use crate::UInt;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(
     not(target_arch = "wasm32"),
-    serde_test(types(pasta_curves::pallas::Scalar), zdata(true))
+    serde_test(types(halo2curves::bn256::Fr), zdata(true))
 )]
 /// A `ZExpr` is the content-addressed representation of a Lurk expression, which enables
 /// efficient serialization and sharing of hashed Lurk data via associated `ZExprPtr`s.

--- a/src/z_data/z_ptr.rs
+++ b/src/z_data/z_ptr.rs
@@ -22,8 +22,8 @@ use crate::tag::{ContTag, ExprTag, Tag};
 #[cfg_attr(
     not(target_arch = "wasm32"),
     serde_test(
-        types(ExprTag, pasta_curves::pallas::Scalar),
-        types(ContTag, pasta_curves::pallas::Scalar),
+        types(ExprTag, halo2curves::bn256::Fr),
+        types(ContTag, halo2curves::bn256::Fr),
         zdata(true)
     )
 )]
@@ -132,7 +132,7 @@ pub type ZContPtr<F> = ZPtr<ContTag, F>;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pasta_curves::pallas::Scalar;
+    use halo2curves::bn256::Fr as Scalar;
 
     proptest! {
         #[test]

--- a/src/z_data/z_store.rs
+++ b/src/z_data/z_store.rs
@@ -25,7 +25,7 @@ use crate::field::LurkField;
 #[cfg_attr(not(target_arch = "wasm32"), proptest(no_bound))]
 #[cfg_attr(
     not(target_arch = "wasm32"),
-    serde_test(types(pasta_curves::pallas::Scalar), zdata(true))
+    serde_test(types(halo2curves::bn256::Fr), zdata(true))
 )]
 /// A `ZStore` is a content-addressed, serializable representation of a Lurk store
 ///


### PR DESCRIPTION
Partially fixes https://github.com/lurk-lab/lurk-rs/issues/1018

I think PR is finally ready for review. 

`LurkField` is changed to Bn256 in the majority of the unit-tests where it could be potentially useful for solidity-verifier to produce the test-vectors, so the field has not been changed in benches and examples - as they are more client-facing programs that somebody can already rely on, so this left for a future PR(s).

Special thanks to @gabriel-barrett ! 