### PR TITLE
chore: simplify and homogenize proving code for Nova and SuperNova proofs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,6 @@ stable_deref_trait = "1.2.0"
 thiserror = { workspace = true }
 abomonation = { workspace = true }
 abomonation_derive = { version = "0.1.0", package = "abomonation_derive_ng" }
-crossbeam = "0.8.2"
 byteorder = "1.4.3"
 circom-scotia = { git = "https://github.com/lurk-lab/circom-scotia", branch = "dev" }
 sha2 = { version = "0.10.2" }


### PR DESCRIPTION
* Remove code duplication in Nova proving
* Factor out and reuse debugging code that was triggered only for Nova proving without "parallel steps"
* Remove the cloning of recursive snarks on SuperNova
* Drop `crossbeam` dependency because `crossbeam::thread::scope` has been soft-deprecated
  in favor of `std::thread::scope` since Rust 1.63 due to performance reasons