### PR TITLE
feat: NIVC support for the REPL

### DIFF
--- a/demo/protocol.lurk
+++ b/demo/protocol.lurk
@@ -9,6 +9,7 @@
         (list6 (mk-open-expr hash) (empty-env) :outermost pair (empty-env) :terminal)
         nil)
       (lambda () (> (car pair) 10))))
+  :backend "nova"
   :rc 10
   :descr "demo protocol")
 

--- a/src/cli/backend.rs
+++ b/src/cli/backend.rs
@@ -5,15 +5,18 @@ use serde::Deserialize;
 use crate::field::LanguageField;
 
 #[derive(Clone, Default, Debug, Deserialize, ValueEnum, PartialEq, Eq)]
+#[clap(rename_all = "lowercase")]
 pub(crate) enum Backend {
     #[default]
     Nova,
+    SuperNova,
 }
 
 impl std::fmt::Display for Backend {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Nova => write!(f, "Nova"),
+            Self::SuperNova => write!(f, "SuperNova"),
         }
     }
 }
@@ -22,7 +25,7 @@ impl Backend {
     fn compatible_fields(&self) -> Vec<LanguageField> {
         use LanguageField::{Pallas, BN256};
         match self {
-            Self::Nova => vec![BN256, Pallas],
+            Self::Nova | Self::SuperNova => vec![BN256, Pallas],
         }
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -90,11 +90,11 @@ struct LoadArgs {
     #[clap(long, value_parser)]
     limit: Option<usize>,
 
-    /// Prover backend (defaults to "Nova")
+    /// Prover backend (defaults to "nova")
     #[clap(long, value_enum)]
     backend: Option<Backend>,
 
-    /// Arithmetic field (defaults to "BN256")
+    /// Arithmetic field (defaults to "bn256")
     #[clap(long, value_enum)]
     field: Option<LanguageField>,
 
@@ -203,11 +203,11 @@ struct ReplArgs {
     #[clap(long, value_parser)]
     limit: Option<usize>,
 
-    /// Prover backend (defaults to "Nova")
+    /// Prover backend (defaults to "nova")
     #[clap(long, value_enum)]
     backend: Option<Backend>,
 
-    /// Arithmetic field (defaults to "BN256")
+    /// Arithmetic field (defaults to "bn256")
     #[clap(long, value_enum)]
     field: Option<LanguageField>,
 
@@ -422,7 +422,7 @@ struct VerifyArgs {
     #[clap(value_parser)]
     proof_key: String,
 
-    /// Arithmetic field (defaults to "BN256")
+    /// Arithmetic field (defaults to "bn256")
     #[clap(long, value_enum)]
     field: Option<LanguageField>,
 
@@ -445,7 +445,7 @@ struct InspectArgs {
     #[clap(value_parser)]
     proof_key: String,
 
-    /// Arithmetic field (defaults to "BN256")
+    /// Arithmetic field (defaults to "bn256")
     #[clap(long, value_enum)]
     field: Option<LanguageField>,
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -36,6 +36,7 @@ use crate::tag::{ContTag, ExprTag, Op1, Op2};
 #[derive(Default, Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ValueEnum)]
 #[cfg_attr(not(target_arch = "wasm32"), derive(Arbitrary))]
 #[cfg_attr(not(target_arch = "wasm32"), serde_test)]
+#[clap(rename_all = "lowercase")]
 pub enum LanguageField {
     /// The BN256 scalar field,
     #[default]

--- a/src/public_parameters/mod.rs
+++ b/src/public_parameters/mod.rs
@@ -83,7 +83,7 @@ where
     disk_cache.read_bytes(instance, &mut bytes).and_then(|()| {
         if let Some((pp, remaining)) = unsafe { decode::<NovaCircuitShape<F>>(&mut bytes) } {
             assert!(remaining.is_empty());
-            eprintln!("Using disk-cached public params for {}", instance.key());
+            info!("Using disk-cached public params for {}", instance.key());
             Ok(pp.clone())
         } else {
             Err(Error::Cache("failed to decode bytes".into()))
@@ -136,7 +136,7 @@ where
     let pp = if let (Ok(circuit_params_vec), Ok(aux_params)) =
         (maybe_circuit_params_vec, maybe_aux_params)
     {
-        println!("generating public params");
+        info!("generating public params");
 
         let pp = SuperNovaPublicParams::<F>::from_parts_unchecked(circuit_params_vec, aux_params);
 
@@ -145,7 +145,7 @@ where
             pk_and_vk: OnceCell::new(),
         }
     } else {
-        println!("generating running claim params");
+        info!("generating running claim params");
         let pp = default(instance_primary);
 
         let (circuit_params_vec, aux_params) = pp.pp.into_parts();


### PR DESCRIPTION
* Extend LurkProof and ProtocolProof to encode SuperNova proofs as well
* Add a new Backend::SuperNova variant
* Code the plumbing for SuperNova proof generation
* Extend the protocol API to handle a backend argument so it can use SuperNova as well

Closes #533