### PR TITLE
feat: `Lang::intern_symbols`

### DIFF
--- a/benches/end2end.rs
+++ b/benches/end2end.rs
@@ -2,7 +2,7 @@ use criterion::{
     black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, SamplingMode,
 };
 use halo2curves::bn256::Fr as Bn;
-use std::{cell::RefCell, rc::Rc, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use lurk::{
     eval::lang::{Coproc, Lang},
@@ -17,7 +17,7 @@ use lurk::{
         self,
         instance::{Instance, Kind},
     },
-    state::State,
+    state::{State, StateRcCell},
 };
 
 mod common;
@@ -25,7 +25,7 @@ use common::set_bench_config;
 
 const DEFAULT_REDUCTION_COUNT: usize = 10;
 
-fn go_base<F: LurkField>(store: &Store<F>, state: Rc<RefCell<State>>, a: u64, b: u64) -> Ptr {
+fn go_base<F: LurkField>(store: &Store<F>, state: StateRcCell, a: u64, b: u64) -> Ptr {
     let program = format!(
         r#"
 (let ((foo (lambda (a b)

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -11,7 +11,7 @@ use criterion::{
     BenchmarkId, Criterion, SamplingMode,
 };
 use halo2curves::bn256::Fr as Bn;
-use std::{cell::RefCell, rc::Rc, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use lurk::{
     coprocessor::sha256::{Sha256Coproc, Sha256Coprocessor},
@@ -27,7 +27,7 @@ use lurk::{
         instance::{Instance, Kind},
         public_params, supernova_public_params,
     },
-    state::{user_sym, State},
+    state::{user_sym, State, StateRcCell},
 };
 
 mod common;
@@ -35,7 +35,7 @@ use common::set_bench_config;
 
 fn sha256_ivc<F: LurkField>(
     store: &Store<F>,
-    state: Rc<RefCell<State>>,
+    state: StateRcCell,
     arity: usize,
     n: usize,
     input: &[usize],
@@ -91,7 +91,7 @@ impl ProveParams {
 fn sha256_ivc_prove<M: measurement::Measurement>(
     prove_params: ProveParams,
     c: &mut BenchmarkGroup<'_, M>,
-    state: &Rc<RefCell<State>>,
+    state: &StateRcCell,
 ) {
     let ProveParams {
         arity,
@@ -172,7 +172,7 @@ fn ivc_prove_benchmarks(c: &mut Criterion) {
 fn sha256_ivc_prove_compressed<M: measurement::Measurement>(
     prove_params: ProveParams,
     c: &mut BenchmarkGroup<'_, M>,
-    state: &Rc<RefCell<State>>,
+    state: &StateRcCell,
 ) {
     let ProveParams {
         arity,
@@ -255,7 +255,7 @@ fn ivc_prove_compressed_benchmarks(c: &mut Criterion) {
 fn sha256_nivc_prove<M: measurement::Measurement>(
     prove_params: ProveParams,
     c: &mut BenchmarkGroup<'_, M>,
-    state: &Rc<RefCell<State>>,
+    state: &StateRcCell,
 ) {
     let ProveParams {
         arity,

--- a/benches/synthesis.rs
+++ b/benches/synthesis.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, rc::Rc, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use bellpepper::util_cs::witness_cs::WitnessCS;
 use bellpepper_core::{Circuit, ConstraintSystem};
@@ -13,10 +13,10 @@ use lurk::{
     field::LurkField,
     lem::{eval::evaluate, multiframe::MultiFrame, pointers::Ptr, store::Store},
     proof::supernova::FoldingConfig,
-    state::State,
+    state::{State, StateRcCell},
 };
 
-fn fib<F: LurkField>(store: &Store<F>, state: Rc<RefCell<State>>, a: u64) -> Ptr {
+fn fib<F: LurkField>(store: &Store<F>, state: StateRcCell, a: u64) -> Ptr {
     let program = format!(
         r#"
 (let ((fib (lambda (target)

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -10,23 +10,20 @@
 //! proof, will actually be a proof *verifying* that the vanilla operation was correctly performed. Therefore, the
 //! vanilla operation needs to provide such a proof so the circuit can verify it.
 
-use std::cell::RefCell;
 // TODO:
 //  - Implement circuit (https://github.com/lurk-lab/lurk-rs/issues/421).
 //  - Adapt to ongoing changes to general coprocessor API, most importantly, absorb
 //    https://github.com/lurk-lab/lurk-rs/issues/398. - If #398 is smooth enough, no actual implementation changes
 //    should be required here, but the test in src/eval/tests/trie.rs can and should be updated.
 use std::marker::PhantomData;
-use std::rc::Rc;
 
 use bellpepper_core::{boolean::Boolean, num::AllocatedNum, ConstraintSystem, SynthesisError};
 
 use lurk_macros::Coproc;
 use serde::{Deserialize, Serialize};
 
-use crate::package::Package;
-use crate::state::State;
-use crate::{self as lurk, Symbol};
+use crate::state::StateRcCell;
+use crate::{self as lurk};
 
 use crate::circuit::gadgets::constraints::{enforce_equal, implies_equal, select};
 use crate::circuit::gadgets::pointer::AllocatedPtr;
@@ -318,17 +315,18 @@ impl<F: LurkField> CoCircuit<F> for InsertCoprocessor<F> {
 
 /// Add the `Trie`-associated functions to a `Lang` with standard bindings.
 // TODO: define standard patterns for such modularity.
-pub fn install<F: LurkField>(state: &Rc<RefCell<State>>, lang: &mut Lang<F, TrieCoproc<F>>) {
+pub fn install<F: LurkField>(state: &StateRcCell, lang: &mut Lang<F, TrieCoproc<F>>) {
     lang.add_coprocessor(".lurk.trie.new", NewCoprocessor::default());
     lang.add_coprocessor(".lurk.trie.lookup", LookupCoprocessor::default());
     lang.add_coprocessor(".lurk.trie.insert", InsertCoprocessor::default());
+    lang.intern_symbols(state);
+}
 
-    let trie_package_name: Symbol = ".lurk.trie".into();
-    let mut package = Package::new(trie_package_name.into());
-    for name in ["new", "lookup", "insert"].into_iter() {
-        package.intern(name);
-    }
-    state.borrow_mut().add_package(package);
+/// Creates a `Lang` using the `Trie`-associated functions with standard bindings
+pub fn mk_lang<F: LurkField>(state: &StateRcCell) -> Lang<F, TrieCoproc<F>> {
+    let mut lang = Lang::new();
+    install(state, &mut lang);
+    lang
 }
 
 pub type ChildMap<F, const ARITY: usize> = InversePoseidonCache<F>;

--- a/src/lem/store.rs
+++ b/src/lem/store.rs
@@ -9,14 +9,14 @@ use indexmap::IndexSet;
 use neptune::Poseidon;
 use nom::{sequence::preceded, Parser};
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
-use std::{cell::RefCell, rc::Rc, sync::Arc};
+use std::sync::Arc;
 
 use crate::{
     field::{FWrap, LurkField},
     hash::{InversePoseidonCache, PoseidonCache},
     lem::Tag,
     parser::{syntax, Error, Span},
-    state::{lurk_sym, user_sym, State},
+    state::{lurk_sym, user_sym, State, StateRcCell},
     symbol::Symbol,
     syntax::Syntax,
     tag::ContTag::{
@@ -945,7 +945,7 @@ impl<F: LurkField> Store<F> {
         }
     }
 
-    pub fn read(&self, state: Rc<RefCell<State>>, input: &str) -> Result<Ptr> {
+    pub fn read(&self, state: StateRcCell, input: &str) -> Result<Ptr> {
         match preceded(
             syntax::parse_space,
             syntax::parse_syntax(state, false, false),
@@ -959,7 +959,7 @@ impl<F: LurkField> Store<F> {
 
     pub fn read_maybe_meta<'a>(
         &self,
-        state: Rc<RefCell<State>>,
+        state: StateRcCell,
         input: &'a str,
     ) -> Result<(usize, Span<'a>, Ptr, bool), Error> {
         match preceded(syntax::parse_space, syntax::parse_maybe_meta(state, false))

--- a/src/lem/tests/eval_tests.rs
+++ b/src/lem/tests/eval_tests.rs
@@ -1,6 +1,5 @@
 use expect_test::{expect, Expect};
 use halo2curves::bn256::Fr;
-use std::{cell::RefCell, rc::Rc};
 
 use crate::{
     coprocessor::Coprocessor,
@@ -13,7 +12,7 @@ use crate::{
         store::Store,
         Tag,
     },
-    state::State,
+    state::{State, StateRcCell},
     tag::Op,
 };
 
@@ -42,7 +41,7 @@ fn test_aux<C: Coprocessor<Fr>>(
 
 fn test_aux_with_state<C: Coprocessor<Fr>>(
     s: &Store<Fr>,
-    state: Rc<RefCell<State>>,
+    state: StateRcCell,
     expr: &str,
     expected_result: Option<Ptr>,
     expected_env: Option<Ptr>,
@@ -3847,13 +3846,11 @@ fn test_dumb_lang() {
 
 #[test]
 fn test_trie_lang() {
-    use crate::coprocessor::trie::{install, TrieCoproc};
+    use crate::coprocessor::trie::mk_lang;
 
     let s = &Store::<Fr>::default();
     let state = State::init_lurk_state().rccell();
-    let mut lang = Lang::<Fr, TrieCoproc<Fr>>::new();
-
-    install(&state, &mut lang);
+    let lang = mk_lang(&state);
 
     let expr = "(let ((trie (.lurk.trie.new)))
                       trie)";

--- a/src/proof/tests/nova_tests.rs
+++ b/src/proof/tests/nova_tests.rs
@@ -1,6 +1,6 @@
 use expect_test::expect;
 use halo2curves::bn256::Fr;
-use std::{cell::RefCell, rc::Rc, sync::Arc};
+use std::sync::Arc;
 
 use crate::{
     eval::lang::{Coproc, Lang},
@@ -9,7 +9,7 @@ use crate::{
         tag::Tag,
     },
     num::Num,
-    state::{user_sym, State},
+    state::{user_sym, State, StateRcCell},
     tag::{ExprTag, Op, Op1, Op2},
 };
 
@@ -3877,7 +3877,7 @@ fn test_prove_head_with_sym_mimicking_value() {
     let s = &Store::<Fr>::default();
     let error = s.cont_error();
 
-    let mk_expr = |s: &Store<Fr>, state: Rc<RefCell<State>>, name, args| {
+    let mk_expr = |s: &Store<Fr>, state: StateRcCell, name, args| {
         let sym_as_char = s.intern_lurk_symbol(name).cast(Tag::Expr(ExprTag::Char));
         let args = s.read(state.clone(), args).unwrap();
         s.cons(sym_as_char, args)
@@ -4100,15 +4100,11 @@ fn test_hello_world_lang() {
 
 #[test]
 fn test_trie_lang() {
-    use crate::coprocessor::trie::{install, TrieCoproc};
+    use crate::coprocessor::trie::{mk_lang, TrieCoproc};
 
     let s = &Store::<Fr>::default();
     let state = State::init_lurk_state().rccell();
-    let mut lang = Lang::<Fr, TrieCoproc<Fr>>::new();
-
-    install(&state, &mut lang);
-
-    let lang = Arc::new(lang);
+    let lang = Arc::new(mk_lang(&state));
 
     let terminal = s.cont_terminal();
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -18,10 +18,13 @@ pub struct State {
     symbol_packages: HashMap<SymbolRef, Package>,
 }
 
+/// Alias for `Rc<RefCell<State>>`
+pub type StateRcCell = Rc<RefCell<State>>;
+
 impl State {
     /// Wraps a state with `Rc<RefCell<...>>`
     #[inline]
-    pub fn rccell(self) -> Rc<RefCell<Self>> {
+    pub fn rccell(self) -> StateRcCell {
         Rc::new(RefCell::new(self))
     }
 
@@ -130,6 +133,16 @@ impl State {
         create_unknown_packges: bool,
     ) -> Result<SymbolRef> {
         self.intern_fold(Symbol::root(keyword).into(), path, create_unknown_packges)
+    }
+
+    /// Call `intern_path` with the symbol's path and keyword flag
+    #[inline]
+    pub fn intern_symbol(
+        &mut self,
+        symbol: &Symbol,
+        create_unknown_packges: bool,
+    ) -> Result<SymbolRef> {
+        self.intern_path(symbol.path(), symbol.is_keyword(), create_unknown_packges)
     }
 
     /// Call `intern_fold` w.r.t. the current package


### PR DESCRIPTION
* Add `Lang::intern_symbols` to facilitate lang installations
* Use `Lang::intern_symbols` on the REPL
* Create an alias for `Rc<RefCell<State>>` and use it
* Rewrite some functions to one-liners