### PR TITLE
chore: depend on bellpepper-core version 0.4.0 as released

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ thiserror = { workspace = true }
 abomonation = { workspace = true }
 abomonation_derive = { version = "0.1.0", package = "abomonation_derive_ng" }
 byteorder = "1.4.3"
-circom-scotia = { git = "https://github.com/huitseeker/circom-scotia", branch = "switch_to_bellppepper_dev" }
+circom-scotia = { git = "https://github.com/lurk-lab/circom-scotia", branch = "dev" }
 sha2 = { version = "0.10.2" }
 reqwest = { version = "0.11.18", features = ["stream", "blocking"] }
 ansi_term = "0.12.1"
@@ -115,14 +115,14 @@ members = ["lurk-macros", "lurk-metrics"]
 [workspace.dependencies]
 abomonation = "0.7.3"
 anyhow = "1.0.72"
-bellpepper = { git = "https://github.com/huitseeker/bellpepper", branch = "dev" }
+bellpepper = { git = "https://github.com/lurk-lab/bellpepper", branch = "dev" }
 bellpepper-core = { version = "0.4.0" }
 bincode = "1.3.3"
 clap = "4.3.17"
 ff = "0.13"
 metrics = "0.22.0"
-neptune = { git = "https://github.com/huitseeker/neptune", branch = "switch-bellpepper-dependency", default-features = false, features = ["abomonation"] }
-nova = { git = "https://github.com/huitseeker/arecibo", branch = "switch-bellpepper-dependency", package = "arecibo", features = ["abomonate"]}
+neptune = { git = "https://github.com/lurk-lab/neptune", branch = "dev", default-features = false, features = ["abomonation"] }
+nova = { git = "https://github.com/lurk-lab/arecibo", branch = "dev", package = "arecibo", features = ["abomonate"]}
 once_cell = "1.18.0"
 pairing = { version = "0.23" }
 pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch = "dev" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ thiserror = { workspace = true }
 abomonation = { workspace = true }
 abomonation_derive = { version = "0.1.0", package = "abomonation_derive_ng" }
 byteorder = "1.4.3"
-circom-scotia = { git = "https://github.com/lurk-lab/circom-scotia", branch = "dev" }
+circom-scotia = { git = "https://github.com/huitseeker/circom-scotia", branch = "switch_to_bellppepper_dev" }
 sha2 = { version = "0.10.2" }
 reqwest = { version = "0.11.18", features = ["stream", "blocking"] }
 ansi_term = "0.12.1"
@@ -115,14 +115,14 @@ members = ["lurk-macros", "lurk-metrics"]
 [workspace.dependencies]
 abomonation = "0.7.3"
 anyhow = "1.0.72"
-bellpepper = { git = "https://github.com/lurk-lab/bellpepper", branch = "dev" }
-bellpepper-core = { git = "https://github.com/lurk-lab/bellpepper", branch = "dev" }
+bellpepper = { git = "https://github.com/huitseeker/bellpepper", branch = "dev" }
+bellpepper-core = { version = "0.4.0" }
 bincode = "1.3.3"
 clap = "4.3.17"
 ff = "0.13"
 metrics = "0.22.0"
-neptune = { git = "https://github.com/lurk-lab/neptune", branch = "dev", default-features = false, features = ["abomonation"] }
-nova = { git = "https://github.com/lurk-lab/arecibo", branch = "dev", package = "arecibo", features = ["abomonate"]}
+neptune = { git = "https://github.com/huitseeker/neptune", branch = "switch-bellpepper-dependency", default-features = false, features = ["abomonation"] }
+nova = { git = "https://github.com/huitseeker/arecibo", branch = "switch-bellpepper-dependency", package = "arecibo", features = ["abomonate"]}
 once_cell = "1.18.0"
 pairing = { version = "0.23" }
 pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch = "dev" }


### PR DESCRIPTION
Companion PR of
- https://github.com/lurk-lab/circom-scotia/pull/31
- https://github.com/lurk-lab/bellpepper/pull/84

> [!IMPORTANT]
> The CI failure on cargo-deny is expected (on commits pointing at the branch of the above PR).
> To stamp, please wait for the commit pointing:
> -  the bellpepper dependency back to https://github.com/lurk-rs/bellpepper@dev
> - the neptune dependency back to https://github.com/lurk-rs/neptune@dev
> - the circom-scotia dependency back to https://github.com/lurk-rs/circom-scotia@dev
> - the arecibo dependency back to https://github.com/lurk-rs/arecibo@dev