### PR TITLE
ci: Switch to reusable `bench-deploy.yml`

### DIFF
--- a/.github/workflows/bench-deploy.yml
+++ b/.github/workflows/bench-deploy.yml
@@ -1,64 +1,14 @@
-name: GPU benchmark on `main`
+# Deploys `criterion` benchmarks and historical plots to `gh-pages`
+# https://lurk-lab.github.io/lurk-rs/benchmarks/criterion/reports/
+# https://lurk-lab.github.io/lurk-rs/benchmarks/history/plots.html
+name: GPU benchmark and deploy on `main`
+
 on:
   push:
-    branches:
-      - main
+    branches: main
+  workflow_dispatch:
 
 jobs:
-  # TODO: Account for different `justfile` and `bench.env` files
-  # One option is to upload them to gh-pages for qualitative comparison
-  # TODO: Fall back to a default if `justfile`/`bench.env` not present
   benchmark:
-    name: Bench and deploy
-    runs-on: [self-hosted, gpu-bench, gh-pages]
-    steps:
-      # Install deps
-      - uses: actions/checkout@v4
-        with:
-          repository: lurk-lab/ci-workflows
-      - uses: ./.github/actions/gpu-setup
-        with:
-          gpu-framework: 'cuda'
-      - uses: ./.github/actions/ci-env
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: just@1.22.0
-      # Run benchmarks and deploy
-      - name: Get old benchmarks
-        uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-          path: gh-pages
-      - run: mkdir -p target; cp -r gh-pages/benchmarks/criterion target;
-      - name: Install criterion
-        run: cargo install cargo-criterion
-      - name: Run benchmarks
-        run: |
-          just gpu-bench-ci fibonacci
-          cp fibonacci-${{ github.sha }}.json ..
-        working-directory: ${{ github.workspace }}/benches
-      # TODO: Prettify labels for easier viewing
-      # Compress the benchmark file and metadata for later analysis
-      - name: Compress artifacts
-        run: |
-          echo $LABELS > labels.md
-          tar -cvzf fibonacci-${{ github.sha }}.tar.gz Cargo.lock fibonacci-${{ github.sha }}.json labels.md
-        working-directory: ${{ github.workspace }}
-      - name: Deploy latest benchmark report
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./target/criterion
-          destination_dir: benchmarks/criterion
-      - name: Copy benchmark json to history
-        run: mkdir history; cp fibonacci-${{ github.sha }}.tar.gz history/
-      - name: Deploy benchmark history
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: history/
-          destination_dir: benchmarks/history
-          keep_files: true
+    # TODO: Switch to `main` once https://github.com/lurk-lab/ci-workflows/pull/44 is merged
+    uses: lurk-lab/ci-workflows/.github/workflows/bench-deploy.yml@bench-deploy

--- a/.github/workflows/bench-pr-comment.yml
+++ b/.github/workflows/bench-pr-comment.yml
@@ -20,4 +20,4 @@ jobs:
     with:
       default-runner: "self-hosted,gpu-bench"
       default-benches: "fibonacci"
-      default-env: "LURK_BENCH_OUTPUT=pr-comment LURK_RC=100,600"
+      default-env: "LURK_BENCH_OUTPUT=pr-comment LURK_BENCH_RC=100,600"

--- a/benches/bench.env
+++ b/benches/bench.env
@@ -1,4 +1,4 @@
 # Lurk config, used only in `justfile` by default
 LURK_PERF=fully-parallel
-LURK_RC=100,600
+LURK_BENCH_RC=100,600
 LURK_BENCH_NOISE_THRESHOLD=0.05

--- a/examples/tp_table.rs
+++ b/examples/tp_table.rs
@@ -96,8 +96,8 @@ fn analyze_adj(data: &[Vec<(usize, Vec<f64>)>], rc_vec: &[usize]) -> Vec<Vec<Str
 }
 
 fn rc_env() -> Result<Vec<usize>> {
-    std::env::var("LURK_RC")
-        .map_err(|e| anyhow!("LURK_RC env var isn't set: {e}"))
+    std::env::var("LURK_BENCH_RC")
+        .map_err(|e| anyhow!("LURK_BENCH_RC env var isn't set: {e}"))
         .and_then(|rc| {
             let vec: Result<Vec<usize>> = rc
                 .split(',')
@@ -125,7 +125,7 @@ fn n_folds_env() -> Result<usize> {
 ///
 /// Example:
 /// ```text
-/// $ LURK_RC=8,16 LURK_N_FOLDS=2 cargo run --release --example tp_table
+/// $ LURK_BENCH_RC=8,16 LURK_N_FOLDS=2 cargo run --release --example tp_table
 /// ...
 /// Raw throughput
 /// ┌────────────┬─────────────┬────────────┬────────────┐


### PR DESCRIPTION
- Adds historical benchmark plots via reusable `bench-deploy.yml` workflow, described in https://github.com/lurk-lab/ci-workflows/pull/44
- Refactors Fibonacci benchmark env configuration
  - Groups benchmarks by `fib_n` input rather than `rc`, which allows for a more natural comparison for each of our output types. For example this means in `gh-pages` we will have one plot per Fib input and one line per RC value, which means different RC performance can be compared directly.
  - Changes the `LURK_RC` env var to `LURK_BENCH_RC` to clarify its usage in benchmarks and bench-like examples only
  - Adds the `LURK_BENCH_FIBN` env var to configure Fibonacci input values as desired (e.g. in a PR comment benchmark)

> [!NOTE]
> Needs further testing once merged