### PR TITLE
chore: default to SuperNova backend

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -3,6 +3,6 @@ extend-ignore-identifiers-re = [
     "[Aa]bomonation",
     "[Ff]o",
     "noo",
-    # Ignores e.g. \"Nova_BN256_10_18748ce7ba3dd0e7560ec64983d6b01d84a6303880b3b0b24878133aa1b4a6bb\"
+    # Ignores e.g. \"supernova_bn256_10_18748ce7ba3dd0e7560ec64983d6b01d84a6303880b3b0b24878133aa1b4a6bb\"
     "[\".*_.*_.*_.*\\\\\"]"
 ]

--- a/demo/bank.lurk
+++ b/demo/bank.lurk
@@ -202,7 +202,7 @@ ledger2
 
 ;; We can verify the proof..
 
-!(verify "Nova_BN256_10_11882126c5f0dd9a94f76ff58ea5c499cfe2364162585c320c55f53651e16ffd")
+!(verify "supernova_bn256_10_11882126c5f0dd9a94f76ff58ea5c499cfe2364162585c320c55f53651e16ffd")
 
 ;; Unfortunately, this functional commitment doesn't let us maintain state.
 ;; Let's turn our single-transaction function into a chained function.
@@ -223,7 +223,7 @@ ledger2
 
 !(prove)
 
-!(verify "Nova_BN256_10_0b72908859e73ee3014067a5eaa557a995aea262cfb5f3621922024a176b8281")
+!(verify "supernova_bn256_10_0b72908859e73ee3014067a5eaa557a995aea262cfb5f3621922024a176b8281")
 
 ;; Then we can transfer 5 more, proceeding from the new head of the chain.
 
@@ -231,7 +231,7 @@ ledger2
 
 !(prove)
 
-!(verify "Nova_BN256_10_0d8159faab0d85855d4cf53c7e36a2357a1766a1540afbafb0ef93d7e1537ca8")
+!(verify "supernova_bn256_10_0d8159faab0d85855d4cf53c7e36a2357a1766a1540afbafb0ef93d7e1537ca8")
 
 ;; And once more, this time we'll transfer 20 from Turing to Church.
 
@@ -239,4 +239,4 @@ ledger2
 
 !(prove)
 
-!(verify "Nova_BN256_10_0a253296edb4d6c204edd92e63176efed7c30e9f5928b52ba9be2b3f2e6e8b08")
+!(verify "supernova_bn256_10_0a253296edb4d6c204edd92e63176efed7c30e9f5928b52ba9be2b3f2e6e8b08")

--- a/demo/chained-functional-commitment.lurk
+++ b/demo/chained-functional-commitment.lurk
@@ -21,7 +21,7 @@
 
 ;; We can verify the proof.
 
-!(verify "Nova_BN256_10_0f54f9e56fa6c436618597c971daa7b525ad80ac48be11226284fd4f8167e60a")
+!(verify "supernova_bn256_10_0f54f9e56fa6c436618597c971daa7b525ad80ac48be11226284fd4f8167e60a")
 
 ;; Now let's chain another call to the new head, adding 12 to the counter.
 
@@ -35,7 +35,7 @@
 
 ;; And verify.
 
-!(verify "Nova_BN256_10_281771b7af2f96cac51cb7579d94f0a6f56e9a9d951b753f8514b2b4ec6ce4db")
+!(verify "supernova_bn256_10_281771b7af2f96cac51cb7579d94f0a6f56e9a9d951b753f8514b2b4ec6ce4db")
 
 ;; One more time, we'll add 14 to the head commitment's internal state.
 
@@ -49,7 +49,7 @@
 
 ;; Verify.
 
-!(verify "Nova_BN256_10_22ab68c1fa6e75f54d213a3ada71edd21331bf58826263a79e3fdd32f1c4c62d")
+!(verify "supernova_bn256_10_22ab68c1fa6e75f54d213a3ada71edd21331bf58826263a79e3fdd32f1c4c62d")
 
 ;; Repeat indefinitely.
 

--- a/demo/functional-commitment.lurk
+++ b/demo/functional-commitment.lurk
@@ -18,12 +18,12 @@
 
 ;; We can inspect the input/output expressions of the proof.
 
-!(inspect "Nova_BN256_10_15c837e5040ac70c00030c228b61fde2c164d930ba6ea396353b3cfcaa16609d")
+!(inspect "supernova_bn256_10_15c837e5040ac70c00030c228b61fde2c164d930ba6ea396353b3cfcaa16609d")
 
 ;; Or the full proof claim
 
-!(inspect-full "Nova_BN256_10_15c837e5040ac70c00030c228b61fde2c164d930ba6ea396353b3cfcaa16609d")
+!(inspect-full "supernova_bn256_10_15c837e5040ac70c00030c228b61fde2c164d930ba6ea396353b3cfcaa16609d")
 
 ;; Finally, and most importantly, we can verify the proof.
 
-!(verify "Nova_BN256_10_15c837e5040ac70c00030c228b61fde2c164d930ba6ea396353b3cfcaa16609d")
+!(verify "supernova_bn256_10_15c837e5040ac70c00030c228b61fde2c164d930ba6ea396353b3cfcaa16609d")

--- a/demo/vdf.lurk
+++ b/demo/vdf.lurk
@@ -51,7 +51,7 @@
 
 !(prove)
 
-!(verify "Nova_BN256_10_2b96123c7e47229622beeef7080c005e9d18ed0cfd2c0b7f06e1d9f1cfcf83a8")
+!(verify "supernova_bn256_10_2b96123c7e47229622beeef7080c005e9d18ed0cfd2c0b7f06e1d9f1cfcf83a8")
 
 !(def timelock-encrypt (lambda (secret-key plaintext rounds)
                           (let ((ciphertext (+ secret-key plaintext))

--- a/src/cli/backend.rs
+++ b/src/cli/backend.rs
@@ -7,16 +7,16 @@ use crate::field::LanguageField;
 #[derive(Clone, Default, Debug, Deserialize, ValueEnum, PartialEq, Eq)]
 #[clap(rename_all = "lowercase")]
 pub(crate) enum Backend {
-    #[default]
     Nova,
+    #[default]
     SuperNova,
 }
 
 impl std::fmt::Display for Backend {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Nova => write!(f, "Nova"),
-            Self::SuperNova => write!(f, "SuperNova"),
+            Self::Nova => write!(f, "nova"),
+            Self::SuperNova => write!(f, "supernova"),
         }
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -90,7 +90,7 @@ struct LoadArgs {
     #[clap(long, value_parser)]
     limit: Option<usize>,
 
-    /// Prover backend (defaults to "nova")
+    /// Prover backend (defaults to "supernova")
     #[clap(long, value_enum)]
     backend: Option<Backend>,
 
@@ -203,7 +203,7 @@ struct ReplArgs {
     #[clap(long, value_parser)]
     limit: Option<usize>,
 
-    /// Prover backend (defaults to "nova")
+    /// Prover backend (defaults to "supernova")
     #[clap(long, value_enum)]
     backend: Option<Backend>,
 

--- a/src/cli/repl/meta_cmd.rs
+++ b/src/cli/repl/meta_cmd.rs
@@ -350,7 +350,7 @@ where
         ],
         example: &[
             "!(prove '(1 2 3))",
-            "!(verify \"Nova_BN256_10_048476fa5e4804639fe4ccfe73d43bf96da6183f670f0b08e4ac8c82bf8efa47\")",
+            "!(verify \"supernova_bn256_10_048476fa5e4804639fe4ccfe73d43bf96da6183f670f0b08e4ac8c82bf8efa47\")",
             "!(open 0x048476fa5e4804639fe4ccfe73d43bf96da6183f670f0b08e4ac8c82bf8efa47)",
         ],
         run: |repl, args, _path| {
@@ -369,7 +369,7 @@ where
         description: &["Verify proof key <string> and print the result."],
         example: &[
             "!(prove '(1 2 3))",
-            "!(verify \"Nova_BN256_10_048476fa5e4804639fe4ccfe73d43bf96da6183f670f0b08e4ac8c82bf8efa47\")",
+            "!(verify \"supernova_bn256_10_048476fa5e4804639fe4ccfe73d43bf96da6183f670f0b08e4ac8c82bf8efa47\")",
             "!(open 0x048476fa5e4804639fe4ccfe73d43bf96da6183f670f0b08e4ac8c82bf8efa47)",
         ],
         run: |repl, args, _path| {
@@ -610,7 +610,7 @@ where
         description: &[],
         example: &[
             "!(prove '(1 2 3))",
-            "!(inspect \"Nova_Pallas_10_002cd7baecd8e781d217cd1eb8b67d4f890005fd3763541e37ce49550bd9f4bf\")",
+            "!(inspect \"supernova_bn256_10_048476fa5e4804639fe4ccfe73d43bf96da6183f670f0b08e4ac8c82bf8efa47\")",
         ],
         run: |repl, args, _path| {
             Self::inspect(repl, args, false)
@@ -624,7 +624,7 @@ where
         description: &[],
         example: &[
             "!(prove '(1 2 3))",
-            "!(inspect-full \"Nova_Pallas_10_002cd7baecd8e781d217cd1eb8b67d4f890005fd3763541e37ce49550bd9f4bf\")",
+            "!(inspect-full \"supernova_bn256_10_048476fa5e4804639fe4ccfe73d43bf96da6183f670f0b08e4ac8c82bf8efa47\")",
         ],
         run: |repl, args, _path| {
             Self::inspect(repl, args, true)

--- a/src/field.rs
+++ b/src/field.rs
@@ -52,10 +52,10 @@ pub enum LanguageField {
 impl std::fmt::Display for LanguageField {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Pallas => write!(f, "Pallas"),
-            Self::Vesta => write!(f, "Vesta"),
-            Self::BN256 => write!(f, "BN256"),
-            Self::Grumpkin => write!(f, "Grumpkin"),
+            Self::Pallas => write!(f, "pallas"),
+            Self::Vesta => write!(f, "vesta"),
+            Self::BN256 => write!(f, "bn256"),
+            Self::Grumpkin => write!(f, "grumpkin"),
         }
     }
 }

--- a/tests/lurk-cli-tests.rs
+++ b/tests/lurk-cli-tests.rs
@@ -55,7 +55,7 @@ fn test_prove_and_verify() {
 
     let mut file = File::create(lurk_file.clone()).unwrap();
     file.write_all(b"!(prove (+ 1 1))\n").unwrap();
-    file.write_all(b"!(verify \"Nova_BN256_10_18748ce7ba3dd0e7560ec64983d6b01d84a6303880b3b0b24878133aa1b4a6bb\")\n").unwrap();
+    file.write_all(b"!(verify \"supernova_bn256_10_18748ce7ba3dd0e7560ec64983d6b01d84a6303880b3b0b24878133aa1b4a6bb\")\n").unwrap();
 
     let mut cmd = lurk_cmd();
     cmd.env("LURK_PERF", "max-parallel-simple");


### PR DESCRIPTION
* Change Backend and LanguageField formatting so it matches the CLI formatting
* Adjust occurrences of hardcoded proof keys accordingly

Addresses @huitseeker's https://github.com/lurk-lab/lurk-rs/pull/1119#pullrequestreview-1880373514 comment