### PR TITLE
Separate coroutine circuits.

### DIFF
--- a/src/coroutine/memoset/demo.rs
+++ b/src/coroutine/memoset/demo.rs
@@ -88,6 +88,22 @@ impl<F: LurkField> Query<F> for DemoQuery<F> {
         }
     }
 
+    fn to_circuit<CS: ConstraintSystem<F>>(&self, cs: &mut CS, s: &Store<F>) -> Self::CQ {
+        match self {
+            DemoQuery::Factorial(n) => {
+                Self::CQ::Factorial(AllocatedPtr::alloc_infallible(cs, || s.hash_ptr(n)))
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn dummy_from_index(s: &Store<F>, index: usize) -> Self {
+        match index {
+            0 => Self::Factorial(s.num(0.into())),
+            _ => unreachable!(),
+        }
+    }
+
     fn index(&self) -> usize {
         match self {
             Self::Factorial(_) => 0,
@@ -208,19 +224,11 @@ impl<F: LurkField> CircuitQuery<F> for DemoCircuitQuery<F> {
     }
 
     fn from_ptr<CS: ConstraintSystem<F>>(cs: &mut CS, s: &Store<F>, ptr: &Ptr) -> Option<Self> {
-        let query = DemoQuery::from_ptr(s, ptr);
-        if let Some(q) = query {
-            match q {
-                DemoQuery::Factorial(n) => {
-                    Some(Self::Factorial(AllocatedPtr::alloc_infallible(cs, || {
-                        s.hash_ptr(&n)
-                    })))
-                }
-                _ => unreachable!(),
-            }
-        } else {
-            None
-        }
+        DemoQuery::from_ptr(s, ptr).map(|q| q.to_circuit(cs, s))
+    }
+
+    fn dummy_from_index<CS: ConstraintSystem<F>>(cs: &mut CS, s: &Store<F>, index: usize) -> Self {
+        DemoQuery::dummy_from_index(s, index).to_circuit(cs, s)
     }
 
     fn symbol(&self) -> Symbol {

--- a/src/coroutine/memoset/demo.rs
+++ b/src/coroutine/memoset/demo.rs
@@ -2,7 +2,7 @@ use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
 
 use super::{
     query::{CircuitQuery, Query},
-    CircuitScope, CircuitTranscript, LogMemo, Scope,
+    CircuitScope, CircuitTranscript, LogMemo, LogMemoCircuit, Scope,
 };
 use crate::circuit::gadgets::constraints::alloc_is_zero;
 use crate::circuit::gadgets::pointer::AllocatedPtr;
@@ -106,7 +106,7 @@ impl<F: LurkField> CircuitQuery<F> for DemoCircuitQuery<F> {
         cs: &mut CS,
         g: &GlobalAllocator<F>,
         store: &Store<F>,
-        scope: &mut CircuitScope<F, LogMemo<F>>,
+        scope: &mut CircuitScope<F, LogMemoCircuit<F>>,
         acc: &AllocatedPtr<F>,
         transcript: &CircuitTranscript<F>,
     ) -> Result<(AllocatedPtr<F>, AllocatedPtr<F>, CircuitTranscript<F>), SynthesisError> {

--- a/src/coroutine/memoset/query.rs
+++ b/src/coroutine/memoset/query.rs
@@ -1,6 +1,6 @@
 use bellpepper_core::{ConstraintSystem, SynthesisError};
 
-use super::{CircuitScope, CircuitTranscript, LogMemo, Scope};
+use super::{CircuitScope, CircuitTranscript, LogMemo, LogMemoCircuit, Scope};
 use crate::circuit::gadgets::pointer::AllocatedPtr;
 use crate::field::LurkField;
 use crate::lem::circuit::GlobalAllocator;
@@ -42,7 +42,7 @@ where
         cs: &mut CS,
         g: &GlobalAllocator<F>,
         store: &Store<F>,
-        scope: &mut CircuitScope<F, LogMemo<F>>,
+        scope: &mut CircuitScope<F, LogMemoCircuit<F>>,
         acc: &AllocatedPtr<F>,
         transcript: &CircuitTranscript<F>,
     ) -> Result<(AllocatedPtr<F>, AllocatedPtr<F>, CircuitTranscript<F>), SynthesisError>;

--- a/src/coroutine/memoset/query.rs
+++ b/src/coroutine/memoset/query.rs
@@ -22,6 +22,9 @@ where
     ) -> Ptr;
     fn from_ptr(s: &Store<F>, ptr: &Ptr) -> Option<Self>;
     fn to_ptr(&self, s: &Store<F>) -> Ptr;
+    fn to_circuit<CS: ConstraintSystem<F>>(&self, cs: &mut CS, s: &Store<F>) -> Self::CQ;
+    fn dummy_from_index(s: &Store<F>, index: usize) -> Self;
+
     fn symbol(&self) -> Symbol;
     fn symbol_ptr(&self, s: &Store<F>) -> Ptr {
         s.intern_symbol(&self.symbol())
@@ -54,4 +57,6 @@ where
     }
 
     fn from_ptr<CS: ConstraintSystem<F>>(cs: &mut CS, s: &Store<F>, ptr: &Ptr) -> Option<Self>;
+
+    fn dummy_from_index<CS: ConstraintSystem<F>>(cs: &mut CS, s: &Store<F>, index: usize) -> Self;
 }


### PR DESCRIPTION
This PR adds and exposes the minimal structure that should allow for creation of distinct circuits for each coroutine. This will be required in order to support actual NIVC proving.

Future work should include:
- minimizing or at least reducing expensive clones. This may require revisiting the underlying data structures (the multiset, the queries map, etc.) to either allow for better sharing — or to accumulate the circuit-specific parts in a way that allows them to be more cheaply separated when needed.
- supporting the equivalent of `rc` per coroutine circuit. Currently, the circuit will just contain exactly as many prove-and-remove steps as required for the actual computation witnessed. In reality, we need a fixed number per circuit — such that multiple circuits can be used if needed, and dummies (which don't affect the MemoSet or transcript) can be provided to pad. i.e. if rc=100 and a computation uses 240, then we would create 3 circuits, the last of which has 60 dummy padding instances.