### PR TITLE
Generic `Prover`

### DIFF
--- a/benches/end2end.rs
+++ b/benches/end2end.rs
@@ -12,7 +12,7 @@ use lurk::{
         pointers::Ptr,
         store::Store,
     },
-    proof::{nova::NovaProver, Prover, RecursiveSNARKTrait},
+    proof::{nova::NovaProver, RecursiveSNARKTrait},
     public_parameters::{
         self,
         instance::{Instance, Kind},
@@ -84,7 +84,7 @@ fn end2end_benchmark(c: &mut Criterion) {
         b.iter(|| {
             let ptr = go_base::<Fq>(&store, state.clone(), s.0, s.1);
             let frames = evaluate::<Fq, Coproc<Fq>>(None, ptr, &store, limit).unwrap();
-            let _result = prover.prove(&pp, &frames, &store).unwrap();
+            let _result = prover.prove_from_frames(&pp, &frames, &store).unwrap();
         })
     });
 
@@ -253,7 +253,7 @@ fn prove_benchmark(c: &mut Criterion) {
         let frames = evaluate::<Fq, Coproc<Fq>>(None, ptr, &store, limit).unwrap();
 
         b.iter(|| {
-            let result = prover.prove(&pp, &frames, &store).unwrap();
+            let result = prover.prove_from_frames(&pp, &frames, &store).unwrap();
             black_box(result);
         })
     });
@@ -300,7 +300,7 @@ fn prove_compressed_benchmark(c: &mut Criterion) {
         let frames = evaluate::<Fq, Coproc<Fq>>(None, ptr, &store, limit).unwrap();
 
         b.iter(|| {
-            let (proof, _, _, _) = prover.prove(&pp, &frames, &store).unwrap();
+            let (proof, _, _, _) = prover.prove_from_frames(&pp, &frames, &store).unwrap();
 
             let compressed_result = proof.compress(&pp).unwrap();
             black_box(compressed_result);
@@ -344,7 +344,8 @@ fn verify_benchmark(c: &mut Criterion) {
             let ptr = go_base(&store, state.clone(), s.0, s.1);
             let prover = NovaProver::new(reduction_count, lang_pallas_rc.clone());
             let frames = evaluate::<Fq, Coproc<Fq>>(None, ptr, &store, limit).unwrap();
-            let (proof, z0, zi, _num_steps) = prover.prove(&pp, &frames, &store).unwrap();
+            let (proof, z0, zi, _num_steps) =
+                prover.prove_from_frames(&pp, &frames, &store).unwrap();
 
             b.iter_batched(
                 || z0.clone(),
@@ -396,7 +397,8 @@ fn verify_compressed_benchmark(c: &mut Criterion) {
             let ptr = go_base(&store, state.clone(), s.0, s.1);
             let prover = NovaProver::new(reduction_count, lang_pallas_rc.clone());
             let frames = evaluate::<Fq, Coproc<Fq>>(None, ptr, &store, limit).unwrap();
-            let (proof, z0, zi, _num_steps) = prover.prove(&pp, &frames, &store).unwrap();
+            let (proof, z0, zi, _num_steps) =
+                prover.prove_from_frames(&pp, &frames, &store).unwrap();
 
             let compressed_proof = proof.compress(&pp).unwrap();
 

--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -10,7 +10,6 @@ use lurk::{
     eval::lang::{Coproc, Lang},
     lem::{eval::evaluate, store::Store},
     proof::nova::NovaProver,
-    proof::Prover,
     public_parameters::{
         instance::{Instance, Kind},
         public_params,
@@ -116,7 +115,7 @@ fn fibonacci_prove<M: measurement::Measurement>(
             b.iter_batched(
                 || frames,
                 |frames| {
-                    let result = prover.prove(&pp, frames, &store);
+                    let result = prover.prove_from_frames(&pp, frames, &store);
                     let _ = black_box(result);
                 },
                 BatchSize::LargeInput,

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -22,7 +22,7 @@ use lurk::{
         pointers::Ptr,
         store::Store,
     },
-    proof::{nova::NovaProver, supernova::SuperNovaProver, Prover, RecursiveSNARKTrait},
+    proof::{nova::NovaProver, supernova::SuperNovaProver, RecursiveSNARKTrait},
     public_parameters::{
         instance::{Instance, Kind},
         public_params, supernova_public_params,
@@ -138,7 +138,7 @@ fn sha256_ivc_prove<M: measurement::Measurement>(
             b.iter_batched(
                 || frames,
                 |frames| {
-                    let result = prover.prove(&pp, frames, store);
+                    let result = prover.prove_from_frames(&pp, frames, store);
                     let _ = black_box(result);
                 },
                 BatchSize::LargeInput,
@@ -219,7 +219,7 @@ fn sha256_ivc_prove_compressed<M: measurement::Measurement>(
             b.iter_batched(
                 || frames,
                 |frames| {
-                    let (proof, _, _, _) = prover.prove(&pp, frames, store).unwrap();
+                    let (proof, _, _, _) = prover.prove_from_frames(&pp, frames, store).unwrap();
                     let compressed_result = proof.compress(&pp).unwrap();
 
                     let _ = black_box(compressed_result);
@@ -303,7 +303,7 @@ fn sha256_nivc_prove<M: measurement::Measurement>(
             b.iter_batched(
                 || frames,
                 |frames| {
-                    let result = prover.prove(&pp, frames, store);
+                    let result = prover.prove_from_frames(&pp, frames, store);
                     let _ = black_box(result);
                 },
                 BatchSize::LargeInput,

--- a/examples/sha256_nivc.rs
+++ b/examples/sha256_nivc.rs
@@ -12,7 +12,7 @@ use lurk::{
         pointers::Ptr,
         store::Store,
     },
-    proof::{supernova::SuperNovaProver, Prover, RecursiveSNARKTrait},
+    proof::{supernova::SuperNovaProver, RecursiveSNARKTrait},
     public_parameters::{
         instance::{Instance, Kind},
         supernova_public_params,
@@ -94,7 +94,11 @@ fn main() {
     println!("Beginning proof step...");
     let proof_start = Instant::now();
     let (proof, z0, zi, _num_steps) = tracing_texray::examine(tracing::info_span!("bang!"))
-        .in_scope(|| supernova_prover.prove(&pp, &frames, store).unwrap());
+        .in_scope(|| {
+            supernova_prover
+                .prove_from_frames(&pp, &frames, store)
+                .unwrap()
+        });
     let proof_end = proof_start.elapsed();
 
     println!("Proofs took {:?}", proof_end);

--- a/examples/tp_table.rs
+++ b/examples/tp_table.rs
@@ -4,10 +4,7 @@ use criterion::black_box;
 use lurk::{
     eval::lang::{Coproc, Lang},
     lem::{eval::evaluate, multiframe::MultiFrame, store::Store},
-    proof::{
-        nova::{public_params, NovaProver, PublicParams},
-        Prover,
-    },
+    proof::nova::{public_params, NovaProver, PublicParams},
 };
 use num_traits::ToPrimitive;
 use pasta_curves::pallas::Scalar as Fr;
@@ -179,7 +176,7 @@ fn main() {
                 let mut timings = Vec::with_capacity(n_samples);
                 for _ in 0..n_samples {
                     let start = Instant::now();
-                    let result = prover.prove(&pp, frames, &store);
+                    let result = prover.prove_from_frames(&pp, frames, &store);
                     let _ = black_box(result);
                     let end = start.elapsed().as_secs_f64();
                     timings.push(end);

--- a/src/cli/lurk_proof.rs
+++ b/src/cli/lurk_proof.rs
@@ -10,7 +10,7 @@ use crate::{
     field::LurkField,
     lem::{pointers::ZPtr, store::Store},
     proof::{
-        nova::{self, CurveCycleEquipped, E1, E2},
+        nova::{self, CurveCycleEquipped, C1LEM, E1, E2},
         RecursiveSNARKTrait,
     },
     public_parameters::{
@@ -131,7 +131,7 @@ pub(crate) enum LurkProof<
     <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     Nova {
-        proof: nova::Proof<'a, F, C>,
+        proof: nova::Proof<F, C1LEM<'a, F, C>>,
         public_inputs: Vec<F>,
         public_outputs: Vec<F>,
         rc: usize,

--- a/src/cli/repl/meta_cmd.rs
+++ b/src/cli/repl/meta_cmd.rs
@@ -23,7 +23,7 @@ use crate::{
     },
     package::{Package, SymbolRef},
     proof::{
-        nova::{self, CurveCycleEquipped, E1, E2},
+        nova::{self, CurveCycleEquipped, C1LEM, E1, E2},
         RecursiveSNARKTrait,
     },
     public_parameters::{
@@ -1104,7 +1104,7 @@ where
 {
     Nova {
         args: LurkData<F>,
-        proof: nova::Proof<'a, F, C>,
+        proof: nova::Proof<F, C1LEM<'a, F, C>>,
     },
 }
 

--- a/src/cli/repl/mod.rs
+++ b/src/cli/repl/mod.rs
@@ -41,7 +41,7 @@ use crate::{
     parser,
     proof::{
         nova::{CurveCycleEquipped, NovaProver},
-        Prover, RecursiveSNARKTrait,
+        RecursiveSNARKTrait,
     },
     public_parameters::{
         instance::{Instance, Kind},
@@ -342,7 +342,7 @@ where
 
                     info!("Proving");
                     let (proof, public_inputs, public_outputs, num_steps) =
-                        prover.prove(&pp, frames, &self.store)?;
+                        prover.prove_from_frames(&pp, frames, &self.store)?;
                     info!("Compressing proof");
                     let proof = proof.compress(&pp)?;
                     assert_eq!(self.rc * num_steps, pad(n_frames, self.rc));

--- a/src/lem/multiframe.rs
+++ b/src/lem/multiframe.rs
@@ -76,6 +76,11 @@ impl<'a, F: LurkField, C: Coprocessor<F>> MultiFrame<'a, F, C> {
     }
 
     #[inline]
+    pub fn input(&self) -> &Option<Vec<Ptr>> {
+        &self.input
+    }
+
+    #[inline]
     pub fn output(&self) -> &Option<Vec<Ptr>> {
         &self.output
     }

--- a/src/lem/multiframe.rs
+++ b/src/lem/multiframe.rs
@@ -75,16 +75,6 @@ impl<'a, F: LurkField, C: Coprocessor<F>> MultiFrame<'a, F, C> {
         self.frames.as_ref()
     }
 
-    #[inline]
-    pub fn input(&self) -> &Option<Vec<Ptr>> {
-        &self.input
-    }
-
-    #[inline]
-    pub fn output(&self) -> &Option<Vec<Ptr>> {
-        &self.output
-    }
-
     pub fn emitted(_store: &Store<F>, eval_frame: &Frame) -> Vec<Ptr> {
         eval_frame.emitted.clone()
     }
@@ -387,6 +377,19 @@ impl CEKState<Ptr> for Vec<Ptr> {
     }
     fn cont(&self) -> &Ptr {
         &self[2]
+    }
+}
+
+impl<'a, F: LurkField, C: Coprocessor<F>> FrameLike<Ptr> for MultiFrame<'a, F, C> {
+    type FrameIO = Vec<Ptr>;
+    #[inline]
+    fn input(&self) -> &Vec<Ptr> {
+        self.input.as_ref().unwrap()
+    }
+
+    #[inline]
+    fn output(&self) -> &Vec<Ptr> {
+        self.output.as_ref().unwrap()
     }
 }
 

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -104,8 +104,6 @@ where
         z0: &[F],
         steps: Vec<C1LEM<'a, F, C>>,
         store: &'a Store<F>,
-        reduction_count: usize,
-        lang: Arc<Lang<F, C>>,
     ) -> Result<Self, ProofError>;
 
     /// Compress a proof
@@ -190,14 +188,7 @@ pub trait Prover<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a> {
         let steps = C1LEM::<'a, F, C>::from_frames(frames, store, &folding_config.into());
         let num_steps = steps.len();
 
-        let prove_output = Self::RecursiveSnark::prove_recursively(
-            pp,
-            &z0,
-            steps,
-            store,
-            self.reduction_count(),
-            lang,
-        )?;
+        let prove_output = Self::RecursiveSnark::prove_recursively(pp, &z0, steps, store)?;
 
         Ok((prove_output, z0, zi, num_steps))
     }

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -174,10 +174,8 @@ pub trait Prover<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a> {
         store: &'a Store<F>,
     ) -> Result<(Self::RecursiveSnark, Vec<F>, Vec<F>, usize), ProofError> {
         store.hydrate_z_cache();
-        let input = steps[0].input().as_ref().unwrap();
-        let z0 = store.to_scalar_vector(input);
-        let output = steps.last().unwrap().output().as_ref().unwrap();
-        let zi = store.to_scalar_vector(output);
+        let z0 = store.to_scalar_vector(steps[0].input());
+        let zi = store.to_scalar_vector(steps.last().unwrap().output());
 
         let num_steps = steps.len();
 

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -88,7 +88,7 @@ pub trait Provable<F: LurkField> {
 // * `Prover`, which abstracts over Nova and SuperNova provers
 
 /// Trait to abstract Nova and SuperNova proofs
-pub trait RecursiveSNARKTrait<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a>
+pub trait RecursiveSNARKTrait<'a, F: CurveCycleEquipped, M>
 where
     Self: Sized,
 {
@@ -102,7 +102,7 @@ where
     fn prove_recursively(
         pp: &Self::PublicParams,
         z0: &[F],
-        steps: Vec<C1LEM<'a, F, C>>,
+        steps: Vec<M>,
         store: &'a Store<F>,
     ) -> Result<Self, ProofError>;
 
@@ -158,7 +158,12 @@ pub trait Prover<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a> {
     type PublicParams;
 
     /// Assiciated proof type, which must implement `RecursiveSNARKTrait`
-    type RecursiveSnark: RecursiveSNARKTrait<'a, F, C, PublicParams = Self::PublicParams>;
+    type RecursiveSnark: RecursiveSNARKTrait<
+        'a,
+        F,
+        C1LEM<'a, F, C>,
+        PublicParams = Self::PublicParams,
+    >;
 
     /// Returns a reference to the prover's FoldingMode
     fn folding_mode(&self) -> &FoldingMode;

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -88,7 +88,7 @@ pub trait Provable<F: LurkField> {
 // * `Prover`, which abstracts over Nova and SuperNova provers
 
 /// Trait to abstract Nova and SuperNova proofs
-pub trait RecursiveSNARKTrait<'a, F: CurveCycleEquipped, M>
+pub trait RecursiveSNARKTrait<F: CurveCycleEquipped, M>
 where
     Self: Sized,
 {
@@ -103,7 +103,7 @@ where
         pp: &Self::PublicParams,
         z0: &[F],
         steps: Vec<M>,
-        store: &'a Store<F>,
+        store: &Store<F>,
     ) -> Result<Self, ProofError>;
 
     /// Compress a proof
@@ -158,12 +158,7 @@ pub trait Prover<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a> {
     type PublicParams;
 
     /// Assiciated proof type, which must implement `RecursiveSNARKTrait`
-    type RecursiveSnark: RecursiveSNARKTrait<
-        'a,
-        F,
-        C1LEM<'a, F, C>,
-        PublicParams = Self::PublicParams,
-    >;
+    type RecursiveSnark: RecursiveSNARKTrait<F, C1LEM<'a, F, C>, PublicParams = Self::PublicParams>;
 
     /// Returns a reference to the prover's FoldingMode
     fn folding_mode(&self) -> &FoldingMode;

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -27,10 +27,7 @@ use crate::{
     proof::nova::E2,
 };
 
-use self::{
-    nova::{CurveCycleEquipped, C1LEM},
-    supernova::FoldingConfig,
-};
+use self::{nova::CurveCycleEquipped, supernova::FoldingConfig};
 
 /// The State of a CEK machine.
 pub trait CEKState<Ptr> {
@@ -153,12 +150,12 @@ impl FoldingMode {
 }
 
 /// A trait for a prover that works with a field `F`.
-pub trait Prover<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a> {
+pub trait Prover<'a, F: CurveCycleEquipped, M: FrameLike<Ptr, FrameIO = Vec<Ptr>>> {
     /// Associated type for public parameters
     type PublicParams;
 
     /// Assiciated proof type, which must implement `RecursiveSNARKTrait`
-    type RecursiveSnark: RecursiveSNARKTrait<F, C1LEM<'a, F, C>, PublicParams = Self::PublicParams>;
+    type RecursiveSnark: RecursiveSNARKTrait<F, M, PublicParams = Self::PublicParams>;
 
     /// Returns a reference to the prover's FoldingMode
     fn folding_mode(&self) -> &FoldingMode;
@@ -170,7 +167,7 @@ pub trait Prover<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a> {
     fn prove(
         &self,
         pp: &Self::PublicParams,
-        steps: Vec<C1LEM<'a, F, C>>,
+        steps: Vec<M>,
         store: &'a Store<F>,
     ) -> Result<(Self::RecursiveSnark, Vec<F>, Vec<F>, usize), ProofError> {
         store.hydrate_z_cache();

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -223,7 +223,8 @@ pub fn circuits<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a>(
     )
 }
 
-impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<'a, F, C> for Proof<'a, F, C>
+impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<'a, F, C1LEM<'a, F, C>>
+    for Proof<'a, F, C>
 where
     <F as PrimeField>::Repr: Abomonation,
     <<<F as CurveCycleEquipped>::E2 as Engine>::Scalar as PrimeField>::Repr: Abomonation,

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -26,7 +26,7 @@ use crate::{
     error::ProofError,
     eval::lang::Lang,
     field::LurkField,
-    lem::store::Store,
+    lem::{interpreter::Frame, pointers::Ptr, store::Store},
     proof::{supernova::FoldingConfig, FrameLike, Prover},
 };
 
@@ -388,7 +388,11 @@ pub struct NovaProver<'a, F: CurveCycleEquipped, C: Coprocessor<F>> {
     _phantom: PhantomData<&'a ()>,
 }
 
-impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> NovaProver<'a, F, C> {
+impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> NovaProver<'a, F, C>
+where
+    <<E1<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
+    <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
+{
     /// Create a new NovaProver with a reduction count and a `Lang`
     #[inline]
     pub fn new(reduction_count: usize, lang: Arc<Lang<F, C>>) -> Self {
@@ -398,6 +402,25 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> NovaProver<'a, F, C> {
             folding_mode: FoldingMode::IVC,
             _phantom: PhantomData,
         }
+    }
+
+    /// Generate a proof from a sequence of frames
+    pub fn prove_from_frames(
+        &self,
+        pp: &PublicParams<F, C1LEM<'a, F, C>>,
+        frames: &[Frame],
+        store: &'a Store<F>,
+    ) -> Result<(Proof<'a, F, C>, Vec<F>, Vec<F>, usize), ProofError> {
+        let folding_config = self
+            .folding_mode()
+            .folding_config(self.lang().clone(), self.reduction_count());
+        let steps = C1LEM::<'a, F, C>::from_frames(frames, store, &folding_config.into());
+        self.prove(pp, steps, store)
+    }
+
+    #[inline]
+    fn lang(&self) -> &Arc<Lang<F, C>> {
+        &self.lang
     }
 }
 
@@ -415,12 +438,20 @@ where
     }
 
     #[inline]
-    fn lang(&self) -> &Arc<Lang<F, C>> {
-        &self.lang
-    }
-
-    #[inline]
     fn folding_mode(&self) -> &FoldingMode {
         &self.folding_mode
+    }
+
+    fn evaluate_and_prove(
+        &self,
+        pp: &Self::PublicParams,
+        expr: Ptr,
+        env: Ptr,
+        store: &'a Store<F>,
+        limit: usize,
+    ) -> Result<(Self::RecursiveSnark, Vec<F>, Vec<F>, usize), ProofError> {
+        let eval_config = self.folding_mode().eval_config(self.lang());
+        let frames = C1LEM::<'a, F, C>::build_frames(expr, env, store, limit, &eval_config)?;
+        self.prove_from_frames(pp, &frames, store)
     }
 }

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -424,7 +424,8 @@ where
     }
 }
 
-impl<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a> Prover<'a, F, C> for NovaProver<'a, F, C>
+impl<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a> Prover<'a, F, C1LEM<'a, F, C>>
+    for NovaProver<'a, F, C>
 where
     <<E1<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -223,7 +223,7 @@ pub fn circuits<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a>(
     )
 }
 
-impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<'a, F, C1LEM<'a, F, C>>
+impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<F, C1LEM<'a, F, C>>
     for Proof<'a, F, C>
 where
     <F as PrimeField>::Repr: Abomonation,
@@ -238,7 +238,7 @@ where
         pp: &PublicParams<F, C1LEM<'a, F, C>>,
         z0: &[F],
         steps: Vec<C1LEM<'a, F, C>>,
-        store: &'a Store<F>,
+        store: &Store<F>,
     ) -> Result<Self, ProofError> {
         assert!(!steps.is_empty());
         assert_eq!(steps[0].arity(), z0.len());

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -299,9 +299,7 @@ where
                     use bellpepper_core::test_cs::TestConstraintSystem;
                     let mut cs = TestConstraintSystem::<<E1<F> as Engine>::Scalar>::new();
 
-                    // This is a CircuitFrame, not an EvalFrame
-                    let first_frame = circuit_primary.frames().unwrap().iter().next().unwrap();
-                    let zi = store.to_scalar_vector(first_frame.input());
+                    let zi = store.to_scalar_vector(circuit_primary.input());
                     let zi_allocated: Vec<_> = zi
                         .iter()
                         .enumerate()

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -238,8 +238,6 @@ where
         z0: &[F],
         steps: Vec<C1LEM<'a, F, C>>,
         store: &'a Store<F>,
-        reduction_count: usize,
-        lang: Arc<Lang<F, C>>,
     ) -> Result<Self, ProofError> {
         assert!(!steps.is_empty());
         assert_eq!(steps[0].arity(), z0.len());
@@ -247,11 +245,7 @@ where
         let z0_primary = z0;
         let z0_secondary = Self::z0_secondary();
 
-        assert_eq!(steps[0].frames().unwrap().len(), reduction_count);
-        let (_circuit_primary, circuit_secondary): (
-            C1LEM<'a, F, C>,
-            TrivialCircuit<<E2<F> as Engine>::Scalar>,
-        ) = circuits(reduction_count, lang);
+        let circuit_secondary = TrivialCircuit::default();
 
         let num_steps = steps.len();
         tracing::debug!("steps.len: {num_steps}");
@@ -283,7 +277,6 @@ where
 
                 for circuit_primary in cc.iter() {
                     let circuit_primary = circuit_primary.lock().unwrap();
-                    assert_eq!(reduction_count, circuit_primary.frames().unwrap().len());
 
                     let mut r_snark = recursive_snark.unwrap_or_else(|| {
                         RecursiveSNARK::new(
@@ -305,7 +298,6 @@ where
             .unwrap()
         } else {
             for circuit_primary in steps.iter() {
-                assert_eq!(reduction_count, circuit_primary.frames().unwrap().len());
                 if debug {
                     // For debugging purposes, synthesize the circuit and check that the constraint system is satisfied.
                     use bellpepper_core::test_cs::TestConstraintSystem;

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -189,7 +189,7 @@ where
     }
 }
 
-impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<'a, F, C1LEM<'a, F, C>>
+impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<F, C1LEM<'a, F, C>>
     for Proof<'a, F, C>
 where
     <<E1<F> as Engine>::Scalar as PrimeField>::Repr: Abomonation,
@@ -204,7 +204,7 @@ where
         pp: &PublicParams<F, C1LEM<'a, F, C>>,
         z0: &[F],
         steps: Vec<C1LEM<'a, F, C>>,
-        store: &'a Store<F>,
+        store: &Store<F>,
     ) -> Result<Self, ProofError> {
         let mut recursive_snark_option: Option<RecursiveSNARK<E1<F>, E2<F>>> = None;
 

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -327,7 +327,8 @@ where
     }
 }
 
-impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> Prover<'a, F, C> for SuperNovaProver<'a, F, C>
+impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> Prover<'a, F, C1LEM<'a, F, C>>
+    for SuperNovaProver<'a, F, C>
 where
     <<E1<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -181,8 +181,6 @@ where
         z0: &[F],
         steps: Vec<C1LEM<'a, F, C>>,
         store: &'a Store<F>,
-        _reduction_count: usize,
-        _lang: Arc<Lang<F, C>>,
     ) -> Result<Self, ProofError> {
         let mut recursive_snark_option: Option<RecursiveSNARK<E1<F>, E2<F>>> = None;
 

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -166,7 +166,8 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a> SuperNovaProver<'a, F, C
     }
 }
 
-impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<'a, F, C> for Proof<'a, F, C>
+impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<'a, F, C1LEM<'a, F, C>>
+    for Proof<'a, F, C>
 where
     <<E1<F> as Engine>::Scalar as PrimeField>::Repr: Abomonation,
     <<E2<F> as Engine>::Scalar as PrimeField>::Repr: Abomonation,

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -128,7 +128,7 @@ where
 /// An enum representing the two types of proofs that can be generated and verified.
 #[derive(Serialize, Deserialize)]
 #[serde(bound = "")]
-pub enum Proof<'a, F: CurveCycleEquipped, C: Coprocessor<F>>
+pub enum Proof<F: CurveCycleEquipped, C1: SuperStepCircuit<F>>
 where
     <<E1<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
     <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
@@ -136,10 +136,7 @@ where
     /// A proof for the intermediate steps of a recursive computation
     Recursive(Box<RecursiveSNARK<E1<F>, E2<F>>>),
     /// A proof for the final step of a recursive computation
-    Compressed(
-        Box<CompressedSNARK<E1<F>, E2<F>, C1LEM<'a, F, C>, C2<F>, SS1<F>, SS2<F>>>,
-        PhantomData<&'a C>,
-    ),
+    Compressed(Box<CompressedSNARK<E1<F>, E2<F>, C1, C2<F>, SS1<F>, SS2<F>>>),
 }
 
 /// A struct for the Nova prover that operates on field elements of type `F`.
@@ -175,7 +172,7 @@ where
         pp: &PublicParams<F, C1LEM<'a, F, C>>,
         frames: &[Frame],
         store: &'a Store<F>,
-    ) -> Result<(Proof<'a, F, C>, Vec<F>, Vec<F>, usize), ProofError> {
+    ) -> Result<(Proof<F, C1LEM<'a, F, C>>, Vec<F>, Vec<F>, usize), ProofError> {
         let folding_config = self
             .folding_mode()
             .folding_config(self.lang().clone(), self.reduction_count());
@@ -190,7 +187,7 @@ where
 }
 
 impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<F, C1LEM<'a, F, C>>
-    for Proof<'a, F, C>
+    for Proof<F, C1LEM<'a, F, C>>
 where
     <<E1<F> as Engine>::Scalar as PrimeField>::Repr: Abomonation,
     <<E2<F> as Engine>::Scalar as PrimeField>::Repr: Abomonation,
@@ -301,14 +298,14 @@ where
 
     fn compress(self, pp: &PublicParams<F, C1LEM<'a, F, C>>) -> Result<Self, ProofError> {
         match &self {
-            Self::Recursive(recursive_snark) => Ok(Self::Compressed(
-                Box::new(CompressedSNARK::<_, _, _, _, SS1<F>, SS2<F>>::prove(
+            Self::Recursive(recursive_snark) => {
+                let snark = CompressedSNARK::<_, _, _, _, SS1<F>, SS2<F>>::prove(
                     &pp.pp,
                     &pp.pk,
                     recursive_snark,
-                )?),
-                PhantomData,
-            )),
+                )?;
+                Ok(Self::Compressed(Box::new(snark)))
+            }
             Self::Compressed(..) => Ok(self),
         }
     }
@@ -320,7 +317,7 @@ where
 
         let (zi_primary_verified, zi_secondary_verified) = match self {
             Self::Recursive(p) => p.verify(&pp.pp, z0_primary, &z0_secondary)?,
-            Self::Compressed(p, _) => p.verify(&pp.pp, &pp.vk, z0_primary, &z0_secondary)?,
+            Self::Compressed(p) => p.verify(&pp.pp, &pp.vk, z0_primary, &z0_secondary)?,
         };
 
         Ok(zi_primary == zi_primary_verified && zi_secondary == &zi_secondary_verified)
@@ -334,7 +331,7 @@ where
     <<E2<F> as Engine>::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
     type PublicParams = PublicParams<F, C1LEM<'a, F, C>>;
-    type RecursiveSnark = Proof<'a, F, C>;
+    type RecursiveSnark = Proof<F, C1LEM<'a, F, C>>;
 
     #[inline]
     fn reduction_count(&self) -> usize {

--- a/src/proof/tests/mod.rs
+++ b/src/proof/tests/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     proof::{
         nova::{public_params, CurveCycleEquipped, NovaProver, C1LEM, E1, E2},
         supernova::FoldingConfig,
-        CEKState, EvaluationStore, Provable, Prover, RecursiveSNARKTrait,
+        CEKState, EvaluationStore, FrameLike, Provable, Prover, RecursiveSNARKTrait,
     },
 };
 
@@ -207,7 +207,7 @@ where
 
         assert!(delta == Delta::Equal);
     }
-    let output = previous_frame.unwrap().output().as_ref().unwrap();
+    let output = previous_frame.unwrap().output();
 
     if let Some(expected_emitted) = expected_emitted {
         let mut emitted_vec = Vec::default();

--- a/src/proof/tests/mod.rs
+++ b/src/proof/tests/mod.rs
@@ -140,7 +140,7 @@ where
 
     if check_nova {
         let pp = public_params(reduction_count, lang.clone());
-        let (proof, z0, zi, _num_steps) = nova_prover.prove(&pp, &frames, s).unwrap();
+        let (proof, z0, zi, _num_steps) = nova_prover.prove_from_frames(&pp, &frames, s).unwrap();
 
         let res = proof.verify(&pp, &z0, &zi);
         if res.is_err() {


### PR DESCRIPTION
This PR changes the prover API quite a bit

1) Prover is generic over a `FrameLike` type, no more hardcoded to the Multiframe
2) Prover is no more tied to coprocessors
3) Prover no longer has a function over `Frame`s

This PR was motivated by the work on systems. I think the API today is too rigid and I'm trying to make it more flexible. I've removed things which I believe has no business being inside the prover, like coprocessors, since this is a property of the multiframe, which is subject to change. Frames are also not important to the prover, only the multiframe is. Plus, with coroutines we might not build a vector of frames anymore, but a more complicated structure. We will need to translate that structure into a ordered multiframe structure however. As of now, the prove function requires a `Vec` but we might generalize that to iterators or something