### PR TITLE
chore: fix `udeps` and `rust-version`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,10 +95,8 @@ criterion = "0.5"
 expect-test = "1.4.1"
 hex = "0.4.3"
 statrs = "0.16.0"
-structopt = { version = "0.3", default-features = false }
 tap = "1.0.1"
 tempfile = { workspace = true }
-tracing-test = "0.2"
 
 [build-dependencies]
 vergen = { version = "8", features = ["build", "git", "gitcl"] }

--- a/lurk-macros/Cargo.toml
+++ b/lurk-macros/Cargo.toml
@@ -16,12 +16,16 @@ proc-macro = true
 proc-macro2 = "1.0.66"
 quote = "1.0.31"
 syn = { version = "1.0.109", features = ["derive", "extra-traits", "full"] }
-proptest = { workspace = true }
-proptest-derive = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 anyhow.workspace = true
 bincode = { workspace = true }
 lurk_crate = { path = "../", package = "lurk" }
 pasta_curves = { workspace = true, features = ["repr-c", "serde"] }
+proptest = { workspace = true }
+proptest-derive = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+
+# `cargo udeps` seems unable to detect dev-dependency usage in a proc macro crate
+[package.metadata.cargo-udeps.ignore]
+development = ["anyhow", "bincode", "lurk_crate", "pasta_curves", "proptest", "proptest-derive", "serde"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
 profile = "default"
-channel = "1.75"
+channel = "1.76"
 targets = [ "wasm32-unknown-unknown" ]
 


### PR DESCRIPTION
Closes #1102 and #1108