### PR TITLE
Add Prov tag.

### DIFF
--- a/src/coprocessor/gadgets.rs
+++ b/src/coprocessor/gadgets.rs
@@ -182,8 +182,7 @@ pub(crate) fn construct_provenance<F: LurkField, CS: ConstraintSystem<F>>(
     result: &AllocatedPtr<F>,
     deps: &AllocatedNum<F>,
 ) -> Result<AllocatedPtr<F>, SynthesisError> {
-    // TODO: should there be a provenance tag?
-    let tag = g.alloc_tag_cloned(cs, &ExprTag::Env);
+    let tag = g.alloc_tag_cloned(cs, &ExprTag::Prov);
 
     let hash = hash_poseidon(
         cs,
@@ -259,7 +258,7 @@ pub(crate) fn deconstruct_provenance<F: LurkField, CS: ConstraintSystem<F>>(
     provenance: &AllocatedNum<F>,
 ) -> Result<(AllocatedNum<F>, AllocatedPtr<F>, AllocatedNum<F>), SynthesisError> {
     let prov_zptr = ZPtr::from_parts(
-        tag::Tag::Expr(ExprTag::Env),
+        tag::Tag::Expr(ExprTag::Prov),
         provenance.get_value().unwrap(),
     );
     let prov_ptr = s.to_ptr(&prov_zptr);

--- a/src/coroutine/memoset/env.rs
+++ b/src/coroutine/memoset/env.rs
@@ -340,21 +340,21 @@ mod test {
             // Without internal insertions transcribed.
 
             let (one_lookup_constraints, one_lookup_aux) =
-                test_lookup_circuit_aux(s, a, empty, expect!["3524"], expect!["3541"]);
+                test_lookup_circuit_aux(s, a, empty, expect!["3525"], expect!["3542"]);
 
-            test_lookup_circuit_aux(s, a, a_env, expect!["3524"], expect!["3541"]);
+            test_lookup_circuit_aux(s, a, a_env, expect!["3525"], expect!["3542"]);
 
             let (two_lookup_constraints, two_lookup_aux) =
-                test_lookup_circuit_aux(s, b, a_env, expect!["6457"], expect!["6485"]);
+                test_lookup_circuit_aux(s, b, a_env, expect!["6459"], expect!["6487"]);
 
-            test_lookup_circuit_aux(s, b, b_env, expect!["3524"], expect!["3541"]);
-            test_lookup_circuit_aux(s, a, a2_env, expect!["3524"], expect!["3541"]);
+            test_lookup_circuit_aux(s, b, b_env, expect!["3525"], expect!["3542"]);
+            test_lookup_circuit_aux(s, a, a2_env, expect!["3525"], expect!["3542"]);
 
             let (three_lookup_constraints, three_lookup_aux) =
-                test_lookup_circuit_aux(s, c, b_env, expect!["9390"], expect!["9429"]);
+                test_lookup_circuit_aux(s, c, b_env, expect!["9393"], expect!["9432"]);
 
-            test_lookup_circuit_aux(s, c, c_env, expect!["3524"], expect!["3541"]);
-            test_lookup_circuit_aux(s, c, a2_env, expect!["6457"], expect!["6485"]);
+            test_lookup_circuit_aux(s, c, c_env, expect!["3525"], expect!["3542"]);
+            test_lookup_circuit_aux(s, c, a2_env, expect!["6459"], expect!["6487"]);
 
             let delta1_constraints = two_lookup_constraints - one_lookup_constraints;
             let delta2_constraints = three_lookup_constraints - two_lookup_constraints;
@@ -363,7 +363,7 @@ mod test {
             assert_eq!(delta1_constraints, delta2_constraints);
 
             // This is the number of constraints per lookup.
-            expect_eq(delta1_constraints, expect!["2933"]);
+            expect_eq(delta1_constraints, expect!["2934"]);
 
             // This is the number of constraints in the constant overhead.
             expect_eq(overhead_constraints, expect!["591"]);
@@ -375,7 +375,7 @@ mod test {
             assert_eq!(delta1_aux, delta2_aux);
 
             // This is the number of aux per lookup.
-            expect_eq(delta1_aux, expect!["2944"]);
+            expect_eq(delta1_aux, expect!["2945"]);
 
             // This is the number of aux in the constant overhead.
             expect_eq(overhead_aux, expect!["597"]);

--- a/src/coroutine/memoset/mod.rs
+++ b/src/coroutine/memoset/mod.rs
@@ -614,7 +614,7 @@ impl<F: LurkField, Q: Query<F>> Scope<Q, LogMemo<F>, F> {
                 .collect::<Vec<_>>();
 
             let result = self.queries.get(query).expect("result missing");
-            let p = Provenance::new(*query, *result, sub_provenances.clone());
+            let p = Provenance::new(*query, *result, sub_provenances);
             let provenance = p.to_ptr(store);
 
             if let Some(dependents) = self.dependents.get(query) {

--- a/src/coroutine/memoset/mod.rs
+++ b/src/coroutine/memoset/mod.rs
@@ -215,7 +215,7 @@ impl Provenance {
                 store.list(self.dependencies.clone())
             };
 
-            store.push_provenance(self.query, self.result, dependencies_list)
+            store.intern_provenance(self.query, self.result, dependencies_list)
         })
     }
 }

--- a/src/lem/store.rs
+++ b/src/lem/store.rs
@@ -420,10 +420,7 @@ impl<F: LurkField> Store<F> {
         // TODO: Deps must be a single Prov or a list (later, an N-ary tuple), but we discard the type tag. This is
         // arguably okay, but it means that in order to recover the preimage we will need to know the expected arity
         // based on the query.
-        assert!(matches!(
-            *deps.tag(),
-            Tag::Expr(Prov) | Tag::Expr(Cons) | Tag::Expr(Nil)
-        ));
+        assert!(matches!(*deps.tag(), Tag::Expr(Prov | Cons | Nil)));
         let raw = self.intern_raw_ptrs::<4>([
             *query.raw(),
             self.tag(*val.tag()),

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -52,6 +52,7 @@ pub enum ExprTag {
     Key,
     Cproc,
     Env,
+    Prov,
     Rec,
 }
 
@@ -83,6 +84,7 @@ impl fmt::Display for ExprTag {
             ExprTag::U64 => write!(f, "u64#"),
             ExprTag::Cproc => write!(f, "cproc#"),
             ExprTag::Env => write!(f, "env#"),
+            ExprTag::Prov => write!(f, "prov#"),
             ExprTag::Rec => write!(f, "rec#"),
         }
     }


### PR DESCRIPTION
This is a follow up to #1109. It adds an explicit `Prov` tag, which is important for manipulating and observing `Provenance`s. This PR also improves general handling and printing of `Provenance`. Note that (like `Env`) there is currently no readable form for `Provenance` — and (unlike `Env`) it's unclear whether there *should* be one.

This PR is a straightforward and strict improvement — without which debugging of the `Provenance` refactor (working toward a sponge transcript) will be impossible.