### PR TITLE
refactor: Refactor namespace allocations using `ns!` macro

### DIFF
--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -44,20 +44,16 @@ mod tests {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
         for x in 0..128 {
-            let alloc_a =
-                AllocatedNum::alloc(&mut cs.namespace(|| x.to_string()), || Ok(Fr::from(x)))
-                    .unwrap();
-            let bits = alloc_a
-                .to_bits_le(&mut cs.namespace(|| format!("bits_{x}")))
-                .unwrap();
+            let alloc_a = AllocatedNum::alloc(ns!(cs, x.to_string()), || Ok(Fr::from(x))).unwrap();
+            let bits = alloc_a.to_bits_le(ns!(cs, format!("bits_{x}"))).unwrap();
             let popcount_result =
-                AllocatedNum::alloc(&mut cs.namespace(|| format!("alloc popcount {x}")), || {
+                AllocatedNum::alloc(ns!(cs, format!("alloc popcount {x}")), || {
                     Ok(Fr::from(u64::from(x.count_ones())))
                 })
                 .unwrap();
 
             popcount_equal(
-                &mut cs.namespace(|| format!("popcount {x}")),
+                ns!(cs, format!("popcount {x}")),
                 &bits,
                 popcount_result.get_variable(),
             );
@@ -69,9 +65,8 @@ mod tests {
     #[test]
     fn test_enforce_pack() {
         let mut cs = TestConstraintSystem::<Fr>::new();
-        let a_num =
-            AllocatedNum::alloc_infallible(&mut cs.namespace(|| "a num"), || Fr::from_u64(42));
-        let bits = a_num.to_bits_le(&mut cs.namespace(|| "bits")).unwrap();
+        let a_num = AllocatedNum::alloc_infallible(ns!(cs, "a num"), || Fr::from_u64(42));
+        let bits = a_num.to_bits_le(ns!(cs, "bits")).unwrap();
         implies_pack(&mut cs, &Boolean::Constant(true), &bits, &a_num);
         assert!(cs.is_satisfied());
     }

--- a/src/circuit/gadgets/data.rs
+++ b/src/circuit/gadgets/data.rs
@@ -42,10 +42,7 @@ impl ExprTag {
         &self,
         cs: &mut CS,
     ) -> AllocatedNum<F> {
-        allocate_constant(
-            &mut cs.namespace(|| format!("{self:?} tag")),
-            self.to_field(),
-        )
+        allocate_constant(ns!(cs, format!("{self:?} tag")), self.to_field())
     }
 }
 
@@ -55,7 +52,7 @@ impl ContTag {
         cs: &mut CS,
     ) -> AllocatedNum<F> {
         allocate_constant(
-            &mut cs.namespace(|| format!("{self:?} base continuation tag")),
+            ns!(cs, format!("{self:?} base continuation tag")),
             self.to_field(),
         )
     }
@@ -66,10 +63,7 @@ impl Op1 {
         &self,
         cs: &mut CS,
     ) -> AllocatedNum<F> {
-        allocate_constant(
-            &mut cs.namespace(|| format!("{self:?} tag")),
-            self.to_field(),
-        )
+        allocate_constant(ns!(cs, format!("{self:?} tag")), self.to_field())
     }
 }
 
@@ -78,9 +72,6 @@ impl Op2 {
         &self,
         cs: &mut CS,
     ) -> AllocatedNum<F> {
-        allocate_constant(
-            &mut cs.namespace(|| format!("{self:?} tag")),
-            self.to_field(),
-        )
+        allocate_constant(ns!(cs, format!("{self:?} tag")), self.to_field())
     }
 }

--- a/src/circuit/gadgets/macros.rs
+++ b/src/circuit/gadgets/macros.rs
@@ -209,11 +209,11 @@ macro_rules! or {
         )
     };
     ($cs:expr, $a:expr, $b:expr, $c:expr, $($x:expr),+) => {{
-        let or_tmp_cs_ =  &mut $cs.namespace(|| format!("or({})", stringify!(vec![$a, $b, $c, $($x),*])));
+        let or_tmp_cs_ =  ns!($cs, format!("or({})", stringify!(vec![$a, $b, $c, $($x),*])));
         bellpepper::gadgets::boolean_utils::or_v(or_tmp_cs_, &[$a, $b, $c, $($x),*])
     }};
     ($cs:expr, $a:expr, $($x:expr),+) => {{
-        let or_tmp_cs_ =  &mut $cs.namespace(|| format!("or {}", stringify!(vec![$a, $($x),*])));
+        let or_tmp_cs_ =  ns!($cs, format!("or {}", stringify!(vec![$a, $($x),*])));
         let or_tmp_ = or!(or_tmp_cs_, $($x),*)?;
         or!(or_tmp_cs_, $a, &or_tmp_)
     }};

--- a/src/coprocessor/gadgets.rs
+++ b/src/coprocessor/gadgets.rs
@@ -146,13 +146,7 @@ where
         .rev()
         .enumerate()
         .try_fold(init, |acc, (i, ptr)| {
-            construct_cons(
-                &mut cs.namespace(|| format!("cons {i}")),
-                g,
-                store,
-                ptr.borrow(),
-                &acc,
-            )
+            construct_cons(ns!(cs, format!("cons {i}")), g, store, ptr.borrow(), &acc)
         })
 }
 
@@ -237,13 +231,13 @@ pub(crate) fn deconstruct_env<F: LurkField, CS: ConstraintSystem<F>>(
         }
     };
 
-    let key_sym_hash = AllocatedNum::alloc_infallible(&mut cs.namespace(|| "key_sym_hash"), || a);
-    let val_tag = AllocatedNum::alloc_infallible(&mut cs.namespace(|| "val_tag"), || b);
-    let val_hash = AllocatedNum::alloc_infallible(&mut cs.namespace(|| "val_hash"), || c);
-    let new_env_hash = AllocatedNum::alloc_infallible(&mut cs.namespace(|| "new_env_hash"), || d);
+    let key_sym_hash = AllocatedNum::alloc_infallible(ns!(cs, "key_sym_hash"), || a);
+    let val_tag = AllocatedNum::alloc_infallible(ns!(cs, "val_tag"), || b);
+    let val_hash = AllocatedNum::alloc_infallible(ns!(cs, "val_hash"), || c);
+    let new_env_hash = AllocatedNum::alloc_infallible(ns!(cs, "new_env_hash"), || d);
 
     let hash = hash_poseidon(
-        &mut cs.namespace(|| "hash"),
+        ns!(cs, "hash"),
         vec![
             key_sym_hash.clone(),
             val_tag.clone(),
@@ -255,7 +249,7 @@ pub(crate) fn deconstruct_env<F: LurkField, CS: ConstraintSystem<F>>(
 
     let val = AllocatedPtr::from_parts(val_tag, val_hash);
 
-    implies_equal(&mut cs.namespace(|| "hash equality"), not_dummy, env, &hash);
+    implies_equal(ns!(cs, "hash equality"), not_dummy, env, &hash);
 
     Ok((key_sym_hash, val, new_env_hash))
 }
@@ -289,15 +283,13 @@ pub(crate) fn deconstruct_provenance<F: LurkField, CS: ConstraintSystem<F>>(
         }
     };
 
-    let query_cons_hash =
-        AllocatedNum::alloc_infallible(&mut cs.namespace(|| "query_cons_hash"), || a);
-    let res_tag = AllocatedNum::alloc_infallible(&mut cs.namespace(|| "res_tag"), || b);
-    let res_hash = AllocatedNum::alloc_infallible(&mut cs.namespace(|| "res_hash"), || c);
-    let deps_tuple_hash =
-        AllocatedNum::alloc_infallible(&mut cs.namespace(|| "deps_tuple_hash"), || d);
+    let query_cons_hash = AllocatedNum::alloc_infallible(ns!(cs, "query_cons_hash"), || a);
+    let res_tag = AllocatedNum::alloc_infallible(ns!(cs, "res_tag"), || b);
+    let res_hash = AllocatedNum::alloc_infallible(ns!(cs, "res_hash"), || c);
+    let deps_tuple_hash = AllocatedNum::alloc_infallible(ns!(cs, "deps_tuple_hash"), || d);
 
     let hash = hash_poseidon(
-        &mut cs.namespace(|| "hash"),
+        ns!(cs, "hash"),
         vec![
             query_cons_hash.clone(),
             res_tag.clone(),
@@ -309,12 +301,7 @@ pub(crate) fn deconstruct_provenance<F: LurkField, CS: ConstraintSystem<F>>(
 
     let res = AllocatedPtr::from_parts(res_tag, res_hash);
 
-    implies_equal(
-        &mut cs.namespace(|| "hash equality"),
-        not_dummy,
-        provenance,
-        &hash,
-    );
+    implies_equal(ns!(cs, "hash equality"), not_dummy, provenance, &hash);
 
     Ok((query_cons_hash, res, deps_tuple_hash))
 }
@@ -358,11 +345,11 @@ pub(crate) fn deconstruct_tuple2<F: LurkField, CS: ConstraintSystem<F>>(
         (ZPtr::dummy(), ZPtr::dummy())
     };
 
-    let a = AllocatedPtr::alloc_infallible(&mut cs.namespace(|| "a"), || a);
-    let b = AllocatedPtr::alloc_infallible(&mut cs.namespace(|| "b"), || b);
+    let a = AllocatedPtr::alloc_infallible(ns!(cs, "a"), || a);
+    let b = AllocatedPtr::alloc_infallible(ns!(cs, "b"), || b);
 
     let hash = hash_poseidon(
-        &mut cs.namespace(|| "hash"),
+        ns!(cs, "hash"),
         vec![
             a.tag().clone(),
             a.hash().clone(),
@@ -372,12 +359,7 @@ pub(crate) fn deconstruct_tuple2<F: LurkField, CS: ConstraintSystem<F>>(
         store.poseidon_cache.constants.c4(),
     )?;
 
-    implies_equal(
-        &mut cs.namespace(|| "hash equality"),
-        not_dummy,
-        tuple.hash(),
-        &hash,
-    );
+    implies_equal(ns!(cs, "hash equality"), not_dummy, tuple.hash(), &hash);
 
     Ok((a, b))
 }
@@ -401,12 +383,12 @@ pub(crate) fn deconstruct_tuple3<F: LurkField, CS: ConstraintSystem<F>>(
         (ZPtr::dummy(), ZPtr::dummy(), ZPtr::dummy())
     };
 
-    let a = AllocatedPtr::alloc_infallible(&mut cs.namespace(|| "a"), || a);
-    let b = AllocatedPtr::alloc_infallible(&mut cs.namespace(|| "b"), || b);
-    let c = AllocatedPtr::alloc_infallible(&mut cs.namespace(|| "c"), || c);
+    let a = AllocatedPtr::alloc_infallible(ns!(cs, "a"), || a);
+    let b = AllocatedPtr::alloc_infallible(ns!(cs, "b"), || b);
+    let c = AllocatedPtr::alloc_infallible(ns!(cs, "c"), || c);
 
     let hash = hash_poseidon(
-        &mut cs.namespace(|| "hash"),
+        ns!(cs, "hash"),
         vec![
             a.tag().clone(),
             a.hash().clone(),
@@ -418,12 +400,7 @@ pub(crate) fn deconstruct_tuple3<F: LurkField, CS: ConstraintSystem<F>>(
         store.poseidon_cache.constants.c6(),
     )?;
 
-    implies_equal(
-        &mut cs.namespace(|| "hash equality"),
-        not_dummy,
-        tuple.hash(),
-        &hash,
-    );
+    implies_equal(ns!(cs, "hash equality"), not_dummy, tuple.hash(), &hash);
 
     Ok((a, b, c))
 }
@@ -460,13 +437,13 @@ pub(crate) fn deconstruct_tuple4<F: LurkField, CS: ConstraintSystem<F>>(
         (ZPtr::dummy(), ZPtr::dummy(), ZPtr::dummy(), ZPtr::dummy())
     };
 
-    let a = AllocatedPtr::alloc_infallible(&mut cs.namespace(|| "a"), || a);
-    let b = AllocatedPtr::alloc_infallible(&mut cs.namespace(|| "b"), || b);
-    let c = AllocatedPtr::alloc_infallible(&mut cs.namespace(|| "c"), || c);
-    let d = AllocatedPtr::alloc_infallible(&mut cs.namespace(|| "d"), || d);
+    let a = AllocatedPtr::alloc_infallible(ns!(cs, "a"), || a);
+    let b = AllocatedPtr::alloc_infallible(ns!(cs, "b"), || b);
+    let c = AllocatedPtr::alloc_infallible(ns!(cs, "c"), || c);
+    let d = AllocatedPtr::alloc_infallible(ns!(cs, "d"), || d);
 
     let hash = hash_poseidon(
-        &mut cs.namespace(|| "hash"),
+        ns!(cs, "hash"),
         vec![
             a.tag().clone(),
             a.hash().clone(),
@@ -480,12 +457,7 @@ pub(crate) fn deconstruct_tuple4<F: LurkField, CS: ConstraintSystem<F>>(
         store.poseidon_cache.constants.c8(),
     )?;
 
-    implies_equal(
-        &mut cs.namespace(|| "hash equality"),
-        not_dummy,
-        tuple.hash(),
-        &hash,
-    );
+    implies_equal(ns!(cs, "hash equality"), not_dummy, tuple.hash(), &hash);
 
     Ok((a, b, c, d))
 }
@@ -512,29 +484,28 @@ pub(crate) fn car_cdr<F: LurkField, CS: ConstraintSystem<F>>(
     let nil = g.alloc_ptr(cs, &store.intern_nil(), store);
     let empty_str = g.alloc_ptr(cs, &store.intern_string(""), store);
 
-    let car = AllocatedPtr::alloc_infallible(&mut cs.namespace(|| "car"), || car);
-    let cdr = AllocatedPtr::alloc_infallible(&mut cs.namespace(|| "cdr"), || cdr);
+    let car = AllocatedPtr::alloc_infallible(ns!(cs, "car"), || car);
+    let cdr = AllocatedPtr::alloc_infallible(ns!(cs, "cdr"), || cdr);
 
-    let data_is_nil = data.alloc_equal(&mut cs.namespace(|| "data is nil"), &nil)?;
+    let data_is_nil = data.alloc_equal(ns!(cs, "data is nil"), &nil)?;
 
-    let data_is_empty_str =
-        data.alloc_equal(&mut cs.namespace(|| "data is empty str"), &empty_str)?;
+    let data_is_empty_str = data.alloc_equal(ns!(cs, "data is empty str"), &empty_str)?;
 
     {
         // when data is nil, we enforce that car and cdr are both nil
         let not_dummy_and_data_is_nil = Boolean::and(
-            &mut cs.namespace(|| "not dummy and data is nil"),
+            ns!(cs, "not dummy and data is nil"),
             not_dummy,
             &data_is_nil,
         )?;
 
         car.implies_ptr_equal(
-            &mut cs.namespace(|| "data is nil implies car is nil"),
+            ns!(cs, "data is nil implies car is nil"),
             &not_dummy_and_data_is_nil,
             &nil,
         );
         cdr.implies_ptr_equal(
-            &mut cs.namespace(|| "data is nil implies cdr is nil"),
+            ns!(cs, "data is nil implies cdr is nil"),
             &not_dummy_and_data_is_nil,
             &nil,
         );
@@ -544,18 +515,18 @@ pub(crate) fn car_cdr<F: LurkField, CS: ConstraintSystem<F>>(
         // when data is the empty string, we enforce that car is nil and cdr is
         // the empty string
         let not_dummy_and_data_is_empty_str = Boolean::and(
-            &mut cs.namespace(|| "not dummy and data is empty str"),
+            ns!(cs, "not dummy and data is empty str"),
             not_dummy,
             &data_is_empty_str,
         )?;
 
         car.implies_ptr_equal(
-            &mut cs.namespace(|| "data is empty str implies car is nil"),
+            ns!(cs, "data is empty str implies car is nil"),
             &not_dummy_and_data_is_empty_str,
             &nil,
         );
         cdr.implies_ptr_equal(
-            &mut cs.namespace(|| "data is empty str implies cdr is empty str"),
+            ns!(cs, "data is empty str implies cdr is empty str"),
             &not_dummy_and_data_is_empty_str,
             &empty_str,
         );
@@ -563,7 +534,7 @@ pub(crate) fn car_cdr<F: LurkField, CS: ConstraintSystem<F>>(
 
     // data is not empty: it's not nil and it's not the empty string
     let data_is_not_empty = Boolean::and(
-        &mut cs.namespace(|| "data is not empty"),
+        ns!(cs, "data is not empty"),
         &data_is_nil.not(),
         &data_is_empty_str.not(),
     )?;
@@ -571,13 +542,13 @@ pub(crate) fn car_cdr<F: LurkField, CS: ConstraintSystem<F>>(
     {
         // when data is not empty, we enforce hash equality
         let not_dumy_and_data_is_not_empty = Boolean::and(
-            &mut cs.namespace(|| "not dummy and data is not empty"),
+            ns!(cs, "not dummy and data is not empty"),
             not_dummy,
             &data_is_not_empty,
         )?;
 
         let hash = hash_poseidon(
-            &mut cs.namespace(|| "hash"),
+            ns!(cs, "hash"),
             vec![
                 car.tag().clone(),
                 car.hash().clone(),
@@ -588,7 +559,7 @@ pub(crate) fn car_cdr<F: LurkField, CS: ConstraintSystem<F>>(
         )?;
 
         implies_equal(
-            &mut cs.namespace(|| "data is not empty implies hash equality"),
+            ns!(cs, "data is not empty implies hash equality"),
             &not_dumy_and_data_is_not_empty,
             data.hash(),
             &hash,
@@ -667,20 +638,12 @@ pub fn chain_car_cdr<F: LurkField, CS: ConstraintSystem<F>>(
     let mut cdr = data.clone();
     let mut length = g.alloc_const_cloned(cs, F::ZERO);
     for i in 0..n {
-        let (car, new_cdr, not_empty) = car_cdr(
-            &mut cs.namespace(|| format!("car_cdr {i}")),
-            g,
-            store,
-            not_dummy,
-            &cdr,
-        )?;
+        let (car, new_cdr, not_empty) =
+            car_cdr(ns!(cs, format!("car_cdr {i}")), g, store, not_dummy, &cdr)?;
         cars.push(car);
         cdr = new_cdr;
-        let not_empty_num = boolean_to_num(
-            &mut cs.namespace(|| format!("not_empty_num {i}")),
-            &not_empty,
-        )?;
-        length = length.add(&mut cs.namespace(|| format!("length {i}")), &not_empty_num)?;
+        let not_empty_num = boolean_to_num(ns!(cs, format!("not_empty_num {i}")), &not_empty)?;
+        length = length.add(ns!(cs, format!("length {i}")), &not_empty_num)?;
     }
     Ok((cars, cdr, length))
 }
@@ -729,35 +692,19 @@ mod test {
         let nil_tag = nil.tag();
         let a_nil = g.alloc_ptr(&mut cs, &nil, &store);
 
-        let nil2 = construct_tuple2(
-            &mut cs.namespace(|| "nil2"),
-            &g,
-            &store,
-            nil_tag,
-            &a_nil,
-            &a_nil,
-        )
-        .unwrap();
+        let nil2 = construct_tuple2(ns!(cs, "nil2"), &g, &store, nil_tag, &a_nil, &a_nil).unwrap();
         let nil2_ptr = intern_ptrs!(store, *nil_tag, nil, nil);
         let z_nil2_ptr = store.hash_ptr(&nil2_ptr);
         assert_eq!(a_ptr_as_z_ptr(&nil2), Some(z_nil2_ptr));
 
-        let nil3 = construct_tuple3(
-            &mut cs.namespace(|| "nil3"),
-            &g,
-            &store,
-            nil_tag,
-            &a_nil,
-            &a_nil,
-            &a_nil,
-        )
-        .unwrap();
+        let nil3 =
+            construct_tuple3(ns!(cs, "nil3"), &g, &store, nil_tag, &a_nil, &a_nil, &a_nil).unwrap();
         let nil3_ptr = intern_ptrs!(store, *nil_tag, nil, nil, nil);
         let z_nil3_ptr = store.hash_ptr(&nil3_ptr);
         assert_eq!(a_ptr_as_z_ptr(&nil3), Some(z_nil3_ptr));
 
         let nil4 = construct_tuple4(
-            &mut cs.namespace(|| "nil4"),
+            ns!(cs, "nil4"),
             &g,
             &store,
             nil_tag,
@@ -803,41 +750,29 @@ mod test {
 
         let tuple2 = intern_ptrs!(store, nil_tag, nil, nil);
         let z_tuple2 = store.hash_ptr(&tuple2);
-        let a_tuple2 = AllocatedPtr::alloc_infallible(&mut cs.namespace(|| "tuple2"), || z_tuple2);
-        let (a, b) = deconstruct_tuple2(
-            &mut cs.namespace(|| "deconstruct tuple2"),
-            &store,
-            &not_dummy,
-            &a_tuple2,
-        )
-        .unwrap();
+        let a_tuple2 = AllocatedPtr::alloc_infallible(ns!(cs, "tuple2"), || z_tuple2);
+        let (a, b) =
+            deconstruct_tuple2(ns!(cs, "deconstruct tuple2"), &store, &not_dummy, &a_tuple2)
+                .unwrap();
         assert_eq!(a_ptr_as_z_ptr(&a), Some(z_nil));
         assert_eq!(a_ptr_as_z_ptr(&b), Some(z_nil));
 
         let tuple3 = intern_ptrs!(store, nil_tag, nil, nil, nil);
         let z_tuple3 = store.hash_ptr(&tuple3);
-        let a_tuple3 = AllocatedPtr::alloc_infallible(&mut cs.namespace(|| "tuple3"), || z_tuple3);
-        let (a, b, c) = deconstruct_tuple3(
-            &mut cs.namespace(|| "deconstruct tuple3"),
-            &store,
-            &not_dummy,
-            &a_tuple3,
-        )
-        .unwrap();
+        let a_tuple3 = AllocatedPtr::alloc_infallible(ns!(cs, "tuple3"), || z_tuple3);
+        let (a, b, c) =
+            deconstruct_tuple3(ns!(cs, "deconstruct tuple3"), &store, &not_dummy, &a_tuple3)
+                .unwrap();
         assert_eq!(a_ptr_as_z_ptr(&a), Some(z_nil));
         assert_eq!(a_ptr_as_z_ptr(&b), Some(z_nil));
         assert_eq!(a_ptr_as_z_ptr(&c), Some(z_nil));
 
         let tuple4 = intern_ptrs!(store, nil_tag, nil, nil, nil, nil);
         let z_tuple4 = store.hash_ptr(&tuple4);
-        let a_tuple4 = AllocatedPtr::alloc_infallible(&mut cs.namespace(|| "tuple4"), || z_tuple4);
-        let (a, b, c, d) = deconstruct_tuple4(
-            &mut cs.namespace(|| "deconstruct tuple4"),
-            &store,
-            &not_dummy,
-            &a_tuple4,
-        )
-        .unwrap();
+        let a_tuple4 = AllocatedPtr::alloc_infallible(ns!(cs, "tuple4"), || z_tuple4);
+        let (a, b, c, d) =
+            deconstruct_tuple4(ns!(cs, "deconstruct tuple4"), &store, &not_dummy, &a_tuple4)
+                .unwrap();
         assert_eq!(a_ptr_as_z_ptr(&a), Some(z_nil));
         assert_eq!(a_ptr_as_z_ptr(&b), Some(z_nil));
         assert_eq!(a_ptr_as_z_ptr(&c), Some(z_nil));
@@ -858,15 +793,9 @@ mod test {
         let not_dummy = Boolean::Constant(true);
 
         // nil
-        let a_nil = AllocatedPtr::alloc_infallible(&mut cs.namespace(|| "nil"), || z_nil);
-        let (car, cdr, not_empty) = car_cdr(
-            &mut cs.namespace(|| "car_cdr of nil"),
-            &g,
-            &store,
-            &not_dummy,
-            &a_nil,
-        )
-        .unwrap();
+        let a_nil = AllocatedPtr::alloc_infallible(ns!(cs, "nil"), || z_nil);
+        let (car, cdr, not_empty) =
+            car_cdr(ns!(cs, "car_cdr of nil"), &g, &store, &not_dummy, &a_nil).unwrap();
         assert_eq!(a_ptr_as_z_ptr(&car), Some(z_nil));
         assert_eq!(a_ptr_as_z_ptr(&cdr), Some(z_nil));
         assert_eq!(not_empty.get_value(), Some(false));
@@ -876,24 +805,17 @@ mod test {
         let z_one = store.hash_ptr(&one);
         let cons = store.cons(one, one);
         let z_cons = store.hash_ptr(&cons);
-        let a_cons = AllocatedPtr::alloc_infallible(&mut cs.namespace(|| "cons"), || z_cons);
-        let (car, cdr, not_empty) = car_cdr(
-            &mut cs.namespace(|| "car_cdr of cons"),
-            &g,
-            &store,
-            &not_dummy,
-            &a_cons,
-        )
-        .unwrap();
+        let a_cons = AllocatedPtr::alloc_infallible(ns!(cs, "cons"), || z_cons);
+        let (car, cdr, not_empty) =
+            car_cdr(ns!(cs, "car_cdr of cons"), &g, &store, &not_dummy, &a_cons).unwrap();
         assert_eq!(a_ptr_as_z_ptr(&car), Some(z_one));
         assert_eq!(a_ptr_as_z_ptr(&cdr), Some(z_one));
         assert_eq!(not_empty.get_value(), Some(true));
 
         // empty string
-        let a_empty_str =
-            AllocatedPtr::alloc_infallible(&mut cs.namespace(|| "empty str"), || z_empty_str);
+        let a_empty_str = AllocatedPtr::alloc_infallible(ns!(cs, "empty str"), || z_empty_str);
         let (car, cdr, not_empty) = car_cdr(
-            &mut cs.namespace(|| "car_cdr of empty str"),
+            ns!(cs, "car_cdr of empty str"),
             &g,
             &store,
             &not_dummy,
@@ -911,15 +833,9 @@ mod test {
         let z_abc = store.hash_ptr(&abc);
         let z_bc = store.hash_ptr(&bc);
         let z_a = store.hash_ptr(&a);
-        let a_abc = AllocatedPtr::alloc_infallible(&mut cs.namespace(|| "abc"), || z_abc);
-        let (car, cdr, not_empty) = car_cdr(
-            &mut cs.namespace(|| "car_cdr of abc"),
-            &g,
-            &store,
-            &not_dummy,
-            &a_abc,
-        )
-        .unwrap();
+        let a_abc = AllocatedPtr::alloc_infallible(ns!(cs, "abc"), || z_abc);
+        let (car, cdr, not_empty) =
+            car_cdr(ns!(cs, "car_cdr of abc"), &g, &store, &not_dummy, &a_abc).unwrap();
         assert_eq!(a_ptr_as_z_ptr(&car), Some(z_a));
         assert_eq!(a_ptr_as_z_ptr(&cdr), Some(z_bc));
         assert_eq!(not_empty.get_value(), Some(true));
@@ -945,9 +861,9 @@ mod test {
         let b = store.char('b');
         let z_a = store.hash_ptr(&a);
         let z_b = store.hash_ptr(&b);
-        let a_ab = AllocatedPtr::alloc_infallible(&mut cs.namespace(|| "ab"), || z_ab);
+        let a_ab = AllocatedPtr::alloc_infallible(ns!(cs, "ab"), || z_ab);
         let (cars, cdr, length) = chain_car_cdr(
-            &mut cs.namespace(|| "chain_car_cdr on ab"),
+            ns!(cs, "chain_car_cdr on ab"),
             &g,
             &store,
             &not_dummy,
@@ -966,9 +882,9 @@ mod test {
         // list
         let list = store.list(vec![ab, ab]);
         let z_list = store.hash_ptr(&list);
-        let a_list = AllocatedPtr::alloc_infallible(&mut cs.namespace(|| "list"), || z_list);
+        let a_list = AllocatedPtr::alloc_infallible(ns!(cs, "list"), || z_list);
         let (cars, cdr, length) = chain_car_cdr(
-            &mut cs.namespace(|| "chain_car_cdr on list"),
+            ns!(cs, "chain_car_cdr on list"),
             &g,
             &store,
             &not_dummy,

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -136,33 +136,25 @@ pub(crate) mod test {
             let a = &input_exprs[0];
             let b = &input_exprs[1];
 
-            let a_is_num = alloc_equal(&mut cs.namespace(|| "fst is num"), a.tag(), num_tag)?;
-            let b_is_num = alloc_equal(&mut cs.namespace(|| "snd is num"), b.tag(), num_tag)?;
-            let types_are_correct = Boolean::and(
-                &mut cs.namespace(|| "types are correct"),
-                &a_is_num,
-                &b_is_num,
-            )?;
+            let a_is_num = alloc_equal(ns!(cs, "fst is num"), a.tag(), num_tag)?;
+            let b_is_num = alloc_equal(ns!(cs, "snd is num"), b.tag(), num_tag)?;
+            let types_are_correct =
+                Boolean::and(ns!(cs, "types are correct"), &a_is_num, &b_is_num)?;
 
             // a^2 + b = c
-            let a2 = mul(&mut cs.namespace(|| "square"), a.hash(), a.hash())?;
-            let c = a2.add(&mut cs.namespace(|| "add"), b.hash())?;
+            let a2 = mul(ns!(cs, "square"), a.hash(), a.hash())?;
+            let c = a2.add(ns!(cs, "add"), b.hash())?;
             let c_ptr = AllocatedPtr::alloc_tag(cs, ExprTag::Num.to_field(), c)?;
 
-            let result_expr0 =
-                AllocatedPtr::pick(&mut cs.namespace(|| "result_expr0"), &b_is_num, &c_ptr, b)?;
+            let result_expr0 = AllocatedPtr::pick(ns!(cs, "result_expr0"), &b_is_num, &c_ptr, b)?;
 
             // If `a` is not a `Num`, then that error takes precedence, and we return `a`. Otherwise, return either the
             // correct result or `b`, depending on whether `b` is a `Num` or not.
-            let result_expr = AllocatedPtr::pick(
-                &mut cs.namespace(|| "result_expr"),
-                &a_is_num,
-                &result_expr0,
-                a,
-            )?;
+            let result_expr =
+                AllocatedPtr::pick(ns!(cs, "result_expr"), &a_is_num, &result_expr0, a)?;
 
             let result_cont = AllocatedPtr::pick(
-                &mut cs.namespace(|| "result_cont"),
+                ns!(cs, "result_cont"),
                 &types_are_correct,
                 input_cont,
                 cont_error,

--- a/src/coprocessor/sha256.rs
+++ b/src/coprocessor/sha256.rs
@@ -35,12 +35,10 @@ fn synthesize_sha256<F: LurkField, CS: ConstraintSystem<F>>(
     };
 
     for ptr in ptrs {
-        let tag_bits = ptr
-            .tag()
-            .to_bits_le_strict(&mut cs.namespace(|| "preimage_tag_bits"))?;
+        let tag_bits = ptr.tag().to_bits_le_strict(ns!(cs, "preimage_tag_bits"))?;
         let hash_bits = ptr
             .hash()
-            .to_bits_le_strict(&mut cs.namespace(|| "preimage_hash_bits"))?;
+            .to_bits_le_strict(ns!(cs, "preimage_hash_bits"))?;
 
         bits.extend(tag_bits);
         pad_to_next_len_multiple_of_8(&mut bits);
@@ -57,7 +55,7 @@ fn synthesize_sha256<F: LurkField, CS: ConstraintSystem<F>>(
     // Fine to lose the last <1 bit of precision.
     let digest_scalar = pack_bits(cs.namespace(|| "digest_scalar"), &digest_bits)?;
     AllocatedPtr::alloc_tag(
-        &mut cs.namespace(|| "output_expr"),
+        ns!(cs, "output_expr"),
         ExprTag::Num.to_field(),
         digest_scalar,
     )

--- a/src/coroutine/memoset/mod.rs
+++ b/src/coroutine/memoset/mod.rs
@@ -156,10 +156,9 @@ impl<F: LurkField> CircuitTranscript<F> {
         provenance: &AllocatedPtr<F>,
         count: u64,
     ) -> Result<(AllocatedPtr<F>, AllocatedNum<F>), SynthesisError> {
-        let allocated_count =
-            { AllocatedNum::alloc(&mut cs.namespace(|| "count"), || Ok(F::from_u64(count)))? };
+        let allocated_count = { AllocatedNum::alloc(ns!(cs, "count"), || Ok(F::from_u64(count)))? };
         let count_ptr = AllocatedPtr::alloc_tag(
-            &mut cs.namespace(|| "count_ptr"),
+            ns!(cs, "count_ptr"),
             ExprTag::Num.to_field(),
             allocated_count.clone(),
         )?;

--- a/src/lem/multiframe.rs
+++ b/src/lem/multiframe.rs
@@ -615,7 +615,7 @@ fn synthesize_frames_sequential<F: LurkField, CS: ConstraintSystem<F>, C: Coproc
             func.bind_input(&input, bound_allocations);
             let output = func
                 .synthesize_frame(
-                    &mut cs.namespace(|| format!("frame {i}")),
+                    ns!(cs, format!("frame {i}")),
                     store,
                     frame,
                     g,
@@ -743,18 +743,16 @@ impl<'a, F: LurkField, C: Coprocessor<F>> Circuit<F> for MultiFrame<'a, F, C> {
                 let z_ptr = store.hash_ptr(ptr);
 
                 let allocated_tag = AllocatedNum::alloc_infallible(
-                    &mut cs.namespace(|| format!("allocated tag for input {i}")),
+                    ns!(cs, format!("allocated tag for input {i}")),
                     || z_ptr.tag_field(),
                 );
-                allocated_tag
-                    .inputize(&mut cs.namespace(|| format!("inputized tag for input {i}")))?;
+                allocated_tag.inputize(ns!(cs, format!("inputized tag for input {i}")))?;
 
                 let allocated_hash = AllocatedNum::alloc_infallible(
-                    &mut cs.namespace(|| format!("allocated hash for input {i}")),
+                    ns!(cs, format!("allocated hash for input {i}")),
                     || *z_ptr.value(),
                 );
-                allocated_hash
-                    .inputize(&mut cs.namespace(|| format!("inputized hash for input {i}")))?;
+                allocated_hash.inputize(ns!(cs, format!("inputized hash for input {i}")))?;
 
                 allocated_input.push(AllocatedPtr::from_parts(allocated_tag, allocated_hash));
             }
@@ -764,18 +762,16 @@ impl<'a, F: LurkField, C: Coprocessor<F>> Circuit<F> for MultiFrame<'a, F, C> {
                 let z_ptr = store.hash_ptr(ptr);
 
                 let allocated_tag = AllocatedNum::alloc_infallible(
-                    &mut cs.namespace(|| format!("allocated tag for output {i}")),
+                    ns!(cs, format!("allocated tag for output {i}")),
                     || z_ptr.tag_field(),
                 );
-                allocated_tag
-                    .inputize(&mut cs.namespace(|| format!("inputized tag for output {i}")))?;
+                allocated_tag.inputize(ns!(cs, format!("inputized tag for output {i}")))?;
 
                 let allocated_hash = AllocatedNum::alloc_infallible(
-                    &mut cs.namespace(|| format!("allocated hash for output {i}")),
+                    ns!(cs, format!("allocated hash for output {i}")),
                     || *z_ptr.value(),
                 );
-                allocated_hash
-                    .inputize(&mut cs.namespace(|| format!("inputized hash for output {i}")))?;
+                allocated_hash.inputize(ns!(cs, format!("inputized hash for output {i}")))?;
 
                 allocated_output.push(AllocatedPtr::from_parts(allocated_tag, allocated_hash));
             }
@@ -792,10 +788,7 @@ impl<'a, F: LurkField, C: Coprocessor<F>> Circuit<F> for MultiFrame<'a, F, C> {
                 .zip(allocated_output)
                 .enumerate()
             {
-                o_res.enforce_equal(
-                    &mut cs.namespace(|| format!("outer output {i} is correct")),
-                    &o,
-                );
+                o_res.enforce_equal(ns!(cs, format!("outer output {i} is correct")), &o);
             }
 
             Ok(())
@@ -935,9 +928,8 @@ impl<'a, F: LurkField, C: Coprocessor<F>> nova::supernova::StepCircuit<F> for Mu
         _pc: Option<&AllocatedNum<F>>,
         z: &[AllocatedNum<F>],
     ) -> Result<(Option<AllocatedNum<F>>, Vec<AllocatedNum<F>>), SynthesisError> {
-        let next_pc = AllocatedNum::alloc_infallible(&mut cs.namespace(|| "next_pc"), || {
-            F::from_u64(self.next_pc as u64)
-        });
+        let next_pc =
+            AllocatedNum::alloc_infallible(ns!(cs, "next_pc"), || F::from_u64(self.next_pc as u64));
         let output = <MultiFrame<'_, F, C> as nova::traits::circuit::StepCircuit<F>>::synthesize(
             self, cs, z,
         )?;


### PR DESCRIPTION
- This codemod was generated by the command
```
rustby '&mut :[cs].namespace(|| :[e])' 'ns!(:[cs], :[e])'
```
where rustby is an alias for
`comby -matcher .rs -extensions .rs -in-place -jobs 10 -exclude-dir "target,.github" -stats -timeout 15 $@`
- Comprehensive refactoring done across multiple modules, including `coprocessor/mod.rs`, `coroutine/memoset/env.rs`, `circuit/circuit_frame.rs`, `circuit/gadgets/pointer.rs`, and many more.
- Switched from `.namespace()` function to the `ns!` macro throughout the code to improve simplicity and readability.