### PR TITLE
chore: refactor PerfConfig

### DIFF
--- a/benches/bench.env
+++ b/benches/bench.env
@@ -1,4 +1,4 @@
 # Lurk config, used only in `justfile` by default
-LURK_PERF=max-parallel-simple
+LURK_PERF=fully-parallel
 LURK_RC=100,600
 LURK_BENCH_NOISE_THRESHOLD=0.05

--- a/src/lem/multiframe.rs
+++ b/src/lem/multiframe.rs
@@ -156,16 +156,12 @@ impl<'a, F: LurkField, C: Coprocessor<F>> MultiFrame<'a, F, C> {
                 store,
                 frames,
                 num_slots_per_frame,
-                lurk_config(None, None)
-                    .perf
-                    .parallelism
-                    .poseidon_witnesses
-                    .is_parallel(),
+                lurk_config(None, None).perf.parallelism.slots.is_parallel(),
             );
             if lurk_config(None, None)
                 .perf
                 .parallelism
-                .synthesis
+                .frames
                 .is_parallel()
             {
                 Ok(synthesize_frames_parallel(

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -290,7 +290,7 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<F, C1LEM<
         recursive_snark_option = if lurk_config(None, None)
             .perf
             .parallelism
-            .recursive_steps
+            .wit_gen_vs_folding
             .is_parallel()
         {
             let cc = steps.into_iter().map(Mutex::new).collect::<Vec<_>>();

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -235,7 +235,7 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<F, C1LEM<
         recursive_snark_option = if lurk_config(None, None)
             .perf
             .parallelism
-            .recursive_steps
+            .wit_gen_vs_folding
             .is_parallel()
         {
             let cc = steps

--- a/tests/lurk-cli-tests.rs
+++ b/tests/lurk-cli-tests.rs
@@ -58,7 +58,7 @@ fn test_prove_and_verify() {
     file.write_all(b"!(verify \"supernova_bn256_10_18748ce7ba3dd0e7560ec64983d6b01d84a6303880b3b0b24878133aa1b4a6bb\")\n").unwrap();
 
     let mut cmd = lurk_cmd();
-    cmd.env("LURK_PERF", "max-parallel-simple");
+    cmd.env("LURK_PERF", "fully-parallel");
     cmd.arg("load");
     cmd.arg(lurk_file.into_string());
     cmd.arg("--public-params-dir");

--- a/tests/lurk-files-tests.rs
+++ b/tests/lurk-files-tests.rs
@@ -57,7 +57,6 @@ fn test_demo() {
 
     demo_examples.into_par_iter().for_each(|f| {
         let mut cmd = lurk_cmd();
-        cmd.env("LURK_PERF", "max-parallel-simple");
         cmd.arg(f);
         cmd.assert().success();
     });


### PR DESCRIPTION
After the switch from Alpha to LEM, some struct attribute and enum variants of our perf config were left with names that no longer represented their semantics very well. This PR aims at improving the status quo.

Closes #1111