### PR TITLE
Coroutine simplifications and generalization

### DIFF
--- a/src/coroutine/memoset/demo.rs
+++ b/src/coroutine/memoset/demo.rs
@@ -112,8 +112,10 @@ impl<F: LurkField> RecursiveQuery<F> for DemoCircuitQuery<F> {
     fn post_recursion<CS: ConstraintSystem<F>>(
         &self,
         cs: &mut CS,
-        subquery_result: AllocatedPtr<F>,
+        subquery_results: &[AllocatedPtr<F>],
     ) -> Result<AllocatedPtr<F>, SynthesisError> {
+        assert_eq!(subquery_results.len(), 1);
+        let subquery_result = &subquery_results[0];
         match self {
             Self::Factorial(n) => {
                 let result_f = n.hash().mul(
@@ -185,7 +187,7 @@ impl<F: LurkField> CircuitQuery<F> for DemoCircuitQuery<F> {
                     g,
                     store,
                     scope,
-                    subquery,
+                    &[subquery],
                     &n_is_zero.not(),
                     (&base_case, acc),
                     allocated_key,

--- a/src/coroutine/memoset/env.rs
+++ b/src/coroutine/memoset/env.rs
@@ -364,7 +364,7 @@ mod test {
             scope.finalize_transcript(s);
 
             let cs = &mut TestConstraintSystem::new();
-            let g = &mut GlobalAllocator::default();
+            let g = &GlobalAllocator::default();
 
             scope.synthesize(cs, g, s).unwrap();
 

--- a/src/coroutine/memoset/env.rs
+++ b/src/coroutine/memoset/env.rs
@@ -112,7 +112,16 @@ impl<F: LurkField> Query<F> for EnvQuery<F> {
     }
 }
 
-impl<F: LurkField> RecursiveQuery<F> for EnvCircuitQuery<F> {}
+impl<F: LurkField> RecursiveQuery<F> for EnvCircuitQuery<F> {
+    fn post_recursion<CS: ConstraintSystem<F>>(
+        &self,
+        _cs: &mut CS,
+        subquery_results: &[AllocatedPtr<F>],
+    ) -> Result<AllocatedPtr<F>, SynthesisError> {
+        assert_eq!(subquery_results.len(), 1);
+        Ok(subquery_results[0].clone())
+    }
+}
 
 impl<F: LurkField> CircuitQuery<F> for EnvCircuitQuery<F> {
     fn synthesize_args<CS: ConstraintSystem<F>>(
@@ -186,7 +195,7 @@ impl<F: LurkField> CircuitQuery<F> for EnvCircuitQuery<F> {
                     g,
                     store,
                     scope,
-                    subquery,
+                    &[subquery],
                     &is_immediate.not(),
                     (&immediate_result, acc),
                     allocated_key,

--- a/src/coroutine/memoset/query.rs
+++ b/src/coroutine/memoset/query.rs
@@ -116,6 +116,7 @@ pub(crate) trait RecursiveQuery<F: LurkField>: CircuitQuery<F> {
         allocated_key: &AllocatedPtr<F>,
     ) -> Result<((AllocatedPtr<F>, AllocatedPtr<F>), AllocatedPtr<F>), SynthesisError> {
         let is_immediate = is_recursive.not();
+        let nil = g.alloc_ptr(ns!(cs, "nil"), &store.intern_nil(), store);
 
         let mut sub_results = vec![];
         let mut dependency_provenances = vec![];
@@ -130,7 +131,6 @@ pub(crate) trait RecursiveQuery<F: LurkField>: CircuitQuery<F> {
                 &new_acc,
                 is_recursive,
             )?;
-            let nil = g.alloc_ptr(ns!(cs, "nil"), &store.intern_nil(), store);
             let dependency_provenance = AllocatedPtr::pick(
                 ns!(cs, "dependency provenance"),
                 &is_immediate,

--- a/src/coroutine/memoset/query.rs
+++ b/src/coroutine/memoset/query.rs
@@ -101,11 +101,8 @@ pub(crate) trait RecursiveQuery<F: LurkField>: CircuitQuery<F> {
     fn post_recursion<CS: ConstraintSystem<F>>(
         &self,
         _cs: &mut CS,
-        subquery_result: AllocatedPtr<F>,
-    ) -> Result<AllocatedPtr<F>, SynthesisError> {
-        // The default implementation provides tail recursion.
-        Ok(subquery_result)
-    }
+        subquery_results: &[AllocatedPtr<F>],
+    ) -> Result<AllocatedPtr<F>, SynthesisError>;
 
     fn recurse<CS: ConstraintSystem<F>>(
         &self,
@@ -113,25 +110,39 @@ pub(crate) trait RecursiveQuery<F: LurkField>: CircuitQuery<F> {
         g: &GlobalAllocator<F>,
         store: &Store<F>,
         scope: &mut CircuitScope<F, LogMemoCircuit<F>>,
-        subquery: Self,
+        subqueries: &[Self],
         is_recursive: &Boolean,
         immediate: (&AllocatedPtr<F>, &AllocatedPtr<F>),
         allocated_key: &AllocatedPtr<F>,
     ) -> Result<((AllocatedPtr<F>, AllocatedPtr<F>), AllocatedPtr<F>), SynthesisError> {
         let is_immediate = is_recursive.not();
 
-        let subquery = subquery.synthesize_query(cs, g, store)?;
+        let mut sub_results = vec![];
+        let mut dependency_provenances = vec![];
+        let mut new_acc = immediate.1.clone();
+        for subquery in subqueries {
+            let subquery = subquery.synthesize_query(cs, g, store)?;
+            let ((sub_result, sub_provenance), next_acc) = scope.synthesize_internal_query(
+                ns!(cs, "recursive query"),
+                g,
+                store,
+                &subquery,
+                &new_acc,
+                is_recursive,
+            )?;
+            let nil = g.alloc_ptr(ns!(cs, "nil"), &store.intern_nil(), store);
+            let dependency_provenance = AllocatedPtr::pick(
+                ns!(cs, "dependency provenance"),
+                &is_immediate,
+                &nil,
+                &sub_provenance,
+            )?;
+            sub_results.push(sub_result);
+            dependency_provenances.push(dependency_provenance);
+            new_acc = next_acc;
+        }
 
-        let ((sub_result, sub_provenance), new_acc) = scope.synthesize_internal_query(
-            ns!(cs, "recursive query"),
-            g,
-            store,
-            &subquery,
-            immediate.1,
-            is_recursive,
-        )?;
-
-        let (recursive_result, recursive_acc) = (self.post_recursion(cs, sub_result)?, new_acc);
+        let (recursive_result, recursive_acc) = (self.post_recursion(cs, &sub_results)?, new_acc);
 
         let value = AllocatedPtr::pick(
             ns!(cs, "pick value"),
@@ -147,21 +158,12 @@ pub(crate) trait RecursiveQuery<F: LurkField>: CircuitQuery<F> {
             &recursive_acc,
         )?;
 
-        let nil = g.alloc_ptr(ns!(cs, "nil"), &store.intern_nil(), store);
-
-        let dependency_provenance = AllocatedPtr::pick(
-            ns!(cs, "dependency provenance"),
-            &is_immediate,
-            &nil,
-            &sub_provenance,
-        )?;
-
         let provenance = self.synthesize_provenance(
             ns!(cs, "provenance"),
             g,
             store,
             value.clone(),
-            vec![dependency_provenance.clone()],
+            dependency_provenances,
             allocated_key,
         )?;
 

--- a/src/coroutine/memoset/query.rs
+++ b/src/coroutine/memoset/query.rs
@@ -88,13 +88,9 @@ where
         store: &Store<F>,
         result: AllocatedPtr<F>,
         dependency_provenances: Vec<AllocatedPtr<F>>,
-        allocated_key: Option<&AllocatedPtr<F>>,
+        allocated_key: &AllocatedPtr<F>,
     ) -> Result<AllocatedPtr<F>, SynthesisError> {
-        let query = if let Some(q) = allocated_key {
-            q.clone()
-        } else {
-            self.synthesize_query(ns!(cs, "query"), g, store)?
-        };
+        let query = allocated_key.clone();
         let p = AllocatedProvenance::new(query, result, dependency_provenances.clone());
 
         Ok(p.to_ptr(cs, g, store)?.clone())
@@ -166,7 +162,7 @@ pub(crate) trait RecursiveQuery<F: LurkField>: CircuitQuery<F> {
             store,
             value.clone(),
             vec![dependency_provenance.clone()],
-            Some(allocated_key),
+            allocated_key,
         )?;
 
         Ok(((value, provenance.clone()), acc))


### PR DESCRIPTION
Some simplifications, refactors, and a generalization of `recurse` to allow any number of recursive subqueries