### PR TITLE
Refactor Query

### DIFF
--- a/src/coroutine/memoset/demo.rs
+++ b/src/coroutine/memoset/demo.rs
@@ -146,6 +146,7 @@ impl<F: LurkField> CircuitQuery<F> for DemoCircuitQuery<F> {
         store: &Store<F>,
         scope: &mut CircuitScope<F, LogMemoCircuit<F>>,
         acc: &AllocatedPtr<F>,
+        allocated_key: &AllocatedPtr<F>,
     ) -> Result<((AllocatedPtr<F>, AllocatedPtr<F>), AllocatedPtr<F>), SynthesisError> {
         match self {
             Self::Factorial(n) => {
@@ -187,6 +188,7 @@ impl<F: LurkField> CircuitQuery<F> for DemoCircuitQuery<F> {
                     subquery,
                     &n_is_zero.not(),
                     (&base_case, acc),
+                    allocated_key,
                 )
             }
         }

--- a/src/coroutine/memoset/env.rs
+++ b/src/coroutine/memoset/env.rs
@@ -142,6 +142,7 @@ impl<F: LurkField> CircuitQuery<F> for EnvCircuitQuery<F> {
         store: &Store<F>,
         scope: &mut CircuitScope<F, LogMemoCircuit<F>>,
         acc: &AllocatedPtr<F>,
+        allocated_key: &AllocatedPtr<F>,
     ) -> Result<((AllocatedPtr<F>, AllocatedPtr<F>), AllocatedPtr<F>), SynthesisError> {
         match self {
             Self::Lookup(var, env) => {
@@ -190,6 +191,7 @@ impl<F: LurkField> CircuitQuery<F> for EnvCircuitQuery<F> {
                     subquery,
                     &is_immediate.not(),
                     (&immediate_result, acc),
+                    allocated_key,
                 )
             }
         }
@@ -303,21 +305,21 @@ mod test {
             // Without internal insertions transcribed.
 
             let (one_lookup_constraints, one_lookup_aux) =
-                test_lookup_circuit_aux(s, a, empty, expect!["3525"], expect!["3543"]);
+                test_lookup_circuit_aux(s, a, empty, expect!["2947"], expect!["2965"]);
 
-            test_lookup_circuit_aux(s, a, a_env, expect!["3525"], expect!["3543"]);
+            test_lookup_circuit_aux(s, a, a_env, expect!["2947"], expect!["2965"]);
 
             let (two_lookup_constraints, two_lookup_aux) =
-                test_lookup_circuit_aux(s, b, a_env, expect!["6459"], expect!["6489"]);
+                test_lookup_circuit_aux(s, b, a_env, expect!["5303"], expect!["5333"]);
 
-            test_lookup_circuit_aux(s, b, b_env, expect!["3525"], expect!["3543"]);
-            test_lookup_circuit_aux(s, a, a2_env, expect!["3525"], expect!["3543"]);
+            test_lookup_circuit_aux(s, b, b_env, expect!["2947"], expect!["2965"]);
+            test_lookup_circuit_aux(s, a, a2_env, expect!["2947"], expect!["2965"]);
 
             let (three_lookup_constraints, three_lookup_aux) =
-                test_lookup_circuit_aux(s, c, b_env, expect!["9393"], expect!["9435"]);
+                test_lookup_circuit_aux(s, c, b_env, expect!["7659"], expect!["7701"]);
 
-            test_lookup_circuit_aux(s, c, c_env, expect!["3525"], expect!["3543"]);
-            test_lookup_circuit_aux(s, c, a2_env, expect!["6459"], expect!["6489"]);
+            test_lookup_circuit_aux(s, c, c_env, expect!["2947"], expect!["2965"]);
+            test_lookup_circuit_aux(s, c, a2_env, expect!["5303"], expect!["5333"]);
 
             let delta1_constraints = two_lookup_constraints - one_lookup_constraints;
             let delta2_constraints = three_lookup_constraints - two_lookup_constraints;
@@ -326,7 +328,7 @@ mod test {
             assert_eq!(delta1_constraints, delta2_constraints);
 
             // This is the number of constraints per lookup.
-            expect_eq(delta1_constraints, expect!["2934"]);
+            expect_eq(delta1_constraints, expect!["2356"]);
 
             // This is the number of constraints in the constant overhead.
             expect_eq(overhead_constraints, expect!["591"]);
@@ -338,7 +340,7 @@ mod test {
             assert_eq!(delta1_aux, delta2_aux);
 
             // This is the number of aux per lookup.
-            expect_eq(delta1_aux, expect!["2946"]);
+            expect_eq(delta1_aux, expect!["2368"]);
 
             // This is the number of aux in the constant overhead.
             expect_eq(overhead_aux, expect!["597"]);

--- a/src/coroutine/memoset/env.rs
+++ b/src/coroutine/memoset/env.rs
@@ -305,21 +305,21 @@ mod test {
             // Without internal insertions transcribed.
 
             let (one_lookup_constraints, one_lookup_aux) =
-                test_lookup_circuit_aux(s, a, empty, expect!["2947"], expect!["2965"]);
+                test_lookup_circuit_aux(s, a, empty, expect!["3525"], expect!["3541"]);
 
-            test_lookup_circuit_aux(s, a, a_env, expect!["2947"], expect!["2965"]);
+            test_lookup_circuit_aux(s, a, a_env, expect!["3525"], expect!["3541"]);
 
             let (two_lookup_constraints, two_lookup_aux) =
-                test_lookup_circuit_aux(s, b, a_env, expect!["5303"], expect!["5333"]);
+                test_lookup_circuit_aux(s, b, a_env, expect!["6459"], expect!["6485"]);
 
-            test_lookup_circuit_aux(s, b, b_env, expect!["2947"], expect!["2965"]);
-            test_lookup_circuit_aux(s, a, a2_env, expect!["2947"], expect!["2965"]);
+            test_lookup_circuit_aux(s, b, b_env, expect!["3525"], expect!["3541"]);
+            test_lookup_circuit_aux(s, a, a2_env, expect!["3525"], expect!["3541"]);
 
             let (three_lookup_constraints, three_lookup_aux) =
-                test_lookup_circuit_aux(s, c, b_env, expect!["7659"], expect!["7701"]);
+                test_lookup_circuit_aux(s, c, b_env, expect!["9393"], expect!["9429"]);
 
-            test_lookup_circuit_aux(s, c, c_env, expect!["2947"], expect!["2965"]);
-            test_lookup_circuit_aux(s, c, a2_env, expect!["5303"], expect!["5333"]);
+            test_lookup_circuit_aux(s, c, c_env, expect!["3525"], expect!["3541"]);
+            test_lookup_circuit_aux(s, c, a2_env, expect!["6459"], expect!["6485"]);
 
             let delta1_constraints = two_lookup_constraints - one_lookup_constraints;
             let delta2_constraints = three_lookup_constraints - two_lookup_constraints;
@@ -328,7 +328,7 @@ mod test {
             assert_eq!(delta1_constraints, delta2_constraints);
 
             // This is the number of constraints per lookup.
-            expect_eq(delta1_constraints, expect!["2356"]);
+            expect_eq(delta1_constraints, expect!["2934"]);
 
             // This is the number of constraints in the constant overhead.
             expect_eq(overhead_constraints, expect!["591"]);
@@ -340,7 +340,7 @@ mod test {
             assert_eq!(delta1_aux, delta2_aux);
 
             // This is the number of aux per lookup.
-            expect_eq(delta1_aux, expect!["2368"]);
+            expect_eq(delta1_aux, expect!["2944"]);
 
             // This is the number of aux in the constant overhead.
             expect_eq(overhead_aux, expect!["597"]);

--- a/src/coroutine/memoset/mod.rs
+++ b/src/coroutine/memoset/mod.rs
@@ -1149,7 +1149,16 @@ impl<F: LurkField> CircuitScope<F, LogMemoCircuit<F>> {
         s: &Store<F>,
     ) -> Result<(), SynthesisError> {
         for (i, kv) in scope.toplevel_insertions.iter().enumerate() {
-            self.synthesize_toplevel_query(cs, g, s, i, kv)?;
+            let cs = ns!(cs, format!("toplevel_insertion-{i}"));
+            let (key, value) = s.car_cdr(kv).expect("kv missing");
+            // NOTE: This is an unconstrained allocation, but when actually hooked up to Lurk reduction, it must be
+            // constrained appropriately.
+            let allocated_key =
+                AllocatedPtr::alloc(ns!(cs, "allocated_key"), || Ok(s.hash_ptr(&key))).unwrap();
+            // NOTE: The returned value is unused here, but when actually hooked up to Lurk reduction, it must be used
+            // as the result of evaluating the query.
+            let _allocated_value =
+                self.synthesize_toplevel_query(cs, g, s, i, &allocated_key, value)?;
         }
         Ok(())
     }
@@ -1160,12 +1169,10 @@ impl<F: LurkField> CircuitScope<F, LogMemoCircuit<F>> {
         g: &mut GlobalAllocator<F>,
         s: &Store<F>,
         i: usize,
-        kv: &Ptr,
-    ) -> Result<(), SynthesisError> {
-        let (key, value) = s.car_cdr(kv).unwrap();
+        allocated_key: &AllocatedPtr<F>,
+        value: Ptr,
+    ) -> Result<AllocatedPtr<F>, SynthesisError> {
         let cs = ns!(cs, format!("toplevel-{i}"));
-        let allocated_key =
-            AllocatedPtr::alloc(ns!(cs, "allocated_key"), || Ok(s.hash_ptr(&key))).unwrap();
 
         let acc = self.acc.clone().unwrap();
         let insertion_transcript = self.transcript.clone();
@@ -1174,7 +1181,7 @@ impl<F: LurkField> CircuitScope<F, LogMemoCircuit<F>> {
             cs,
             g,
             s,
-            &allocated_key,
+            allocated_key,
             &acc,
             &insertion_transcript,
             &Boolean::Constant(true),
@@ -1186,7 +1193,7 @@ impl<F: LurkField> CircuitScope<F, LogMemoCircuit<F>> {
 
         self.acc = Some(new_acc);
         self.transcript = new_transcript;
-        Ok(())
+        Ok(val)
     }
 
     fn synthesize_prove_key_query<CS: ConstraintSystem<F>, Q: Query<F>>(
@@ -1240,7 +1247,7 @@ impl<F: LurkField> CircuitScope<F, LogMemoCircuit<F>> {
         let acc = self.acc.clone().unwrap();
 
         let ((val, provenance), new_acc) = circuit_query
-            .synthesize_eval(ns!(cs, "eval"), g, s, self, &acc)
+            .synthesize_eval(ns!(cs, "eval"), g, s, self, &acc, allocated_key)
             .unwrap();
 
         let (new_acc, new_transcript) = self.synthesize_remove(
@@ -1467,24 +1474,24 @@ mod test {
     #[test]
     fn test_query() {
         test_query_aux(
-            expect!["9451"],
-            expect!["9507"],
-            expect!["10034"],
-            expect!["10097"],
+            expect!["8006"],
+            expect!["8062"],
+            expect!["8589"],
+            expect!["8652"],
             1,
         );
         test_query_aux(
-            expect!["11191"],
-            expect!["11253"],
-            expect!["11774"],
-            expect!["11843"],
+            expect!["9457"],
+            expect!["9519"],
+            expect!["10040"],
+            expect!["10109"],
             3,
         );
         test_query_aux(
-            expect!["18239"],
-            expect!["18336"],
-            expect!["18822"],
-            expect!["18926"],
+            expect!["15349"],
+            expect!["15446"],
+            expect!["15932"],
+            expect!["16036"],
             10,
         )
     }

--- a/src/coroutine/memoset/query.rs
+++ b/src/coroutine/memoset/query.rs
@@ -61,6 +61,38 @@ where
     fn from_ptr<CS: ConstraintSystem<F>>(cs: &mut CS, s: &Store<F>, ptr: &Ptr) -> Option<Self>;
 
     fn dummy_from_index<CS: ConstraintSystem<F>>(cs: &mut CS, s: &Store<F>, index: usize) -> Self;
+
+    fn synthesize_args<CS: ConstraintSystem<F>>(
+        &self,
+        cs: &mut CS,
+        g: &GlobalAllocator<F>,
+        store: &Store<F>,
+    ) -> Result<AllocatedPtr<F>, SynthesisError>;
+
+    fn synthesize_query<CS: ConstraintSystem<F>>(
+        &self,
+        cs: &mut CS,
+        g: &GlobalAllocator<F>,
+        store: &Store<F>,
+    ) -> Result<AllocatedPtr<F>, SynthesisError> {
+        let symbol = g.alloc_ptr(ns!(cs, "symbol_"), &self.symbol_ptr(store), store);
+        let args = self.synthesize_args(ns!(cs, "args"), g, store)?;
+        construct_cons(ns!(cs, "query"), g, store, &symbol, &args)
+    }
+
+    fn synthesize_provenance<CS: ConstraintSystem<F>>(
+        &self,
+        cs: &mut CS,
+        g: &GlobalAllocator<F>,
+        store: &Store<F>,
+        result: AllocatedPtr<F>,
+        dependency_provenances: Vec<AllocatedPtr<F>>,
+    ) -> Result<AllocatedPtr<F>, SynthesisError> {
+        let query = self.synthesize_query(ns!(cs, "query"), g, store)?;
+        let p = AllocatedProvenance::new(query, result, dependency_provenances.clone());
+
+        Ok(p.to_ptr(cs, g, store)?.clone())
+    }
 }
 
 pub(crate) trait RecursiveQuery<F: LurkField>: CircuitQuery<F> {
@@ -69,6 +101,7 @@ pub(crate) trait RecursiveQuery<F: LurkField>: CircuitQuery<F> {
         _cs: &mut CS,
         subquery_result: AllocatedPtr<F>,
     ) -> Result<AllocatedPtr<F>, SynthesisError> {
+        // The default implementation provides tail recursion.
         Ok(subquery_result)
     }
 
@@ -78,17 +111,13 @@ pub(crate) trait RecursiveQuery<F: LurkField>: CircuitQuery<F> {
         g: &GlobalAllocator<F>,
         store: &Store<F>,
         scope: &mut CircuitScope<F, LogMemoCircuit<F>>,
-        query: &AllocatedPtr<F>,
-        args: &AllocatedPtr<F>,
+        subquery: Self,
         is_recursive: &Boolean,
         immediate: (&AllocatedPtr<F>, &AllocatedPtr<F>),
     ) -> Result<((AllocatedPtr<F>, AllocatedPtr<F>), AllocatedPtr<F>), SynthesisError> {
         let is_immediate = is_recursive.not();
 
-        let subquery = {
-            let symbol = g.alloc_ptr(ns!(cs, "symbol"), &self.symbol_ptr(store), store);
-            construct_cons(ns!(cs, "subquery"), g, store, &symbol, args)?
-        };
+        let subquery = subquery.synthesize_query(cs, g, store)?;
 
         let ((sub_result, sub_provenance), new_acc) = scope.synthesize_internal_query(
             ns!(cs, "recursive query"),
@@ -124,13 +153,13 @@ pub(crate) trait RecursiveQuery<F: LurkField>: CircuitQuery<F> {
             &sub_provenance,
         )?;
 
-        let p = AllocatedProvenance::new(
-            query.clone(),
+        let provenance = self.synthesize_provenance(
+            ns!(cs, "provenance"),
+            g,
+            store,
             value.clone(),
             vec![dependency_provenance.clone()],
-        );
-
-        let provenance = p.to_ptr(cs, g, store)?;
+        )?;
 
         Ok(((value, provenance.clone()), acc))
     }


### PR DESCRIPTION
This PR refactors the `CircuitQuery` and `RecursiveCircuitQuery` traits to allow more granular implementations. This is a step toward more flexible and optimized Coroutine circuit proofs.

UPDATE: https://github.com/lurk-lab/lurk-rs/pull/1146/commits/90d76eab4182c8e07b8d5be18ccf5a4eaee1121e intends to a fix a bug whereby the allocated keys and values were not properly connected.

Notice that this fix remove a few hashes and noticeably reduces constraints, since we are now correctly reusing an allocated value rather than expensively recomputing it.
