### PR TITLE
refactor: Improve memory  efficiency in Nova's PP abomonation 

### DIFF
--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -107,7 +107,7 @@ pub type NovaCircuitShape<F> = R1CSWithArity<E1<F>>;
 pub type NovaPublicParams<F, C1> = nova::PublicParams<E1<F>, E2<F>, C1, C2<F>>;
 
 /// A struct that contains public parameters for the Nova proving system.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct PublicParams<F, SC: StepCircuit<F>>
 where

--- a/src/public_parameters/mod.rs
+++ b/src/public_parameters/mod.rs
@@ -18,9 +18,9 @@ use crate::public_parameters::error::Error;
 use self::disk_cache::DiskCache;
 use self::instance::Instance;
 
-pub fn public_params<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'static>(
+pub fn public_params<F: CurveCycleEquipped, C: Coprocessor<F> + 'static>(
     instance: &Instance<'static, F, C>,
-) -> Result<Arc<PublicParams<F, C1LEM<'a, F, C>>>, Error>
+) -> Result<Arc<PublicParams<F, C1LEM<'static, F, C>>>, Error>
 where
     <<E1<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,


### PR DESCRIPTION
- Removed the `Clone` trait from `PublicParams` struct in `nova.
- Enhanced doc for memory safety in `PublicParamMemCache` in `mem_cache.rs`
- Replaced cloning commands with transmutation, resulting in improved memory utilization.

Blocks https://github.com/lurk-lab/arecibo/pull/268