### PR TITLE
ci: Use configurable `!benchmark` PR comment

### DIFF
--- a/.github/workflows/bench-pr-comment.yml
+++ b/.github/workflows/bench-pr-comment.yml
@@ -9,89 +9,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  cpu-benchmark:
-    name: run fibonacci benchmark
-    runs-on: buildjet-32vcpu-ubuntu-2204
+  benchmark:
+    name: Comparative PR benchmark comment
     if:
       github.event.issue.pull_request
       && github.event.issue.state == 'open'
       && contains(github.event.comment.body, '!benchmark')
       && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: lurk-lab/ci-workflows
-      - uses: ./.github/actions/ci-env
-      # Get base branch of the PR
-      - uses: xt0rted/pull-request-comment-branch@v2
-        id: comment-branch
-      - uses: actions/checkout@v4
-      - name: Checkout PR branch
-        run: gh pr checkout $PR_NUMBER
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.issue.number }}
-      # Install dependencies
-      - name: Install dependencies
-        run: sudo apt-get install -y pkg-config libssl-dev
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Set output type
-        run: |
-          echo "LURK_BENCH_OUTPUT=pr-comment" >> $GITHUB_ENV
-      - uses: cardinalby/export-env-action@v2
-        with:
-          envFile:
-            'benches/bench.env'
-      # Run the comparative benchmark and comment output on the PR
-      - uses: boa-dev/criterion-compare-action@v3
-        with:
-          # Optional. Compare only this benchmark target
-          benchName: "fibonacci"
-          # Needed. The name of the branch to compare with
-          branchName: ${{ steps.comment-branch.outputs.base_ref }}
-
-  gpu-benchmark:
-    name: run fibonacci benchmark on GPU
-    runs-on: [self-hosted, gpu-bench]
-    if:
-      github.event.issue.pull_request
-      && github.event.issue.state == 'open'
-      && contains(github.event.comment.body, '!gpu-benchmark')
-      && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')
-    steps:
-      # Set up GPU env
-      - uses: actions/checkout@v4
-        with:
-          repository: lurk-lab/ci-workflows
-      - uses: ./.github/actions/gpu-setup
-        with:
-          gpu-framework: 'cuda'
-      - uses: ./.github/actions/ci-env
-      # Get base branch of the PR
-      - uses: xt0rted/pull-request-comment-branch@v2
-        id: comment-branch
-      - uses: actions/checkout@v4
-      - name: Checkout PR branch
-        run: gh pr checkout $PR_NUMBER
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.issue.number }}
-      # Install dependencies
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Set output type
-        run: echo "LURK_BENCH_OUTPUT=pr-comment" >> $GITHUB_ENV
-      - uses: cardinalby/export-env-action@v2
-        with:
-          envFile: 'benches/bench.env'
-      # Run the comparative benchmark and comment output on the PR
-      - uses: boa-dev/criterion-compare-action@v3
-        with:
-          # Note: Removing `benchName` causes `criterion` errors: https://github.com/boa-dev/criterion-compare-action#troubleshooting
-          # Optional. Compare only this benchmark target
-          benchName: "fibonacci"
-          # Optional. Features activated in the benchmark
-          features: "cuda"
-          # Needed. The name of the branch to compare with
-          branchName: ${{ steps.comment-branch.outputs.base_ref }}
+    uses: lurk-lab/ci-workflows/.github/workflows/bench-pr-comment.yml@main
+    with:
+      default-runner: "self-hosted,gpu-bench"
+      default-benches: "fibonacci"
+      default-env: "LURK_BENCH_OUTPUT=pr-comment LURK_RC=100,600"


### PR DESCRIPTION
# Configurable `!benchmark` PR comment
Uses the reusable workflow from https://github.com/lurk-lab/ci-workflows/pull/38. This replaces the existing `!gpu-benchmark` command with 
`!benchmark`, as shown in the following examples:
```
!benchmark
```
This will run the default benchmark settings, specified in the workflow file of this PR.
Alternatively: 
```
!benchmark --bench fibonacci --bench end2end --features cuda
LURK_RC=100,600,900
LURK_PERF="fully-sequential"
```
This will run with each of the input benchmarks, features, and env vars.

> [!IMPORTANT]
> - If you want to benchmark with GPU acceleration enabled, you *must* specify `--features cuda` in the comment body (see above example). Otherwise, the benchmarks will still run on the same GPU-equipped benchmark machine, but will run using the CPU only.

## Details
- The previous `!gpu-benchmark` syntax will no longer work. The command must start with `!benchmark`.
- Each benchmark specified with `--bench` will spawn a new CI job, which means they will each output a separate comment.

The default env vars specified in this PR are 
```
LURK_BENCH_OUTPUT=pr-comment
LURK_PERF=100,600
```
If identically named env vars are specified in the `!benchmark` comment, they will overwrite the above defaults.