### PR TITLE
Make internal insertion transcript optional with config.

### DIFF
--- a/src/coroutine/memoset/demo.rs
+++ b/src/coroutine/memoset/demo.rs
@@ -157,7 +157,7 @@ impl<F: LurkField> CircuitQuery<F> for DemoCircuitQuery<F> {
                         )?
                     };
 
-                    let (sub_result, new_acc, new_transcript) = scope.synthesize_query(
+                    let (sub_result, new_acc, new_transcript) = scope.synthesize_internal_query(
                         &mut cs.namespace(|| "recursive query"),
                         g,
                         store,


### PR DESCRIPTION
This PR makes whether or not to add internal insertions to the transcript configurable. Until we determine that it is definitely safe to omit, we should preserve the ability not to. You can see the performance impact on the test examples below.

```
    fn test_query_with_internal_insertion_transcript() {
        test_query_aux(
            true,
            expect!["10826"],
            expect!["10859"],
            expect!["11408"],
            expect!["11445"],
        )
    }

    #[test]
    fn test_query_without_internal_insertion_transcript() {
        test_query_aux(
            false,
            expect!["9381"],
            expect!["9414"],
            expect!["9963"],
            expect!["10000"],
        )
    }
```