### PR TITLE
Make topological sort fully general.

### DIFF
--- a/src/coroutine/memoset/mod.rs
+++ b/src/coroutine/memoset/mod.rs
@@ -594,6 +594,12 @@ impl<F: LurkField, Q: Query<F>> Scope<Q, LogMemo<F>, F> {
             );
         }
 
+        assert_eq!(
+            self.queries.len(),
+            provenances.len(),
+            "incomplete provenance computation (probably a forbidden cyclic query)"
+        );
+
         provenances
             .iter()
             .map(|(k, v)| (store.hash_ptr(k), store.hash_ptr(v)))


### PR DESCRIPTION
This PR generalizes the topological sort used when computing the provenances. The previous code relied on limitations on possible DAG shape in the singly self-recursive queries implemented so far. These changes should be fully general and support any dependency structure recorded by the queries.