### PR TITLE
chore: consider comm pointers as potential functions

### DIFF
--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -789,13 +789,16 @@ fn reduce(cprocs: &[(&Symbol, usize)]) -> Func {
         let cons: Expr::Cons;
         let thunk: Expr::Thunk;
         let num: Expr::Num;
+        let comm: Expr::Comm;
         let head_is_fun = eq_tag(head, fun);
         let head_is_cons = eq_tag(head, cons);
         let head_is_thunk = eq_tag(head, thunk);
         let head_is_num = eq_tag(head, num);
+        let head_is_comm = eq_tag(head, comm);
         let acc = or(head_is_fun, head_is_cons);
         let acc = or(acc, head_is_thunk);
         let acc = or(acc, head_is_num);
+        let acc = or(acc, head_is_comm);
         if acc {
             let t = Symbol("t");
             return (t)
@@ -1759,8 +1762,8 @@ mod tests {
         expect_eq(func.slots_count.commitment, expect!["1"]);
         expect_eq(func.slots_count.bit_decomp, expect!["3"]);
         expect_eq(cs.num_inputs(), expect!["1"]);
-        expect_eq(cs.aux().len(), expect!["9107"]);
-        expect_eq(cs.num_constraints(), expect!["11044"]);
+        expect_eq(cs.aux().len(), expect!["9110"]);
+        expect_eq(cs.num_constraints(), expect!["11048"]);
         assert_eq!(func.num_constraints(&store), cs.num_constraints());
     }
 }

--- a/src/lem/tests/eval_tests.rs
+++ b/src/lem/tests/eval_tests.rs
@@ -391,6 +391,30 @@ fn evaluate_comm_callable2() {
 }
 
 #[test]
+fn evaluate_comm_callable3() {
+    let s = &Store::<Fr>::default();
+    let comm_id_expr = s
+        .read_with_default_state("(commit (lambda (x) x))")
+        .unwrap();
+    let (io, ..) = evaluate_simple::<_, Coproc<Fr>>(None, comm_id_expr, s, 100).unwrap();
+    let comm_id = io[0];
+    let expr = s.list([comm_id, s.intern_nil()]);
+
+    let expected = s.intern_nil();
+    let terminal = s.cont_terminal();
+    do_test_aux::<Coproc<Fr>>(
+        s,
+        &expr,
+        Some(expected),
+        None,
+        Some(terminal),
+        None,
+        &expect!["4"],
+        &None,
+    );
+}
+
+#[test]
 fn evaluate_num_callable() {
     let s = &Store::<Fr>::default();
     let expr = "((num (commit (lambda (x) x))) nil)";


### PR DESCRIPTION
This PR covers a case I had forgotten in #1163: when the head of the call expression is *already* a `Comm` pointer before its evaluation.