### PR TITLE
Update sha256 coprocessor discarded bits

### DIFF
--- a/src/coprocessor/sha256.rs
+++ b/src/coprocessor/sha256.rs
@@ -137,9 +137,7 @@ fn discard_bits<Scalar: LurkField>(bytes: &mut [u8]) {
     let full_bytes_to_zero = bits_to_zero / 8;
     let partial_bits_to_zero = bits_to_zero % 8;
 
-    for i in 0..full_bytes_to_zero {
-        bytes[i] = 0;
-    }
+    bytes[..full_bytes_to_zero].iter_mut().for_each(|b| *b = 0);
 
     if partial_bits_to_zero > 0 {
         let mask = 0xFF >> partial_bits_to_zero;


### PR DESCRIPTION
Previously, the pallas curve had a capacity of 254 bits. The new bn256 curve has a capacity of 253 bits. This makes the pack_bits gadget used by sha256 coprocessor drop the three most significant bits of the output instead of just two.

This commit updates the coprocessor's evaluate_simple implementation to drop the three most significant bits of the hash output to avoid a potential panic caused by a mismatch between the synthesize and evaluate outputs.