### PR TITLE
chore: Adapt to Arecibo changes (easy)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ clap = "4.3.17"
 ff = "0.13"
 metrics = "0.22.0"
 neptune = { git = "https://github.com/lurk-lab/neptune", branch = "dev", default-features = false, features = ["abomonation"] }
-nova = { git = "https://github.com/huitseeker/arecibo", branch = "forward_ports", package = "arecibo", features = ["abomonate"]}
+nova = { git = "https://github.com/lurk-lab/arecibo", branch = "dev", package = "arecibo", features = ["abomonate"]}
 once_cell = "1.18.0"
 pairing = { version = "0.23" }
 pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch = "dev" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ clap = "4.3.17"
 ff = "0.13"
 metrics = "0.22.0"
 neptune = { git = "https://github.com/lurk-lab/neptune", branch = "dev", default-features = false, features = ["abomonation"] }
-nova = { git = "https://github.com/lurk-lab/arecibo", branch = "dev", package = "arecibo", features = ["abomonate"]}
+nova = { git = "https://github.com/huitseeker/arecibo", branch = "forward_ports", package = "arecibo", features = ["abomonate"]}
 once_cell = "1.18.0"
 pairing = { version = "0.23" }
 pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch = "dev" }

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -205,7 +205,8 @@ pub fn public_params<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a>(
         &circuit_secondary,
         &*commitment_size_hint1,
         &*commitment_size_hint2,
-    );
+    )
+    .unwrap();
     PublicParams {
         pp,
         pk_and_vk: OnceCell::new(),


### PR DESCRIPTION
- Companion PR of https://github.com/lurk-lab/arecibo/pull/329

> [!NOTE]
> CI failure on initial commit due to cargo-deny expected,
> CI failure of compilation of second commit expected.