### PR TITLE
Accumulate insertions in HashMap to avoid sort.

### DIFF
--- a/src/coroutine/memoset/demo.rs
+++ b/src/coroutine/memoset/demo.rs
@@ -203,22 +203,20 @@ impl<F: LurkField> CircuitQuery<F> for DemoCircuitQuery<F> {
         }
     }
 
-    fn from_ptr<CS: ConstraintSystem<F>>(
-        cs: &mut CS,
-        s: &Store<F>,
-        ptr: &Ptr,
-    ) -> Result<Option<Self>, SynthesisError> {
+    fn from_ptr<CS: ConstraintSystem<F>>(cs: &mut CS, s: &Store<F>, ptr: &Ptr) -> Option<Self> {
         let query = DemoQuery::from_ptr(s, ptr);
-        Ok(if let Some(q) = query {
+        if let Some(q) = query {
             match q {
-                DemoQuery::Factorial(n) => Some(Self::Factorial(AllocatedPtr::alloc(cs, || {
-                    Ok(s.hash_ptr(&n))
-                })?)),
+                DemoQuery::Factorial(n) => {
+                    Some(Self::Factorial(AllocatedPtr::alloc_infallible(cs, || {
+                        s.hash_ptr(&n)
+                    })))
+                }
                 _ => unreachable!(),
             }
         } else {
             None
-        })
+        }
     }
 
     fn symbol(&self) -> Symbol {

--- a/src/coroutine/memoset/demo.rs
+++ b/src/coroutine/memoset/demo.rs
@@ -94,6 +94,10 @@ impl<F: LurkField> Query<F> for DemoQuery<F> {
             _ => unreachable!(),
         }
     }
+
+    fn count() -> usize {
+        1
+    }
 }
 
 impl<F: LurkField> CircuitQuery<F> for DemoCircuitQuery<F> {

--- a/src/coroutine/memoset/mod.rs
+++ b/src/coroutine/memoset/mod.rs
@@ -277,13 +277,12 @@ impl<F: LurkField, Q: Query<F>> Scope<Q, LogMemo<F>> {
         let mut insert = |kv: Ptr| {
             let key = s.car_cdr(&kv).unwrap().0;
 
-            if insertions.get(&key).is_none() {
-                unique_keys.push(key);
-                insertions.insert(key, vec![kv]);
-            } else {
-                insertions
-                    .entry(key)
-                    .and_modify(|kvs: &mut Vec<Ptr>| kvs.push(kv));
+            match insertions.get_mut(&key) {
+                Some(kvs) => kvs.push(kv),
+                None => {
+                    unique_keys.push(key);
+                    insertions.insert(key, vec![kv]);
+                }
             }
         };
 

--- a/src/coroutine/memoset/mod.rs
+++ b/src/coroutine/memoset/mod.rs
@@ -191,7 +191,7 @@ pub struct Scope<Q, M> {
     /// internally-inserted keys
     internal_insertions: Vec<Ptr>,
     /// unique keys
-    all_insertions: Vec<Ptr>,
+    unique_inserted_keys: Vec<Ptr>,
 }
 
 impl<F: LurkField, Q> Default for Scope<Q, LogMemo<F>> {
@@ -202,7 +202,7 @@ impl<F: LurkField, Q> Default for Scope<Q, LogMemo<F>> {
             dependencies: Default::default(),
             toplevel_insertions: Default::default(),
             internal_insertions: Default::default(),
-            all_insertions: Default::default(),
+            unique_inserted_keys: Default::default(),
         }
     }
 }
@@ -258,7 +258,7 @@ impl<F: LurkField, Q: Query<F>> Scope<Q, LogMemo<F>> {
     fn finalize_transcript(&mut self, s: &Store<F>) -> Transcript<F> {
         let (transcript, insertions) = self.build_transcript(s);
         self.memoset.finalize_transcript(s, transcript.clone());
-        self.all_insertions = insertions;
+        self.unique_inserted_keys = insertions;
         transcript
     }
 
@@ -556,9 +556,31 @@ impl<F: LurkField> CircuitScope<F, LogMemo<F>> {
         g: &mut GlobalAllocator<F>,
         s: &Store<F>,
     ) -> Result<(), SynthesisError> {
-        for (i, kv) in scope.all_insertions.iter().enumerate() {
-            self.synthesize_prove_query::<_, Q::CQ>(cs, g, s, i, kv)?;
+        for (i, key) in scope.unique_inserted_keys.iter().enumerate() {
+            let cs = &mut cs.namespace(|| format!("internal-{i}"));
+
+            let _ = self.synthesize_prove_key_query::<_, Q>(cs, g, s, key)?;
         }
+        Ok(())
+    }
+
+    fn synthesize_prove_key_query<CS: ConstraintSystem<F>, Q: Query<F>>(
+        &mut self,
+        cs: &mut CS,
+        g: &mut GlobalAllocator<F>,
+        s: &Store<F>,
+        key: &Ptr,
+    ) -> Result<(), SynthesisError> {
+        let allocated_key =
+            AllocatedPtr::alloc(
+                &mut cs.namespace(|| "allocated_key"),
+                || Ok(s.hash_ptr(key)),
+            )
+            .unwrap();
+
+        let circuit_query = Q::CQ::from_ptr(&mut cs.namespace(|| "circuit_query"), s, key).unwrap();
+
+        self.synthesize_prove_query::<_, Q::CQ>(cs, g, s, allocated_key, circuit_query)?;
         Ok(())
     }
 
@@ -567,25 +589,13 @@ impl<F: LurkField> CircuitScope<F, LogMemo<F>> {
         cs: &mut CS,
         g: &mut GlobalAllocator<F>,
         s: &Store<F>,
-        i: usize,
-        key: &Ptr,
+        allocated_key: AllocatedPtr<F>,
+        circuit_query: CQ,
     ) -> Result<(), SynthesisError> {
-        let cs = &mut cs.namespace(|| format!("internal-{i}"));
-
-        let allocated_key =
-            AllocatedPtr::alloc(
-                &mut cs.namespace(|| "allocated_key"),
-                || Ok(s.hash_ptr(key)),
-            )
-            .unwrap();
-
-        let circuit_query = CQ::from_ptr(&mut cs.namespace(|| "circuit_query"), s, key).unwrap();
-
         let acc = self.acc.clone().unwrap();
         let transcript = self.transcript.clone();
 
         let (val, new_acc, new_transcript) = circuit_query
-            .expect("not a query form")
             .synthesize_eval(&mut cs.namespace(|| "eval"), g, s, self, &acc, &transcript)
             .unwrap();
 

--- a/src/coroutine/memoset/mod.rs
+++ b/src/coroutine/memoset/mod.rs
@@ -615,7 +615,7 @@ impl<F: LurkField> CircuitScope<F, LogMemo<F>> {
             .unwrap();
 
         let (new_acc, new_transcript) =
-            self.synthesize_remove(cs, g, s, &new_acc, &new_transcript, &allocated_key, &val)?;
+            self.synthesize_remove(cs, g, s, &new_acc, &new_transcript, allocated_key, &val)?;
 
         self.acc = Some(new_acc);
         self.transcript = new_transcript;

--- a/src/coroutine/memoset/mod.rs
+++ b/src/coroutine/memoset/mod.rs
@@ -277,12 +277,11 @@ impl<F: LurkField, Q: Query<F>> Scope<Q, LogMemo<F>> {
         let mut insert = |kv: Ptr| {
             let key = s.car_cdr(&kv).unwrap().0;
 
-            match insertions.get_mut(&key) {
-                Some(kvs) => kvs.push(kv),
-                None => {
-                    unique_keys.push(key);
-                    insertions.insert(key, vec![kv]);
-                }
+            if let Some(kvs) = insertions.get_mut(&key) {
+                kvs.push(kv)
+            } else {
+                unique_keys.push(key);
+                insertions.insert(key, vec![kv]);
             }
         };
 

--- a/src/coroutine/memoset/query.rs
+++ b/src/coroutine/memoset/query.rs
@@ -50,9 +50,5 @@ where
         s.intern_symbol(&self.symbol())
     }
 
-    fn from_ptr<CS: ConstraintSystem<F>>(
-        cs: &mut CS,
-        s: &Store<F>,
-        ptr: &Ptr,
-    ) -> Result<Option<Self>, SynthesisError>;
+    fn from_ptr<CS: ConstraintSystem<F>>(cs: &mut CS, s: &Store<F>, ptr: &Ptr) -> Option<Self>;
 }

--- a/src/coroutine/memoset/query.rs
+++ b/src/coroutine/memoset/query.rs
@@ -27,7 +27,10 @@ where
         s.intern_symbol(&self.symbol())
     }
 
+    /// What is this queries index? Used for ordering circuits and transcripts, grouped by query type.
     fn index(&self) -> usize;
+    /// How many types of query are provided?
+    fn count() -> usize;
 }
 
 pub trait CircuitQuery<F: LurkField>


### PR DESCRIPTION
As noted in a comment to #1004 (https://github.com/lurk-lab/lurk-rs/pull/1004#discussion_r1452834234), we can avoid the `sort` by accumulating insertions in a `HashMap`. This PR does that.

UPDATE: As I noted in a comment, there is still some sorting, just 'less' — sorry for any confusion.
UPDATE 2: Last sorting has been removed.

Base branch is currently #1048, but the intention is to only merge after that one. Hopefully GH will correctly update base branch of this PR then.