### PR TITLE
ci: Add nightly typo checker

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -107,3 +107,6 @@ jobs:
 
   rust-version-check:
     uses: lurk-lab/ci-workflows/.github/workflows/rust-version-check.yml@main
+
+  typos:
+    uses: lurk-lab/ci-workflows/.github/workflows/typos.yml@main

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,4 +1,8 @@
 [default]
 extend-ignore-identifiers-re = [
     "[Aa]bomonation",
+    "[Ff]o",
+    "noo",
+    # Ignores e.g. \"Nova_BN256_10_18748ce7ba3dd0e7560ec64983d6b01d84a6303880b3b0b24878133aa1b4a6bb\"
+    "[\".*_.*_.*_.*\\\\\"]"
 ]


### PR DESCRIPTION
Uses the typo checker workflow added in https://github.com/lurk-lab/ci-workflows/pull/29, which opens a PR with typo fixes and comments unsolvable typos in the PR description.

I tested the output of `typos --write-changes` locally, and fixed the false positives with the changes to `_typos.toml`. I'd welcome an alternative to the last regex which is a bit janky.