### PR TITLE
LEM deconflict simplification

### DIFF
--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -445,7 +445,7 @@ fn run_cproc(cproc_sym: Symbol, arity: usize) -> Func {
         ctrl: Ctrl::match_tag(cproc.clone(), vec![(Tag::Expr(Cproc), block)], None),
     };
     let func_inp = vec![cproc, env, cont];
-    Func::new_unchecked("run_cproc".into(), func_inp, 3, block)
+    Func::new("run_cproc".into(), func_inp, 3, block).unwrap()
 }
 
 /// Creates the `Func`s used to call coprocessors in the NIVC scenario. Each

--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -3,6 +3,7 @@ use indexmap::IndexMap;
 use once_cell::sync::OnceCell;
 
 use crate::{
+    aux_func,
     coprocessor::Coprocessor,
     ctrl,
     eval::lang::Lang,
@@ -301,7 +302,7 @@ fn make_eval_step(cprocs: &[(&Symbol, usize)], ivc: bool) -> Func {
 /// Simpler version of `car_cdr` that doesn't deconstruct strings to save some
 /// constraints
 fn car_cdr() -> Func {
-    func!(car_cdr(xs): 2 => {
+    aux_func!(car_cdr(xs): 2 => {
         let nil = Symbol("nil");
         let nil = cast(nil, Expr::Nil);
         match xs.tag {
@@ -444,7 +445,7 @@ fn run_cproc(cproc_sym: Symbol, arity: usize) -> Func {
         ctrl: Ctrl::match_tag(cproc.clone(), vec![(Tag::Expr(Cproc), block)], None),
     };
     let func_inp = vec![cproc, env, cont];
-    Func::new("run_cproc".into(), func_inp, 3, block).unwrap()
+    Func::new_unchecked("run_cproc".into(), func_inp, 3, block)
 }
 
 /// Creates the `Func`s used to call coprocessors in the NIVC scenario. Each
@@ -479,7 +480,7 @@ pub fn make_cprocs_funcs_from_lang<F: LurkField, C: Coprocessor<F>>(
 /// ```
 fn is_cproc(cprocs: &[(&Symbol, usize)]) -> Func {
     if cprocs.is_empty() {
-        func!(is_cproc(_head): 1 => {
+        aux_func!(is_cproc(_head): 1 => {
             let nil = Symbol("nil");
             let nil = cast(nil, Expr::Nil);
             return (nil);
@@ -497,7 +498,7 @@ fn is_cproc(cprocs: &[(&Symbol, usize)]) -> Func {
             .collect();
         let def = Some(Block::ctrl(ctrl!(return (nil))));
         let ctrl = Ctrl::match_symbol(head.clone(), match_symbol_cases, def);
-        Func::new("is_cproc".into(), vec![head], 1, Block { ops, ctrl }).unwrap()
+        Func::new_unchecked("is_cproc".into(), vec![head], 1, Block { ops, ctrl })
     }
 }
 
@@ -648,19 +649,18 @@ fn match_and_run_cproc(cprocs: &[(&Symbol, usize)]) -> Func {
             op!(let nil = cast(nil, Expr::Nil)),
         ]
     };
-    Func::new(
+    Func::new_unchecked(
         "match_and_run_cproc".into(),
         func_inp,
         4,
         Block { ops, ctrl },
     )
-    .unwrap()
 }
 
 fn reduce(cprocs: &[(&Symbol, usize)]) -> Func {
     // Auxiliary functions
     let car_cdr = car_cdr();
-    let expand_bindings = func!(expand_bindings(head, body, body1, rest_bindings): 1 => {
+    let expand_bindings = aux_func!(expand_bindings(head, body, body1, rest_bindings): 1 => {
         match rest_bindings.tag {
             Expr::Nil => {
                 return (body1)
@@ -670,7 +670,7 @@ fn reduce(cprocs: &[(&Symbol, usize)]) -> Func {
         let expanded: Expr::Cons = cons2(head, expanded_0);
         return (expanded)
     });
-    let get_unop = func!(get_unop(head): 1 => {
+    let get_unop = aux_func!(get_unop(head): 1 => {
         let nil = Symbol("nil");
         let nil = cast(nil, Expr::Nil);
         match symbol head {
@@ -721,7 +721,7 @@ fn reduce(cprocs: &[(&Symbol, usize)]) -> Func {
         };
         return (nil)
     });
-    let get_binop = func!(get_binop(head): 1 => {
+    let get_binop = aux_func!(get_binop(head): 1 => {
         let nil = Symbol("nil");
         let nil = cast(nil, Expr::Nil);
         match symbol head {
@@ -784,7 +784,7 @@ fn reduce(cprocs: &[(&Symbol, usize)]) -> Func {
         };
         return (nil)
     });
-    let is_potentially_fun = func!(is_potentially_fun(head): 1 => {
+    let is_potentially_fun = aux_func!(is_potentially_fun(head): 1 => {
         let fun: Expr::Fun;
         let cons: Expr::Cons;
         let thunk: Expr::Thunk;
@@ -802,7 +802,7 @@ fn reduce(cprocs: &[(&Symbol, usize)]) -> Func {
         return (nil)
     });
     let is_cproc = is_cproc(cprocs);
-    let lookup = func!(lookup(expr, env, state): 3 => {
+    let lookup = aux_func!(lookup(expr, env, state): 3 => {
         let found = Symbol("found");
         let not_found = Symbol("not_found");
         let error = Symbol("error");
@@ -823,7 +823,7 @@ fn reduce(cprocs: &[(&Symbol, usize)]) -> Func {
         return (expr, smaller_env, not_found)
     });
 
-    func!(reduce(expr, env, cont): 4 => {
+    aux_func!(reduce(expr, env, cont): 4 => {
         let ret = Symbol("return");
         let term: Cont::Terminal = HASH_8_ZEROS;
         let err: Cont::Error = HASH_8_ZEROS;
@@ -1134,7 +1134,7 @@ fn reduce(cprocs: &[(&Symbol, usize)]) -> Func {
 /// from outside, which is supposed to know how to reduce such expression.
 fn choose_cproc_call(cprocs: &[(&Symbol, usize)], ivc: bool) -> Func {
     if cprocs.is_empty() {
-        func!(no_cproc_error(cproc_name, _evaluated_args, env, _cont): 4 => {
+        aux_func!(no_cproc_error(cproc_name, _evaluated_args, env, _cont): 4 => {
             let err: Cont::Error = HASH_8_ZEROS;
             let errctrl = Symbol("error");
             return (cproc_name, env, err, errctrl);
@@ -1142,7 +1142,7 @@ fn choose_cproc_call(cprocs: &[(&Symbol, usize)], ivc: bool) -> Func {
     } else if ivc {
         match_and_run_cproc(cprocs)
     } else {
-        func!(setup_cproc_loop(cproc_name, evaluated_args, env, cont): 4 => {
+        aux_func!(setup_cproc_loop(cproc_name, evaluated_args, env, cont): 4 => {
             let ret = Symbol("return");
             // setup loop
             let cproc: Expr::Cproc = cons2(cproc_name, evaluated_args);
@@ -1155,7 +1155,7 @@ fn apply_cont(cprocs: &[(&Symbol, usize)], ivc: bool) -> Func {
     let car_cdr = car_cdr();
     // Returns 0u64 if both arguments are U64, 0 (num) if the arguments are some kind of number (either U64 or Num),
     // and nil otherwise
-    let args_num_type = func!(args_num_type(arg1, arg2): 1 => {
+    let args_num_type = aux_func!(args_num_type(arg1, arg2): 1 => {
         let nil = Symbol("nil");
         let nil = cast(nil, Expr::Nil);
         match arg1.tag {
@@ -1189,7 +1189,7 @@ fn apply_cont(cprocs: &[(&Symbol, usize)], ivc: bool) -> Func {
         return (nil)
     });
     let choose_cproc_call = choose_cproc_call(cprocs, ivc);
-    func!(apply_cont(result, env, cont, ctrl): 4 => {
+    aux_func!(apply_cont(result, env, cont, ctrl): 4 => {
         match symbol ctrl {
             "apply-continuation" => {
                 let makethunk = Symbol("make-thunk");
@@ -1698,7 +1698,7 @@ fn apply_cont(cprocs: &[(&Symbol, usize)], ivc: bool) -> Func {
 }
 
 fn make_thunk() -> Func {
-    func!(make_thunk(expr, env, cont, ctrl): 3 => {
+    aux_func!(make_thunk(expr, env, cont, ctrl): 3 => {
         match symbol ctrl {
             "make-thunk" => {
                 match cont.tag {

--- a/src/lem/macros.rs
+++ b/src/lem/macros.rs
@@ -715,6 +715,18 @@ macro_rules! func {
     };
 }
 
+#[macro_export]
+macro_rules! aux_func {
+    ($name:ident($( $in:ident ),*): $size:expr => $lem:tt) => {
+        $crate::lem::Func::new_unchecked(
+            stringify!($name).into(),
+            vec![$($crate::var!($in)),*],
+            $size,
+            $crate::block!($lem),
+        )
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{

--- a/src/lem/macros.rs
+++ b/src/lem/macros.rs
@@ -704,6 +704,7 @@ macro_rules! block {
 }
 
 #[macro_export]
+/// Creates a checked `Func`
 macro_rules! func {
     ($name:ident($( $in:ident ),*): $size:expr => $lem:tt) => {
         $crate::lem::Func::new(
@@ -716,6 +717,7 @@ macro_rules! func {
 }
 
 #[macro_export]
+/// Creates an auxiliary `Func`. No transformations or checks are performed
 macro_rules! aux_func {
     ($name:ident($( $in:ident ),*): $size:expr => $lem:tt) => {
         $crate::lem::Func::new_unchecked(

--- a/src/lem/mod.rs
+++ b/src/lem/mod.rs
@@ -266,6 +266,22 @@ impl Func {
         Ok(func)
     }
 
+    pub fn new_unchecked(
+        name: String,
+        input_params: Vec<Var>,
+        output_size: usize,
+        body: Block,
+    ) -> Func {
+        let slots_count = body.count_slots();
+        Func {
+            slots_count,
+            name,
+            input_params,
+            output_size,
+            body,
+        }
+    }
+
     /// Performs the static checks described in LEM's docstring.
     pub fn check(&self) -> Result<()> {
         use std::collections::{HashMap, HashSet};
@@ -551,7 +567,8 @@ impl Block {
                 Op::Call(out, func, inp) => {
                     let inp = map.get_many_cloned(&inp)?;
                     let out = insert_many(map, uniq, &out);
-                    let func = Box::new(func.deconflict(map, uniq)?);
+                    let new_map = &mut VarMap::new();
+                    let func = Box::new(func.deconflict(new_map, uniq)?);
                     ops.push(Op::Call(out, func, inp))
                 }
                 Op::Copy(tgt, src) => {

--- a/src/lem/mod.rs
+++ b/src/lem/mod.rs
@@ -143,8 +143,8 @@ impl Var {
 /// delimits their variables' scope.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Block {
-    ops: Vec<Op>,
-    ctrl: Ctrl,
+    pub ops: Vec<Op>,
+    pub ctrl: Ctrl,
 }
 
 /// The basic control nodes for LEM logical paths.

--- a/src/lem/mod.rs
+++ b/src/lem/mod.rs
@@ -266,6 +266,8 @@ impl Func {
         Ok(func)
     }
 
+    /// Instantiates a `Func` with no transformations or check. Should only be used for auxiliary `Func`s, i.e.,
+    /// `Func`s that are used inside other `Func`s
     pub fn new_unchecked(
         name: String,
         input_params: Vec<Var>,


### PR DESCRIPTION
Auxiliary `Func`s don't need to be deconflicted/checked since they will eventually be checked once the main function is. This simplifies the variable names A LOT. No more stuff like `x#13#8#38#2`, but instead `x#342`

Btw, `Block` is pub now because `Func`s also are. I'm using it for the compiler of my runtime project