### PR TITLE
Implement env lookup query.

### DIFF
--- a/src/circuit/gadgets/macros.rs
+++ b/src/circuit/gadgets/macros.rs
@@ -195,7 +195,7 @@ macro_rules! equal_t {
 // Returns a Boolean which is true if any of its arguments are true.
 macro_rules! or {
     ($cs:expr, $a:expr, $b:expr) => {
-        or(
+        crate::circuit::gadgets::constraints::or(
             $cs.namespace(|| format!("{} or {}", stringify!($a), stringify!($b))),
             $a,
             $b,
@@ -203,7 +203,7 @@ macro_rules! or {
     };
     ($cs:expr, $a:expr, $b:expr, $c:expr, $($x:expr),+) => {{
         let or_tmp_cs_ =  &mut $cs.namespace(|| format!("or({})", stringify!(vec![$a, $b, $c, $($x),*])));
-        or_v(or_tmp_cs_, &[$a, $b, $c, $($x),*])
+        bellpepper::gadgets::boolean_utils::or_v(or_tmp_cs_, &[$a, $b, $c, $($x),*])
     }};
     ($cs:expr, $a:expr, $($x:expr),+) => {{
         let or_tmp_cs_ =  &mut $cs.namespace(|| format!("or {}", stringify!(vec![$a, $($x),*])));

--- a/src/coroutine/memoset/demo.rs
+++ b/src/coroutine/memoset/demo.rs
@@ -1,7 +1,7 @@
 use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
 
 use super::{
-    query::{CircuitQuery, Query},
+    query::{CircuitQuery, Query, RecursiveQuery},
     CircuitScope, CircuitTranscript, LogMemo, LogMemoCircuit, Scope,
 };
 use crate::circuit::gadgets::constraints::alloc_is_zero;
@@ -106,6 +106,32 @@ impl<F: LurkField> Query<F> for DemoQuery<F> {
     }
 }
 
+impl<F: LurkField> RecursiveQuery<F> for DemoCircuitQuery<F> {
+    // It would be nice if this could be passed to `CircuitQuery::recurse` as an optional closure, rather than be a
+    // trait method. That would allow more generality. The types get complicated, though. For generality, we should
+    // support a context object that can be initialized once in `synthesize_eval` and be passed through for use here.
+    fn post_recursion<CS: ConstraintSystem<F>>(
+        &self,
+        cs: &mut CS,
+        subquery_result: AllocatedPtr<F>,
+    ) -> Result<AllocatedPtr<F>, SynthesisError> {
+        match self {
+            Self::Factorial(n) => {
+                let result_f = n.hash().mul(
+                    &mut cs.namespace(|| "incremental multiplication"),
+                    subquery_result.hash(),
+                )?;
+
+                AllocatedPtr::alloc_tag(
+                    &mut cs.namespace(|| "result"),
+                    ExprTag::Num.to_field(),
+                    result_f,
+                )
+            }
+        }
+    }
+}
+
 impl<F: LurkField> CircuitQuery<F> for DemoCircuitQuery<F> {
     fn synthesize_eval<CS: ConstraintSystem<F>>(
         &self,
@@ -117,8 +143,6 @@ impl<F: LurkField> CircuitQuery<F> for DemoCircuitQuery<F> {
         transcript: &CircuitTranscript<F>,
     ) -> Result<(AllocatedPtr<F>, AllocatedPtr<F>, CircuitTranscript<F>), SynthesisError> {
         match self {
-            // TODO: Factor out the recursive boilerplate so individual queries can just implement their distinct logic
-            // using a sane framework.
             Self::Factorial(n) => {
                 // FIXME: Check n tag or decide not to.
                 let base_case_f = g.alloc_const(cs, F::ONE);
@@ -130,85 +154,45 @@ impl<F: LurkField> CircuitQuery<F> for DemoCircuitQuery<F> {
 
                 let n_is_zero = alloc_is_zero(&mut cs.namespace(|| "n_is_zero"), n.hash())?;
 
-                let (recursive_result, recursive_acc, recursive_transcript) = {
-                    let new_n = AllocatedNum::alloc(&mut cs.namespace(|| "new_n"), || {
-                        n.hash()
-                            .get_value()
-                            .map(|n| n - F::ONE)
-                            .ok_or(SynthesisError::AssignmentMissing)
-                    })?;
+                let new_n = AllocatedNum::alloc(&mut cs.namespace(|| "new_n"), || {
+                    n.hash()
+                        .get_value()
+                        .map(|n| n - F::ONE)
+                        .ok_or(SynthesisError::AssignmentMissing)
+                })?;
 
-                    // new_n * 1 = n - 1
-                    cs.enforce(
-                        || "enforce_new_n",
-                        |lc| lc + new_n.get_variable(),
-                        |lc| lc + CS::one(),
-                        |lc| lc + n.hash().get_variable() - CS::one(),
-                    );
+                // new_n * 1 = n - 1
+                cs.enforce(
+                    || "enforce_new_n",
+                    |lc| lc + new_n.get_variable(),
+                    |lc| lc + CS::one(),
+                    |lc| lc + n.hash().get_variable() - CS::one(),
+                );
 
-                    let subquery = {
-                        let symbol = g.alloc_ptr(cs, &self.symbol_ptr(store), store);
-
-                        let new_num = AllocatedPtr::alloc_tag(
-                            &mut cs.namespace(|| "new_num"),
-                            ExprTag::Num.to_field(),
-                            new_n,
-                        )?;
-                        construct_list(
-                            &mut cs.namespace(|| "subquery"),
-                            g,
-                            store,
-                            &[&symbol, &new_num],
-                            None,
-                        )?
-                    };
-
-                    let (sub_result, new_acc, new_transcript) = scope.synthesize_internal_query(
-                        &mut cs.namespace(|| "recursive query"),
-                        g,
-                        store,
-                        &subquery,
-                        acc,
-                        transcript,
-                        &n_is_zero.not(),
-                    )?;
-
-                    let result_f = n.hash().mul(
-                        &mut cs.namespace(|| "incremental multiplication"),
-                        sub_result.hash(),
-                    )?;
-
-                    let result = AllocatedPtr::alloc_tag(
-                        &mut cs.namespace(|| "result"),
-                        ExprTag::Num.to_field(),
-                        result_f,
-                    )?;
-
-                    (result, new_acc, new_transcript)
-                };
-
-                let value = AllocatedPtr::pick(
-                    &mut cs.namespace(|| "pick value"),
-                    &n_is_zero,
-                    &base_case,
-                    &recursive_result,
+                let new_num = AllocatedPtr::alloc_tag(
+                    &mut cs.namespace(|| "new_num"),
+                    ExprTag::Num.to_field(),
+                    new_n,
                 )?;
 
-                let acc = AllocatedPtr::pick(
-                    &mut cs.namespace(|| "pick acc"),
-                    &n_is_zero,
-                    acc,
-                    &recursive_acc,
+                // FIXME: Don't bother making this wasteful list.
+                let recursive_args = construct_list(
+                    &mut cs.namespace(|| "recursive_args"),
+                    g,
+                    store,
+                    &[&new_num],
+                    None,
                 )?;
 
-                let transcript = CircuitTranscript::pick(
-                    &mut cs.namespace(|| "pick recursive_transcript"),
-                    &n_is_zero,
-                    transcript,
-                    &recursive_transcript,
-                )?;
-
-                Ok((value, acc, transcript))
+                self.recurse(
+                    cs,
+                    g,
+                    store,
+                    scope,
+                    &recursive_args,
+                    &n_is_zero.not(),
+                    (&base_case, acc, transcript),
+                )
             }
         }
     }

--- a/src/coroutine/memoset/demo.rs
+++ b/src/coroutine/memoset/demo.rs
@@ -28,7 +28,6 @@ pub(crate) enum DemoCircuitQuery<F: LurkField> {
 impl<F: LurkField> Query<F> for DemoQuery<F> {
     type CQ = DemoCircuitQuery<F>;
 
-    // DemoQuery and Scope depend on each other.
     fn eval(&self, s: &Store<F>, scope: &mut Scope<Self, LogMemo<F>>) -> Ptr {
         match self {
             Self::Factorial(n) => {
@@ -47,15 +46,6 @@ impl<F: LurkField> Query<F> for DemoQuery<F> {
             }
             _ => unreachable!(),
         }
-    }
-
-    fn recursive_eval(
-        &self,
-        scope: &mut Scope<Self, LogMemo<F>>,
-        s: &Store<F>,
-        subquery: Self,
-    ) -> Ptr {
-        scope.query_recursively(s, self, subquery)
     }
 
     fn symbol(&self) -> Symbol {

--- a/src/coroutine/memoset/env.rs
+++ b/src/coroutine/memoset/env.rs
@@ -1,0 +1,476 @@
+use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
+
+use super::{
+    query::{CircuitQuery, Query},
+    CircuitScope, CircuitTranscript, LogMemo, LogMemoCircuit, Scope,
+};
+use crate::circuit::gadgets::constraints::{alloc_equal, alloc_is_zero};
+use crate::circuit::gadgets::pointer::AllocatedPtr;
+use crate::coprocessor::gadgets::{construct_cons, deconstruct_env};
+use crate::field::LurkField;
+use crate::lem::circuit::GlobalAllocator;
+use crate::lem::{pointers::Ptr, store::Store};
+use crate::symbol::Symbol;
+use crate::tag::ExprTag;
+
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub(crate) enum EnvQuery<F> {
+    Lookup(Ptr, Ptr),
+    Phantom(F),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum EnvCircuitQuery<F: LurkField> {
+    Lookup(AllocatedNum<F>, AllocatedNum<F>),
+}
+
+impl<F: LurkField> Query<F> for EnvQuery<F> {
+    type CQ = EnvCircuitQuery<F>;
+
+    fn eval(&self, s: &Store<F>, scope: &mut Scope<Self, LogMemo<F>>) -> Ptr {
+        match self {
+            Self::Lookup(var, env) => {
+                if let Some([v, val, new_env]) = s.pop_binding(*env) {
+                    if s.ptr_eq(var, &v) {
+                        let t = s.intern_t();
+                        s.cons(val, t)
+                    } else {
+                        self.recursive_eval(scope, s, Self::Lookup(*var, new_env))
+                    }
+                } else {
+                    let nil = s.intern_nil();
+                    s.cons(nil, nil)
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn recursive_eval(
+        &self,
+        scope: &mut Scope<Self, LogMemo<F>>,
+        s: &Store<F>,
+        subquery: Self,
+    ) -> Ptr {
+        scope.query_recursively(s, self, subquery)
+    }
+
+    fn symbol(&self) -> Symbol {
+        match self {
+            Self::Lookup(_, _) => Symbol::sym(&["lurk", "env", "lookup"]),
+            _ => unreachable!(),
+        }
+    }
+
+    fn from_ptr(s: &Store<F>, ptr: &Ptr) -> Option<Self> {
+        let (head, body) = s.car_cdr(ptr).expect("query should be cons");
+        let sym = s.fetch_sym(&head).expect("head should be sym");
+
+        if sym == Symbol::sym(&["lurk", "env", "lookup"]) {
+            let (var, env) = s.car_cdr(&body).expect("query body should be cons");
+            Some(Self::Lookup(var, env))
+        } else {
+            None
+        }
+    }
+
+    fn to_ptr(&self, s: &Store<F>) -> Ptr {
+        match self {
+            Self::Lookup(var, env) => {
+                let lookup = s.intern_symbol(&self.symbol());
+                // Since var and env will actually be single field elements in the circuit, we could reduce the cost of
+                // this to use a smaller hash. This could get ugly fast, but this possibility is a consequence of the
+                // optimized env-binding data structure we've adopted.
+                let args = s.cons(*var, *env);
+                s.cons(lookup, args)
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn index(&self) -> usize {
+        match self {
+            Self::Lookup(_, _) => 0,
+            _ => unreachable!(),
+        }
+    }
+
+    fn count() -> usize {
+        1
+    }
+}
+
+impl<F: LurkField> CircuitQuery<F> for EnvCircuitQuery<F> {
+    fn synthesize_eval<CS: ConstraintSystem<F>>(
+        &self,
+        cs: &mut CS,
+        g: &GlobalAllocator<F>,
+        store: &Store<F>,
+        scope: &mut CircuitScope<F, LogMemoCircuit<F>>,
+        acc: &AllocatedPtr<F>,
+        transcript: &CircuitTranscript<F>,
+    ) -> Result<(AllocatedPtr<F>, AllocatedPtr<F>, CircuitTranscript<F>), SynthesisError> {
+        match self {
+            Self::Lookup(var, env) => {
+                let nil = store.intern_nil();
+                let t = store.intern_t();
+                let allocated_nil = g.alloc_ptr(cs, &nil, store);
+                let allocated_t = g.alloc_ptr(cs, &t, store);
+                let sym_tag = g.alloc_tag(&mut cs.namespace(|| "sym_tag"), &ExprTag::Sym);
+                let env_tag = g.alloc_tag(&mut cs.namespace(|| "env_tag"), &ExprTag::Env);
+
+                let env_is_empty = alloc_is_zero(&mut cs.namespace(|| "env_is_empty"), env)?;
+
+                let (next_var, next_val, new_env) = deconstruct_env(
+                    &mut cs.namespace(|| "deconstruct_env"),
+                    store,
+                    &env_is_empty.not(),
+                    env,
+                )?;
+
+                let var_matches = alloc_equal(&mut cs.namespace(|| "var_matches"), var, &next_var)?;
+                let is_immediate = or!(cs, &var_matches, &env_is_empty)?;
+
+                let immediate_val = AllocatedPtr::pick(
+                    &mut cs.namespace(|| "immediate_val"),
+                    &var_matches,
+                    &next_val,
+                    &allocated_nil,
+                )?;
+
+                let immediate_bound = AllocatedPtr::pick(
+                    &mut cs.namespace(|| "immediate_bound"),
+                    &var_matches,
+                    &allocated_t,
+                    &allocated_nil,
+                )?;
+
+                let immediate_result = construct_cons(
+                    &mut cs.namespace(|| "immediate_result"),
+                    g,
+                    store,
+                    &immediate_val,
+                    &immediate_bound,
+                )?;
+
+                let (recursive_result, recursive_acc, recursive_transcript) = {
+                    let subquery = {
+                        let symbol = g.alloc_ptr(cs, &self.symbol_ptr(store), store);
+
+                        let new_env_x = AllocatedPtr::from_parts(env_tag.clone(), new_env);
+                        let var_x = AllocatedPtr::from_parts(sym_tag.clone(), var.clone());
+
+                        let recursive_args = construct_cons(
+                            &mut cs.namespace(|| "recursive_args"),
+                            g,
+                            store,
+                            &var_x,
+                            &new_env_x,
+                        )?;
+
+                        construct_cons(
+                            &mut cs.namespace(|| "subquery"),
+                            g,
+                            store,
+                            &symbol,
+                            &recursive_args,
+                        )?
+                    };
+
+                    let (sub_result, new_acc, new_transcript) = scope.synthesize_internal_query(
+                        &mut cs.namespace(|| "recursive query"),
+                        g,
+                        store,
+                        &subquery,
+                        acc,
+                        transcript,
+                        &is_immediate.not(),
+                    )?;
+
+                    (sub_result, new_acc, new_transcript)
+                };
+
+                let value = AllocatedPtr::pick(
+                    &mut cs.namespace(|| "pick value"),
+                    &is_immediate,
+                    &immediate_result,
+                    &recursive_result,
+                )?;
+
+                let acc = AllocatedPtr::pick(
+                    &mut cs.namespace(|| "pick acc"),
+                    &is_immediate,
+                    acc,
+                    &recursive_acc,
+                )?;
+
+                let transcript = CircuitTranscript::pick(
+                    &mut cs.namespace(|| "pick recursive_transcript"),
+                    &is_immediate,
+                    transcript,
+                    &recursive_transcript,
+                )?;
+
+                Ok((value, acc, transcript))
+            }
+        }
+    }
+
+    fn from_ptr<CS: ConstraintSystem<F>>(cs: &mut CS, s: &Store<F>, ptr: &Ptr) -> Option<Self> {
+        let query = EnvQuery::from_ptr(s, ptr);
+        if let Some(q) = query {
+            match q {
+                EnvQuery::Lookup(var, env) => {
+                    let allocated_var =
+                        AllocatedNum::alloc_infallible(&mut cs.namespace(|| "var"), || {
+                            *s.hash_ptr(&var).value()
+                        });
+                    let allocated_env =
+                        AllocatedNum::alloc_infallible(&mut cs.namespace(|| "env"), || {
+                            *s.hash_ptr(&env).value()
+                        });
+                    Some(Self::Lookup(allocated_var, allocated_env))
+                }
+                _ => unreachable!(),
+            }
+        } else {
+            None
+        }
+    }
+
+    fn symbol(&self) -> Symbol {
+        match self {
+            Self::Lookup(_, _) => Symbol::sym(&["lurk", "env", "lookup"]),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use crate::state::State;
+    use crate::sym;
+
+    use bellpepper_core::{test_cs::TestConstraintSystem, Comparable};
+    use expect_test::{expect, Expect};
+    use ff::Field;
+    use halo2curves::bn256::Fr as F;
+    use std::default::Default;
+
+    #[test]
+    fn test_env_lookup() {
+        let s = Store::<F>::default();
+        let mut scope: Scope<EnvQuery<F>, LogMemo<F>> = Scope::default();
+        let a = s.intern_symbol(&sym!("a"));
+        let b = s.intern_symbol(&sym!("b"));
+        let c = s.intern_symbol(&sym!("c"));
+
+        let one = s.num(F::ONE);
+        let two = s.num(F::from_u64(2));
+        let three = s.num(F::from_u64(3));
+        let four = s.num(F::from_u64(4));
+
+        let empty = s.intern_empty_env();
+        let a_env = s.push_binding(a, one, empty);
+        let b_env = s.push_binding(b, two, a_env);
+        let c_env = s.push_binding(c, three, b_env);
+        let a2_env = s.push_binding(a, four, c_env);
+
+        let t = s.intern_t();
+        let nil = s.intern_nil();
+
+        let mut test = |var, env, found| {
+            let expected = if let Some(val) = found {
+                s.cons(val, t)
+            } else {
+                s.cons(nil, nil)
+            };
+
+            let result = EnvQuery::Lookup(var, env).eval(&s, &mut scope);
+            assert!(s.ptr_eq(&expected, &result))
+        };
+
+        test(a, empty, None);
+        test(a, a_env, Some(one));
+        test(b, a_env, None);
+        test(b, b_env, Some(two));
+        test(a, a2_env, Some(four));
+        test(c, b_env, None);
+        test(c, c_env, Some(three));
+        test(c, a2_env, Some(three));
+    }
+
+    #[test]
+    fn test_lookup_circuit() {
+        let expect_eq = |computed: usize, expected: Expect| {
+            expected.assert_eq(&computed.to_string());
+        };
+
+        let s = &Store::<F>::default();
+
+        let a = s.intern_symbol(&sym!("a"));
+        let b = s.intern_symbol(&sym!("b"));
+        let c = s.intern_symbol(&sym!("c"));
+
+        let one = s.num(F::ONE);
+        let two = s.num(F::from_u64(2));
+        let three = s.num(F::from_u64(3));
+        let four = s.num(F::from_u64(4));
+
+        let empty = s.intern_empty_env();
+        let a_env = s.push_binding(a, one, empty);
+        let b_env = s.push_binding(b, two, a_env);
+        let c_env = s.push_binding(c, three, b_env);
+        let a2_env = s.push_binding(a, four, c_env);
+
+        {
+            // With internal insertions transcribed.
+
+            let (one_lookup_constraints, one_lookup_aux) =
+                test_lookup_circuit_aux(s, a, empty, true, expect!["3227"], expect!["3238"]);
+
+            test_lookup_circuit_aux(s, a, a_env, true, expect!["3227"], expect!["3238"]);
+
+            let (two_lookup_constraints, two_lookup_aux) =
+                test_lookup_circuit_aux(s, b, a_env, true, expect!["5856"], expect!["5875"]);
+
+            test_lookup_circuit_aux(s, b, b_env, true, expect!["3227"], expect!["3238"]);
+            test_lookup_circuit_aux(s, a, a2_env, true, expect!["3227"], expect!["3238"]);
+
+            let (three_lookup_constraints, three_lookup_aux) =
+                test_lookup_circuit_aux(s, c, b_env, true, expect!["8485"], expect!["8512"]);
+
+            test_lookup_circuit_aux(s, c, c_env, true, expect!["3227"], expect!["3238"]);
+            test_lookup_circuit_aux(s, c, a2_env, true, expect!["5856"], expect!["5875"]);
+
+            let delta1_constraints = two_lookup_constraints - one_lookup_constraints;
+            let delta2_constraints = three_lookup_constraints - two_lookup_constraints;
+            let overhead_constraints = one_lookup_constraints - delta1_constraints;
+
+            assert_eq!(delta1_constraints, delta2_constraints);
+
+            // This is the number of constraints per lookup.
+            expect_eq(delta1_constraints, expect!["2629"]);
+
+            // This is the number of constraints in the constant overhead.
+            expect_eq(overhead_constraints, expect!["598"]);
+
+            let delta1_aux = two_lookup_aux - one_lookup_aux;
+            let delta2_aux = three_lookup_aux - two_lookup_aux;
+            let overhead_aux = one_lookup_aux - delta1_aux;
+
+            assert_eq!(delta1_aux, delta2_aux);
+
+            // This is the number of aux per lookup.
+            expect_eq(delta1_aux, expect!["2637"]);
+
+            // This is the number of aux in the constant overhead.
+            expect_eq(overhead_aux, expect!["601"]);
+        }
+
+        {
+            // Without internal insertions transcribed.
+
+            let (one_lookup_constraints, one_lookup_aux) =
+                test_lookup_circuit_aux(s, a, empty, false, expect!["2938"], expect!["2949"]);
+
+            test_lookup_circuit_aux(s, a, a_env, false, expect!["2938"], expect!["2949"]);
+
+            let (two_lookup_constraints, two_lookup_aux) =
+                test_lookup_circuit_aux(s, b, a_env, false, expect!["5278"], expect!["5297"]);
+
+            test_lookup_circuit_aux(s, b, b_env, false, expect!["2938"], expect!["2949"]);
+            test_lookup_circuit_aux(s, a, a2_env, false, expect!["2938"], expect!["2949"]);
+
+            let (three_lookup_constraints, three_lookup_aux) =
+                test_lookup_circuit_aux(s, c, b_env, false, expect!["7618"], expect!["7645"]);
+
+            test_lookup_circuit_aux(s, c, c_env, false, expect!["2938"], expect!["2949"]);
+            test_lookup_circuit_aux(s, c, a2_env, false, expect!["5278"], expect!["5297"]);
+
+            let delta1_constraints = two_lookup_constraints - one_lookup_constraints;
+            let delta2_constraints = three_lookup_constraints - two_lookup_constraints;
+            let overhead_constraints = one_lookup_constraints - delta1_constraints;
+
+            assert_eq!(delta1_constraints, delta2_constraints);
+
+            // This is the number of constraints per lookup.
+            expect_eq(delta1_constraints, expect!["2340"]);
+
+            // This is the number of constraints in the constant overhead.
+            expect_eq(overhead_constraints, expect!["598"]);
+
+            let delta1_aux = two_lookup_aux - one_lookup_aux;
+            let delta2_aux = three_lookup_aux - two_lookup_aux;
+            let overhead_aux = one_lookup_aux - delta1_aux;
+
+            assert_eq!(delta1_aux, delta2_aux);
+
+            // This is the number of aux per lookup.
+            expect_eq(delta1_aux, expect!["2348"]);
+
+            // This is the number of aux in the constant overhead.
+            expect_eq(overhead_aux, expect!["601"]);
+        }
+    }
+
+    fn test_lookup_circuit_aux(
+        s: &Store<F>,
+        sym: Ptr,
+        env: Ptr,
+        transcribe_internal_insertions: bool,
+        expected_constraints_simple: Expect,
+        expected_aux_simple: Expect,
+    ) -> (usize, usize) {
+        let state = State::init_lurk_state();
+        let expect_eq = |computed: usize, expected: Expect| {
+            expected.assert_eq(&computed.to_string());
+        };
+
+        let mut scope: Scope<EnvQuery<F>, LogMemo<F>> = Scope::new(transcribe_internal_insertions);
+
+        let make_query = |sym, env| EnvQuery::Lookup(sym, env).to_ptr(s);
+
+        {
+            let query = make_query(sym, env);
+
+            scope.query(s, query);
+
+            for (k, v) in scope.queries.iter() {
+                println!("k: {}", k.fmt_to_string(s, &state));
+                println!("v: {}", v.fmt_to_string(s, &state));
+            }
+
+            scope.finalize_transcript(s);
+
+            let cs = &mut TestConstraintSystem::new();
+            let g = &mut GlobalAllocator::default();
+
+            scope.synthesize(cs, g, s).unwrap();
+
+            println!(
+                "transcript: {}",
+                scope
+                    .memoset
+                    .transcript
+                    .get()
+                    .unwrap()
+                    .fmt_to_string_simple(s)
+            );
+
+            expect_eq(cs.num_constraints(), expected_constraints_simple);
+            expect_eq(cs.aux().len(), expected_aux_simple);
+
+            let unsat = cs.which_is_unsatisfied();
+
+            if unsat.is_some() {
+                dbg!(unsat);
+            }
+            assert!(cs.is_satisfied());
+
+            (cs.num_constraints(), cs.aux().len())
+        }
+    }
+}

--- a/src/coroutine/memoset/env.rs
+++ b/src/coroutine/memoset/env.rs
@@ -47,15 +47,6 @@ impl<F: LurkField> Query<F> for EnvQuery<F> {
         }
     }
 
-    fn recursive_eval(
-        &self,
-        scope: &mut Scope<Self, LogMemo<F>>,
-        s: &Store<F>,
-        subquery: Self,
-    ) -> Ptr {
-        scope.query_recursively(s, self, subquery)
-    }
-
     fn symbol(&self) -> Symbol {
         match self {
             Self::Lookup(_, _) => Symbol::sym(&["lurk", "env", "lookup"]),

--- a/src/coroutine/memoset/env.rs
+++ b/src/coroutine/memoset/env.rs
@@ -85,10 +85,10 @@ impl<F: LurkField> Query<F> for EnvQuery<F> {
             EnvQuery::Lookup(var, env) => {
                 let mut var_cs = cs.namespace(|| "var");
                 let allocated_var =
-                    AllocatedNum::alloc_infallible(&mut var_cs, || *s.hash_ptr(&var).value());
+                    AllocatedNum::alloc_infallible(&mut var_cs, || *s.hash_ptr(var).value());
                 let mut env_cs = var_cs.namespace(|| "env");
                 let allocated_env =
-                    AllocatedNum::alloc_infallible(&mut env_cs, || *s.hash_ptr(&env).value());
+                    AllocatedNum::alloc_infallible(&mut env_cs, || *s.hash_ptr(env).value());
                 Self::CQ::Lookup(allocated_var, allocated_env)
             }
             _ => unreachable!(),

--- a/src/coroutine/memoset/mod.rs
+++ b/src/coroutine/memoset/mod.rs
@@ -1122,8 +1122,8 @@ mod test {
             Scope::new(transcribe_internal_insertions, circuit_query_rc);
         let state = State::init_lurk_state();
 
-        let fact_4 = s.read_with_default_state("(factorial 4)").unwrap();
-        let fact_3 = s.read_with_default_state("(factorial 3)").unwrap();
+        let fact_4 = s.read_with_default_state("(factorial . 4)").unwrap();
+        let fact_3 = s.read_with_default_state("(factorial . 3)").unwrap();
 
         let expect_eq = |computed: usize, expected: Expect| {
             expected.assert_eq(&computed.to_string());

--- a/src/coroutine/memoset/mod.rs
+++ b/src/coroutine/memoset/mod.rs
@@ -51,6 +51,7 @@ use multiset::MultiSet;
 pub use query::{CircuitQuery, Query};
 
 mod demo;
+mod env;
 mod multiset;
 mod query;
 
@@ -528,6 +529,7 @@ impl<F: LurkField, Q: Query<F>> Scope<Q, LogMemo<F>> {
         }
 
         circuit_scope.finalize(cs, g);
+
         Ok(())
     }
 

--- a/src/coroutine/memoset/mod.rs
+++ b/src/coroutine/memoset/mod.rs
@@ -1057,26 +1057,26 @@ mod test {
     fn test_query_with_internal_insertion_transcript() {
         test_query_aux(
             true,
-            expect!["10875"],
-            expect!["10908"],
-            expect!["11457"],
-            expect!["11494"],
+            expect!["9430"],
+            expect!["9463"],
+            expect!["10012"],
+            expect!["10049"],
             1,
         );
         test_query_aux(
             true,
-            expect!["12908"],
-            expect!["12947"],
-            expect!["13490"],
-            expect!["13533"],
+            expect!["11174"],
+            expect!["11213"],
+            expect!["11756"],
+            expect!["11799"],
             3,
         );
         test_query_aux(
             true,
-            expect!["21106"],
-            expect!["21169"],
-            expect!["21688"],
-            expect!["21755"],
+            expect!["18216"],
+            expect!["18279"],
+            expect!["18798"],
+            expect!["18865"],
             10,
         )
     }
@@ -1085,26 +1085,26 @@ mod test {
     fn test_query_without_internal_insertion_transcript() {
         test_query_aux(
             false,
-            expect!["9430"],
-            expect!["9463"],
-            expect!["10012"],
-            expect!["10049"],
+            expect!["7985"],
+            expect!["8018"],
+            expect!["8567"],
+            expect!["8604"],
             1,
         );
         test_query_aux(
             false,
-            expect!["11174"],
-            expect!["11213"],
-            expect!["11756"],
-            expect!["11799"],
+            expect!["9440"],
+            expect!["9479"],
+            expect!["10022"],
+            expect!["10065"],
             3,
         );
         test_query_aux(
             false,
-            expect!["18216"],
-            expect!["18279"],
-            expect!["18798"],
-            expect!["18865"],
+            expect!["15326"],
+            expect!["15389"],
+            expect!["15908"],
+            expect!["15975"],
             10,
         )
     }

--- a/src/coroutine/memoset/query.rs
+++ b/src/coroutine/memoset/query.rs
@@ -1,7 +1,8 @@
-use bellpepper_core::{ConstraintSystem, SynthesisError};
+use bellpepper_core::{boolean::Boolean, ConstraintSystem, SynthesisError};
 
 use super::{CircuitScope, CircuitTranscript, LogMemo, LogMemoCircuit, Scope};
 use crate::circuit::gadgets::pointer::AllocatedPtr;
+use crate::coprocessor::gadgets::construct_cons;
 use crate::field::LurkField;
 use crate::lem::circuit::GlobalAllocator;
 use crate::lem::{pointers::Ptr, store::Store};
@@ -61,4 +62,75 @@ where
     fn from_ptr<CS: ConstraintSystem<F>>(cs: &mut CS, s: &Store<F>, ptr: &Ptr) -> Option<Self>;
 
     fn dummy_from_index<CS: ConstraintSystem<F>>(cs: &mut CS, s: &Store<F>, index: usize) -> Self;
+}
+
+pub(crate) trait RecursiveQuery<F: LurkField>: CircuitQuery<F> {
+    fn post_recursion<CS: ConstraintSystem<F>>(
+        &self,
+        _cs: &mut CS,
+        subquery_result: AllocatedPtr<F>,
+    ) -> Result<AllocatedPtr<F>, SynthesisError> {
+        Ok(subquery_result)
+    }
+
+    fn recurse<CS: ConstraintSystem<F>>(
+        &self,
+        cs: &mut CS,
+        g: &GlobalAllocator<F>,
+        store: &Store<F>,
+        scope: &mut CircuitScope<F, LogMemoCircuit<F>>,
+        args: &AllocatedPtr<F>,
+        is_recursive: &Boolean,
+        immediate: (&AllocatedPtr<F>, &AllocatedPtr<F>, &CircuitTranscript<F>),
+    ) -> Result<(AllocatedPtr<F>, AllocatedPtr<F>, CircuitTranscript<F>), SynthesisError> {
+        let is_immediate = is_recursive.not();
+
+        let subquery = {
+            let symbol = g.alloc_ptr(
+                &mut cs.namespace(|| "symbol"),
+                &self.symbol_ptr(store),
+                store,
+            );
+            construct_cons(&mut cs.namespace(|| "subquery"), g, store, &symbol, args)?
+        };
+
+        let (sub_result, new_acc, new_transcript) = scope.synthesize_internal_query(
+            &mut cs.namespace(|| "recursive query"),
+            g,
+            store,
+            &subquery,
+            immediate.1,
+            immediate.2,
+            is_recursive,
+        )?;
+
+        let (recursive_result, recursive_acc, recursive_transcript) = (
+            self.post_recursion(cs, sub_result)?,
+            new_acc,
+            new_transcript,
+        );
+
+        let value = AllocatedPtr::pick(
+            &mut cs.namespace(|| "pick value"),
+            &is_immediate,
+            immediate.0,
+            &recursive_result,
+        )?;
+
+        let acc = AllocatedPtr::pick(
+            &mut cs.namespace(|| "pick acc"),
+            &is_immediate,
+            immediate.1,
+            &recursive_acc,
+        )?;
+
+        let transcript = CircuitTranscript::pick(
+            &mut cs.namespace(|| "pick recursive_transcript"),
+            &is_immediate,
+            immediate.2,
+            &recursive_transcript,
+        )?;
+
+        Ok((value, acc, transcript))
+    }
 }

--- a/src/coroutine/memoset/query.rs
+++ b/src/coroutine/memoset/query.rs
@@ -19,7 +19,9 @@ where
         scope: &mut Scope<Self, LogMemo<F>>,
         s: &Store<F>,
         subquery: Self,
-    ) -> Ptr;
+    ) -> Ptr {
+        scope.query_recursively(s, self, subquery)
+    }
     fn from_ptr(s: &Store<F>, ptr: &Ptr) -> Option<Self>;
     fn to_ptr(&self, s: &Store<F>) -> Ptr;
     fn to_circuit<CS: ConstraintSystem<F>>(&self, cs: &mut CS, s: &Store<F>) -> Self::CQ;

--- a/src/lem/store.rs
+++ b/src/lem/store.rs
@@ -622,6 +622,11 @@ impl<F: LurkField> Store<F> {
     }
 
     #[inline]
+    pub fn intern_t(&self) -> Ptr {
+        self.intern_lurk_symbol("t")
+    }
+
+    #[inline]
     pub fn intern_user_symbol(&self, name: &str) -> Ptr {
         self.intern_symbol(&user_sym(name))
     }


### PR DESCRIPTION
NOTE: This PR currently targets #1076 as base branch, to simplify review. The intention is that it merge after that PR, rather than be merged into it.

This PR adds `EnvQuery` and `EnvCircuitQuery` — suitable for use in Lurk to provide cheap and memoized lexical env lookups. Of note:

- The args to the query are provided as a cons, rather than a list. This enshrines the general design pattern that coroutines need not use Lurk 'calling conventions' to encode non-unary input. This helps reduce hashing costs and could be taken further.
- The result returned is a cons whose cdr is a Lurk boolean (nil or t) indicating whether the var was bound in the env, necessary for the Lurk context.

Future work:
- [x] Refactor `EnvQuery` and `DemoQuery` so `Lookup` and `Factorial` implementations can share boilerplate. This will require some abstraction to emerge. I won't speculate too much about the shape this should take here. UPDATE: I've added a first cut of this to the PR.
- [ ] Enhance tests to also check correctness of query results, which may require refactoring the internal helper functions — which currently exist in a vacuum to facilitate integration into a meaningful computational context.

It is worth noting that the current Lurk reduction examines 8 binding frames (`Env`s) at a time, so naively substituting a MemoSet `Lookup` query *instead* of this will likely reduce performance. However, if the lookup is inserted only after multiple frames have been examined, we can get the memoization benefits without sacrificing performance for 'superlocal' lookups.

Of course, there is a tradeoff for the hashes required in the query (insertion), so we may have to reduce the number frames examined so the hash slots can be shared. An alternate (or complementary) approach would be to extend the query to unroll the recursion (to some depth) and therefore examine multiple binding frames per query. This would provide the best of both worlds. We should probably do this (and in a maximally automated way, hence my mention of 'unrolling' — or perhaps 'flattening'), but it will require greater care to ensure chunked queries still overlap where useful for memoization.

This implies non-deterministic decision-making on the part of the prover. The decisions will need to be made during the phase between evaluation and proving, when the transcript is assembled; and there will need to be a general mechanism for the decisions made to be formalized as hints passed to the prover, so the same decisions can be replayed to reach an identical transcript at proving time.
