### PR TITLE
chore: forget cached `MultiFrame` witnesses after they're used

### DIFF
--- a/src/lem/multiframe.rs
+++ b/src/lem/multiframe.rs
@@ -97,6 +97,11 @@ impl<'a, F: LurkField, C: Coprocessor<F>> MultiFrame<'a, F, C> {
     }
 
     #[inline]
+    pub fn clear_cached_witness(&mut self) {
+        self.cached_witness = OnceCell::new();
+    }
+
+    #[inline]
     pub fn precedes(&self, maybe_next: &Self) -> bool {
         self.output == maybe_next.input
     }

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -273,7 +273,7 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<F, C1LEM<
                 });
 
                 for circuit_primary in cc.iter() {
-                    let circuit_primary = circuit_primary.lock().unwrap();
+                    let mut circuit_primary = circuit_primary.lock().unwrap();
 
                     let mut r_snark = recursive_snark.unwrap_or_else(|| {
                         RecursiveSNARK::new(
@@ -288,6 +288,7 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<F, C1LEM<
                     r_snark
                         .prove_step(&pp.pp, &*circuit_primary, &circuit_secondary)
                         .expect("failure to prove Nova step");
+                    circuit_primary.clear_cached_witness();
                     recursive_snark = Some(r_snark);
                 }
                 recursive_snark

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -279,7 +279,9 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<F, C1LEM<
                 });
 
                 for (i, (_, step)) in cc.iter().enumerate() {
-                    prove_step(i, &step.lock().unwrap());
+                    let mut step = step.lock().unwrap();
+                    prove_step(i, &step);
+                    step.clear_cached_witness();
                 }
             })
             .unwrap()


### PR DESCRIPTION
The following profiles are from calling `lurk` with `--rc 100` and `--limit 10000` and then proving the following (infinite, but capped) computation:
```lisp
(letrec ((loop (lambda () (loop)))) (loop))
```
Before:
![Captura de tela de 2024-02-08 10-01-40](https://github.com/lurk-lab/lurk-rs/assets/1919110/c569a38b-3847-4c15-93c4-ddeee8775925)

After:
![Captura de tela de 2024-02-08 09-51-35](https://github.com/lurk-lab/lurk-rs/assets/1919110/9a8020ac-d114-4955-a930-ef110811e882)

Note: the memory peak wasn't affected on my weak machine. But if the computation is long enough (so it takes longer to generate the witnesses for all multiframes) and there is a GPU available (so each proving step is faster), used witnesses from earlier multiframes will start being cleared out before new witnesses from later frames are created.