### PR TITLE
fix: properly reduce commitment hash expressions on call and chain meta commands

### DIFF
--- a/demo/chained-functional-commitment.lurk
+++ b/demo/chained-functional-commitment.lurk
@@ -25,7 +25,7 @@
 
 ;; Now let's chain another call to the new head, adding 12 to the counter.
 
-!(chain 0x1d10fb6dea15a5865565d571efbcaf535750ab93ba4d9018bd6b7b803e86d986 12)
+!(chain (comm 0x1d10fb6dea15a5865565d571efbcaf535750ab93ba4d9018bd6b7b803e86d986) 12)
 
 ;; Now the counter is 21, and we have a new head commitment.
 


### PR DESCRIPTION
* Fix/simplify `get_comm_hash` and adjust places where it's called
* Add a variation to `demo/chained-functional-commitment.lurk` to exercise this fix

Closes #1125