### PR TITLE
chore: refine Coprocessors' API

### DIFF
--- a/lurk-macros/src/lib.rs
+++ b/lurk-macros/src/lib.rs
@@ -31,7 +31,6 @@ pub fn derive_enum_coproc(input: TokenStream) -> TokenStream {
 }
 
 fn impl_enum_coproc(name: &Ident, variants: &DataEnum) -> TokenStream {
-    let eval_arity_arms = eval_arity_match_arms(name, variants);
     let evaluate_internal_arms = evaluate_internal_match_arms(name, variants);
     let evaluate_arms = evaluate_match_arms(name, variants);
     let evaluate_simple_arms = evaluate_simple_match_arms(name, variants);
@@ -46,12 +45,6 @@ fn impl_enum_coproc(name: &Ident, variants: &DataEnum) -> TokenStream {
 
     let res = quote! {
         impl <F: lurk::field::LurkField> lurk::coprocessor::Coprocessor<F> for #name<F> {
-            fn eval_arity(&self) -> usize {
-                match self {
-                    #eval_arity_arms
-                }
-            }
-
             fn evaluate_internal(&self, s: &lurk::lem::store::Store<F>, ptrs: &[lurk::lem::pointers::Ptr]) -> Vec<lurk::lem::pointers::Ptr> {
                 match self {
                     #evaluate_internal_arms
@@ -129,18 +122,6 @@ fn impl_enum_coproc(name: &Ident, variants: &DataEnum) -> TokenStream {
         #from_impls
     };
     res.into()
-}
-
-fn eval_arity_match_arms(name: &Ident, variants: &DataEnum) -> proc_macro2::TokenStream {
-    let mut match_arms = quote! {};
-    for variant in variants.variants.iter() {
-        let variant_ident = &variant.ident;
-
-        match_arms.extend(quote! {
-            #name::#variant_ident(coprocessor) => coprocessor.eval_arity(),
-        });
-    }
-    match_arms
 }
 
 fn evaluate_internal_match_arms(name: &Ident, variants: &DataEnum) -> proc_macro2::TokenStream {

--- a/src/coprocessor/circom.rs
+++ b/src/coprocessor/circom.rs
@@ -123,14 +123,18 @@ Then run `lurk coprocessor --name {name} <{}_FOLDER>` to instantiate a new gadge
 
             Ok(res)
         }
+
+        fn alloc_globals<CS: ConstraintSystem<F>>(
+            &self,
+            cs: &mut CS,
+            g: &crate::lem::circuit::GlobalAllocator<F>,
+            _s: &Store<F>,
+        ) {
+            g.alloc_tag(cs, &crate::tag::ExprTag::Num);
+        }
     }
 
     impl<F: LurkField, C: CircomGadget<F> + Debug> Coprocessor<F> for CircomCoprocessor<F, C> {
-        /// TODO: Generalize
-        fn eval_arity(&self) -> usize {
-            0
-        }
-
         fn evaluate_simple(&self, s: &Store<F>, args: &[Ptr]) -> Ptr {
             self.gadget.evaluate_simple(s, args)
         }

--- a/src/coprocessor/sha256.rs
+++ b/src/coprocessor/sha256.rs
@@ -106,10 +106,6 @@ impl<F: LurkField> CoCircuit<F> for Sha256Coprocessor<F> {
 }
 
 impl<F: LurkField> Coprocessor<F> for Sha256Coprocessor<F> {
-    fn eval_arity(&self) -> usize {
-        self.n
-    }
-
     fn has_circuit(&self) -> bool {
         true
     }

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -63,10 +63,6 @@ pub struct NewCoprocessor<F> {
 }
 
 impl<F: LurkField> Coprocessor<F> for NewCoprocessor<F> {
-    fn eval_arity(&self) -> usize {
-        0
-    }
-
     fn evaluate_simple(&self, s: &Store<F>, _args: &[Ptr]) -> Ptr {
         let trie: StandardTrie<'_, F> = Trie::new(&s.poseidon_cache, &s.inverse_poseidon_cache);
         // TODO: Use a custom type.
@@ -109,10 +105,6 @@ pub struct LookupCoprocessor<F> {
 }
 
 impl<F: LurkField> Coprocessor<F> for LookupCoprocessor<F> {
-    fn eval_arity(&self) -> usize {
-        2
-    }
-
     fn evaluate_simple(&self, s: &Store<F>, args: &[Ptr]) -> Ptr {
         let root_ptr = &args[0];
         let key_ptr = &args[1];
@@ -203,6 +195,15 @@ impl<F: LurkField> CoCircuit<F> for LookupCoprocessor<F> {
             result_commitment_val,
         ))
     }
+
+    fn alloc_globals<CS: ConstraintSystem<F>>(
+        &self,
+        cs: &mut CS,
+        g: &lurk::lem::circuit::GlobalAllocator<F>,
+        _s: &Store<F>,
+    ) {
+        g.alloc_tag(cs, &ExprTag::Comm);
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Default, Deserialize)]
@@ -211,10 +212,6 @@ pub struct InsertCoprocessor<F> {
 }
 
 impl<F: LurkField> Coprocessor<F> for InsertCoprocessor<F> {
-    fn eval_arity(&self) -> usize {
-        3
-    }
-
     fn evaluate_simple(&self, s: &Store<F>, args: &[Ptr]) -> Ptr {
         let root_ptr = &args[0];
         let key_ptr = &args[1];
@@ -307,6 +304,15 @@ impl<F: LurkField> CoCircuit<F> for InsertCoprocessor<F> {
 
         let num_tag = g.alloc_tag(cs, &ExprTag::Num);
         Ok(AllocatedPtr::from_parts(num_tag.clone(), new_root_val))
+    }
+
+    fn alloc_globals<CS: ConstraintSystem<F>>(
+        &self,
+        cs: &mut CS,
+        g: &lurk::lem::circuit::GlobalAllocator<F>,
+        _s: &Store<F>,
+    ) {
+        g.alloc_tag(cs, &ExprTag::Num);
     }
 }
 

--- a/src/eval/lang.rs
+++ b/src/eval/lang.rs
@@ -24,11 +24,6 @@ pub struct DummyCoprocessor<F> {
 }
 
 impl<F: LurkField> Coprocessor<F> for DummyCoprocessor<F> {
-    /// Dummy Coprocessor takes no arguments.
-    fn eval_arity(&self) -> usize {
-        0
-    }
-
     /// And does nothing but return nil. It should probably never be used and can perhaps be eliminated,
     /// but for now it exists as an exemplar demonstrating the intended shape of enums like the default, `Coproc`.
     fn evaluate_simple(&self, s: &Store<F>, _args: &[Ptr]) -> Ptr {
@@ -36,7 +31,11 @@ impl<F: LurkField> Coprocessor<F> for DummyCoprocessor<F> {
     }
 }
 
-impl<F: LurkField> CoCircuit<F> for DummyCoprocessor<F> {}
+impl<F: LurkField> CoCircuit<F> for DummyCoprocessor<F> {
+    fn arity(&self) -> usize {
+        0
+    }
+}
 
 impl<F> DummyCoprocessor<F> {
     #[allow(dead_code)]

--- a/src/lem/multiframe.rs
+++ b/src/lem/multiframe.rs
@@ -770,7 +770,7 @@ impl<'a, F: LurkField, C: Coprocessor<F>> Circuit<F> for MultiFrame<'a, F, C> {
                 allocated_output.push(AllocatedPtr::from_parts(allocated_tag, allocated_hash));
             }
 
-            let g = self.lurk_step.alloc_consts(cs, store);
+            let g = self.lurk_step.alloc_consts(cs, store, self.get_lang());
 
             let allocated_output_result =
                 self.synthesize_frames(cs, store, allocated_input, frames, &g)?;
@@ -891,13 +891,13 @@ impl<'a, F: LurkField, C: Coprocessor<F>> nova::traits::circuit::StepCircuit<F>
             if self.pc != 0 {
                 assert_eq!(frames.len(), 1);
             }
-            let g = self.lurk_step.alloc_consts(cs, store);
+            let g = self.lurk_step.alloc_consts(cs, store, self.get_lang());
             self.synthesize_frames(cs, store, input, frames, &g)?
         } else {
             let store = Store::default();
             let blank_frame = Frame::blank(self.get_func(), self.pc, &store);
             let frames = vec![blank_frame; self.num_frames];
-            let g = self.lurk_step.alloc_consts(cs, &store);
+            let g = self.lurk_step.alloc_consts(cs, &store, self.get_lang());
             self.synthesize_frames(cs, &store, input, &frames, &g)?
         };
 
@@ -1066,7 +1066,10 @@ mod tests {
                 }
             }
         }
-        let g = lurk_step.alloc_consts(&mut cs, &store);
+
+        let lang = Lang::<Bn>::new();
+
+        let g = lurk_step.alloc_consts(&mut cs, &store, &lang);
 
         // asserting equality of frames witnesses
         let frame = frames.first().unwrap();
@@ -1081,8 +1084,6 @@ mod tests {
         }
 
         let mut cs_clone = cs.clone();
-
-        let lang = Lang::<Bn>::new();
 
         let output_sequential = synthesize_frames_sequential(
             &mut cs,

--- a/src/proof/tests/nova_tests.rs
+++ b/src/proof/tests/nova_tests.rs
@@ -9,8 +9,7 @@ use crate::{
         tag::Tag,
     },
     num::Num,
-    state::user_sym,
-    state::State,
+    state::{user_sym, State},
     tag::{ExprTag, Op, Op1, Op2},
 };
 
@@ -4047,7 +4046,7 @@ fn test_dumb_lang() {
 
 #[test]
 fn test_terminator_lang() {
-    use crate::{coprocessor::test::Terminator, state::user_sym};
+    use crate::coprocessor::test::Terminator;
 
     let mut lang = Lang::<Fr, Terminator<Fr>>::new();
     let dumb = Terminator::new();
@@ -4064,6 +4063,32 @@ fn test_terminator_lang() {
     test_aux::<_, Terminator<_>>(
         s,
         expr,
+        Some(res),
+        None,
+        Some(terminal),
+        None,
+        &expect!["1"],
+        &Some(lang.into()),
+    );
+}
+
+#[test]
+fn test_hello_world_lang() {
+    use crate::coprocessor::test::HelloWorld;
+
+    let mut lang = Lang::<Fr, HelloWorld<Fr>>::new();
+    let hello_world = HelloWorld::new();
+    let name = user_sym("hello-world");
+
+    let s = &Store::default();
+    lang.add_coprocessor(name, hello_world);
+
+    let res = HelloWorld::intern_hello_world(s);
+    let terminal = s.cont_terminal();
+
+    test_aux::<_, HelloWorld<_>>(
+        s,
+        "(hello-world)",
         Some(res),
         None,
         Some(terminal),


### PR DESCRIPTION
* Allow coprocessor to alloc their own global constants
* Remove Coprocessor::eval_arity since the implementer already defines CoCircuit::arity

Closes #979