### PR TITLE
chore: Drop OpenCL, and refactor Cargo.toml for workspace use

### DIFF
--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -1,4 +1,4 @@
-# Runs the test suite on a self-hosted GPU machine with CUDA and OpenCL enabled
+# Runs the test suite on a self-hosted GPU machine with CUDA enabled
 name: GPU tests
 
 on:
@@ -67,38 +67,3 @@ jobs:
           EC_GPU_FRAMEWORK: cuda
         run: |
           cargo nextest run --profile ci --cargo-profile dev-ci --features cuda
-
-  opencl:
-    name: Rust tests on OpenCL
-    if: github.event_name != 'pull_request' || github.event.action == 'enqueued'
-    runs-on: [self-hosted, gpu-ci]
-    env:
-      NVIDIA_VISIBLE_DEVICES: all
-      NVIDIA_DRIVER_CAPABILITITES: compute,utility
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@nextest
-      - uses: Swatinem/rust-cache@v2
-      # Check we have access to the machine's Nvidia drivers
-      - run: nvidia-smi
-      # The `compute`/`sm` number corresponds to the Nvidia GPU architecture
-      # In this case, the self-hosted machine uses the Ampere architecture, but we want this to be configurable
-      # See https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
-      - name: Set env for CUDA compute
-        run: echo "CUDA_ARCH=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader | sed 's/\.//g')" >> $GITHUB_ENV
-      - name: set env for EC_GPU
-        run: echo 'EC_GPU_CUDA_NVCC_ARGS=--fatbin --gpu-architecture=sm_${{ env.CUDA_ARCH }} --generate-code=arch=compute_${{ env.CUDA_ARCH }},code=sm_${{ env.CUDA_ARCH }}' >> $GITHUB_ENV
-      - run: echo "${{ env.EC_GPU_CUDA_NVCC_ARGS}}"
-      # Check that CUDA is installed with a driver-compatible version
-      # This must also be compatible with the GPU architecture, see above link
-      - run: nvcc --version
-      # Check that we can access the OpenCL headers
-      - run: clinfo
-      - name: OpenCL tests
-        env:
-          EC_GPU_FRAMEWORK: opencl
-        run: |
-          cargo nextest run --profile ci --cargo-profile dev-ci --features cuda,opencl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 authors.workspace = true
 homepage.workspace = true
 license.workspace = true
-rust-version.workspace = true
+rust-version = "1.72" # allows msrv verify to work in CI
 
 [dependencies]
 ahash = "0.8.6"
@@ -151,7 +151,7 @@ edition = "2021"
 homepage = "https://lurk-lang.org/"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/lurk-lab/lurk-rs"
-rust-version = "1.71.1"
+rust-version = "1.72"
 
 [[bin]]
 name = "lurk"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "lurk"
 version = "0.3.1"
-authors = ["Lurk Lab Engineering <engineering@lurk-lab.com>"]
-license = "MIT OR Apache-2.0"
 description = "Turing-Complete Zero Knowledge"
-edition = "2021"
-repository = "https://github.com/lurk-lab/lurk-rs"
-rust-version = "1.71.1"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+edition.workspace = true
+repository.workspace = true
+authors.workspace = true
+homepage.workspace = true
+license.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 ahash = "0.8.6"
@@ -74,7 +74,6 @@ halo2curves = { version = "0.6.0", features = ["bits", "derive_serde"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 memmap = { version = "0.5.10", package = "memmap2" }
-pasta-msm = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 rand = "0.8.5"
@@ -87,14 +86,6 @@ home = "0.5.5"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
 rustyline = { version = "13.0", features = ["derive"], default-features = false }
-
-[features]
-default = []
-opencl = ["neptune/opencl", "nova/opencl"]
-cuda = ["neptune/cuda", "nova/cuda"]
-# compile without ISA extensions
-portable = ["pasta-msm/portable", "nova/portable"]
-flamegraph = ["pprof/flamegraph", "pprof/criterion"]
 
 [dev-dependencies]
 assert_cmd = "2.0.12"
@@ -112,6 +103,13 @@ tracing-test = "0.2"
 
 [build-dependencies]
 vergen = { version = "8", features = ["build", "git", "gitcl"] }
+
+[features]
+default = []
+cuda = ["neptune/cuda", "nova/cuda"]
+# compile without ISA extensions
+portable = ["nova/portable"]
+flamegraph = ["pprof/flamegraph", "pprof/criterion"]
 
 [workspace]
 resolver = "2"
@@ -133,8 +131,6 @@ nova = { git = "https://github.com/lurk-lab/arecibo", branch = "dev", package = 
 once_cell = "1.18.0"
 pairing = { version = "0.23" }
 pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch = "dev" }
-pasta-msm = { git = "https://github.com/lurk-lab/pasta-msm", branch = "dev" }
-grumpkin-msm = { git = "https://github.com/lurk-lab/grumpkin-msm", branch = "dev" }
 proptest = "1.2.0"
 proptest-derive = "0.3"
 rand = "0.8"
@@ -146,6 +142,16 @@ thiserror = "1.0.44"
 tracing = "0.1.37"
 tracing-texray = "0.2.0"
 tracing-subscriber = "0.3.17"
+
+# All workspace members should inherit these keys
+# for package declarations.
+[workspace.package]
+authors = ["Lurk Lab Engineering <engineering@lurk-lab.com>"]
+edition = "2021"
+homepage = "https://lurk-lang.org/"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/lurk-lab/lurk-rs"
+rust-version = "1.71.1"
 
 [[bin]]
 name = "lurk"

--- a/lurk-macros/Cargo.toml
+++ b/lurk-macros/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "lurk-macros"
 version = "0.2.0"
-authors = ["porcuquine <porcuquine@gmail.com>"]
-license = "MIT OR Apache-2.0"
 description = "Custom derives for `lurk`"
-edition = "2021"
-repository = "https://github.com/lurk-lab/lurk-rs"
+edition.workspace = true
+repository.workspace = true
+authors.workspace = true
+homepage.workspace = true
+license.workspace = true
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/lurk-macros/src/lib.rs
+++ b/lurk-macros/src/lib.rs
@@ -11,7 +11,6 @@
 //!
 //! Although severely limited in the expressions it can represent, and still lacking quasiquoting,
 //! the `lurk` macro allows embedding Lurk code in Rust source. See tests for examples.
-
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::{quote, ToTokens};

--- a/lurk-metrics/Cargo.toml
+++ b/lurk-metrics/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "lurk-metrics"
-authors = ["Lurk Lab <engineering@lurk-lab.com>"]
 version = "0.2.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
 description = "Metrics Sink for lurk"
-repository = "https://github.com/lurk-lab/lurk-rs"
+edition.workspace = true
+repository.workspace = true
+authors.workspace = true
+homepage.workspace = true
+license.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 metrics = { workspace = true }


### PR DESCRIPTION
- Refined GitHub GPU CI workflow by removing OpenCL Rust tests and enabling only CUDA tests
- Revamped package settings to workspace level across the GitHub repository, implemented in `lurk-macros`, `lurk-metrics` and `Cargo.toml`
- Removed specific dependencies `pasta-msm` and `grumpkin-msm` from `Cargo.toml`,
- Reordered the features in `Cargo.toml`, removed `opencl` and some deps off `portable` for better maintainability
- Cleaned up minor formatting issue in 'lurk-macros/src/lib.rs'