### PR TITLE
chore: unify interpretation data for MultiFrame

### DIFF
--- a/src/cli/repl/meta_cmd.rs
+++ b/src/cli/repl/meta_cmd.rs
@@ -532,10 +532,10 @@ where
         }
         let open = repl.store.intern_lurk_symbol("open");
         let open_expr = repl.store.list(vec![open, repl.store.num(hash)]);
-        let Some((args_vec, _)) = repl.store.fetch_list(&args) else {
-            bail!("Data must have been interned");
-        };
-
+        let (args_vec, _) = repl
+            .store
+            .fetch_list(&args)
+            .expect("list of arguments must have been interned");
         let mut expr_vec = Vec::with_capacity(args_vec.len() + 1);
         expr_vec.push(open_expr);
         expr_vec.extend(args_vec);


### PR DESCRIPTION
* Create a (new) InterpretationData to hold interpretation data on MultiFrame
* Remove some unwraps/expects because interpretation data is no longer spread across multiple holders
* [unrelated] Undo a change from #1106 where a panic was the desired behavior

cc @vuvoth 