### PR TITLE
chore: Modify Neptune package features in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ bincode = "1.3.3"
 clap = "4.3.17"
 ff = "0.13"
 metrics = "0.22.0"
-neptune = { git = "https://github.com/lurk-lab/neptune", branch = "dev", features = ["abomonation"] }
+neptune = { git = "https://github.com/lurk-lab/neptune", branch = "dev", default-features = false, features = ["abomonation"] }
 nova = { git = "https://github.com/lurk-lab/arecibo", branch = "dev", package = "arecibo", features = ["abomonate"]}
 once_cell = "1.18.0"
 pairing = { version = "0.23" }


### PR DESCRIPTION
- Disabled default features for Neptune package to curb unnecessary functionalities

Moves our dependency graph for blst from
```
blst v0.3.11
├── blstrs v0.7.1 (https://github.com/lurk-lab/blstrs.git?branch=dev#ea97fc1a)
│   └── neptune v13.0.0 (https://github.com/lurk-lab/neptune?branch=dev#9105c4fd)
│       ├── arecibo v0.2.0 (https://github.com/lurk-lab/arecibo?branch=dev#7a5d7bf0)
│       │   └── lurk v0.3.1 (/Users/huitseeker/tmp/lurk-rs)
│       │       [dev-dependencies]
│       │       └── lurk-macros v0.2.0 (proc-macro) (/Users/huitseeker/tmp/lurk-rs/lurk-macros)
│       │           └── lurk v0.3.1 (/Users/huitseeker/tmp/lurk-rs) (*)
│       └── lurk v0.3.1 (/Users/huitseeker/tmp/lurk-rs) (*)
│   [build-dependencies]
│   └── neptune v13.0.0 (https://github.com/lurk-lab/neptune?branch=dev#9105c4fd) (*)
└── grumpkin-msm v0.1.0 (https://github.com/lurk-lab/grumpkin-msm?branch=dev#29af3cd2)
    └── arecibo v0.2.0 (https://github.com/lurk-lab/arecibo?branch=dev#7a5d7bf0) (*)
```
To:
```
blst v0.3.11
├── blstrs v0.7.1 (https://github.com/lurk-lab/blstrs.git?branch=dev#ea97fc1a)
│   [build-dependencies]
│   └── neptune v13.0.0 (https://github.com/lurk-lab/neptune?branch=dev#9105c4fd)
│       ├── arecibo v0.2.0 (https://github.com/lurk-lab/arecibo?branch=dev#7a5d7bf0)
│       │   └── lurk v0.3.1 (/Users/huitseeker/tmp/lurk-rs)
│       │       [dev-dependencies]
│       │       └── lurk-macros v0.2.0 (proc-macro) (/Users/huitseeker/tmp/lurk-rs/lurk-macros)
│       │           └── lurk v0.3.1 (/Users/huitseeker/tmp/lurk-rs) (*)
│       └── lurk v0.3.1 (/Users/huitseeker/tmp/lurk-rs) (*)
└── grumpkin-msm v0.1.0 (https://github.com/lurk-lab/grumpkin-msm?branch=dev#29af3cd2)
    └── arecibo v0.2.0 (https://github.com/lurk-lab/arecibo?branch=dev#7a5d7bf0) (*)
```

IOW, neptune doesn't load blst(rs) unless explicitly told to. (It is already told to load pasta)