### PR TITLE
Fix coprocessors returning lists in SuperNova

### DIFF
--- a/src/cli/repl/mod.rs
+++ b/src/cli/repl/mod.rs
@@ -43,10 +43,7 @@ use crate::{
         supernova::SuperNovaProver,
         RecursiveSNARKTrait,
     },
-    public_parameters::{
-        instance::{Instance, Kind},
-        public_params, supernova_public_params,
-    },
+    public_parameters::{instance::Instance, public_params, supernova_public_params},
     state::State,
     tag::{ContTag, ExprTag},
     Symbol,
@@ -338,12 +335,11 @@ where
             info!("Proof not cached");
             let (proof, public_inputs, public_outputs) = match self.backend {
                 Backend::Nova => {
+                    let prover = NovaProver::<_, C>::new(self.rc, self.lang.clone());
                     info!("Loading Nova public parameters");
-                    let instance =
-                        Instance::new(self.rc, self.lang.clone(), true, Kind::NovaPublicParams);
+                    let instance = Instance::new_nova(&prover, true);
                     let pp = public_params(&instance)?;
 
-                    let prover = NovaProver::<_, C>::new(self.rc, self.lang.clone());
                     info!("Proving with NovaProver");
                     let (proof, public_inputs, public_outputs, num_steps) =
                         prover.prove_from_frames(&pp, frames, &self.store)?;
@@ -354,12 +350,11 @@ where
                     (LurkProofWrapper::Nova(proof), public_inputs, public_outputs)
                 }
                 Backend::SuperNova => {
+                    let prover = SuperNovaProver::<_, C>::new(self.rc, self.lang.clone());
                     info!("Loading SuperNova public parameters");
-                    let instance =
-                        Instance::new(self.rc, self.lang.clone(), true, Kind::SuperNovaAuxParams);
+                    let instance = Instance::new_supernova(&prover, true);
                     let pp = supernova_public_params(&instance)?;
 
-                    let prover = SuperNovaProver::<_, C>::new(self.rc, self.lang.clone());
                     info!("Proving with SuperNovaProver");
                     let (proof, public_inputs, public_outputs, _num_steps) =
                         prover.prove_from_frames(&pp, frames, &self.store)?;

--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -353,6 +353,7 @@ fn car_cdr() -> Func {
 ///                             // there must be no remaining arguments
 ///                             if is_nil {
 ///                                 Op::Cproc([expr, env, cont], x, [x0, x1, ..., x{n-1}, env, cont]);
+///                                 let expr: Expr::Thunk = cons2(expr, cont);
 ///                                 return (expr, env, cont);
 ///                             }
 ///                             return (evaluated_args_cp, env, err);
@@ -390,7 +391,10 @@ fn run_cproc(cproc_sym: Symbol, arity: usize) -> Func {
     cproc_inp.push(env.clone());
     cproc_inp.push(cont.clone());
     let mut block = Block {
-        ops: vec![Op::Cproc(cproc_out, cproc_sym.clone(), cproc_inp.clone())],
+        ops: vec![
+            Op::Cproc(cproc_out, cproc_sym.clone(), cproc_inp.clone()),
+            op!(let expr: Expr::Thunk = cons2(expr, cont)),
+        ],
         ctrl: Ctrl::Return(func_out),
     };
     for (i, cproc_arg) in cproc_inp[0..arity].iter().enumerate() {

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -399,7 +399,8 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a> NovaProver<'a, F, C> {
     }
 
     #[inline]
-    fn lang(&self) -> &Arc<Lang<F, C>> {
+    /// Returns the `Lang` wrapped with `Arc` for cheap cloning
+    pub fn lang(&self) -> &Arc<Lang<F, C>> {
         &self.lang
     }
 }

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -183,7 +183,8 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a> SuperNovaProver<'a, F, C
     }
 
     #[inline]
-    fn lang(&self) -> &Arc<Lang<F, C>> {
+    /// Returns the `Lang` wrapped with `Arc` for cheap cloning
+    pub fn lang(&self) -> &Arc<Lang<F, C>> {
         &self.lang
     }
 }

--- a/src/proof/tests/mod.rs
+++ b/src/proof/tests/mod.rs
@@ -1,4 +1,6 @@
 mod nova_tests;
+mod supernova_tests;
+
 use bellpepper::util_cs::{metric_cs::MetricCS, witness_cs::WitnessCS, Comparable};
 use bellpepper_core::{test_cs::TestConstraintSystem, Circuit, ConstraintSystem, Delta};
 use expect_test::Expect;

--- a/src/proof/tests/supernova_tests.rs
+++ b/src/proof/tests/supernova_tests.rs
@@ -1,0 +1,62 @@
+use halo2curves::bn256::Fr;
+use std::sync::Arc;
+
+use crate::{
+    eval::lang::Lang,
+    lem::{
+        eval::{evaluate, make_cprocs_funcs_from_lang, make_eval_step_from_config, EvalConfig},
+        store::Store,
+    },
+    proof::{supernova::SuperNovaProver, RecursiveSNARKTrait},
+    public_parameters::{instance::Instance, supernova_public_params},
+    state::user_sym,
+};
+
+#[test]
+fn test_nil_nil_lang() {
+    use crate::coprocessor::test::NilNil;
+    let mut lang = Lang::<Fr, NilNil<Fr>>::new();
+    lang.add_coprocessor(user_sym("nil-nil"), NilNil::new());
+
+    let eval_config = EvalConfig::new_nivc(&lang);
+    let lurk_step = make_eval_step_from_config(&eval_config);
+    let cprocs = make_cprocs_funcs_from_lang(&lang);
+
+    let store = Store::default();
+    let expr = store.read_with_default_state("(nil-nil)").unwrap();
+    let frames = evaluate(Some((&lurk_step, &cprocs, &lang)), expr, &store, 50).unwrap();
+
+    // iteration 1: main circuit sets up a call to the coprocessor
+    // iteration 2: coprocessor does its job
+    // iteration 3: main circuit sets termination to terminal
+    assert_eq!(frames.len(), 3);
+
+    let first_frame = frames.first().unwrap();
+    let last_frame = frames.last().unwrap();
+    let output = &last_frame.output;
+
+    // the result is the (nil . nil) pair
+    let nil = store.intern_nil();
+    assert!(store.ptr_eq(&output[0], &store.cons(nil, nil)));
+
+    // computation must end with the terminal continuation
+    assert!(store.ptr_eq(&output[2], &store.cont_terminal()));
+
+    let supernova_prover = SuperNovaProver::new(5, Arc::new(lang));
+    let instance = Instance::new_supernova(&supernova_prover, true);
+    let pp = supernova_public_params(&instance).unwrap();
+
+    let (proof, ..) = supernova_prover
+        .prove_from_frames(&pp, &frames, &store)
+        .unwrap();
+
+    let input_scalar = store.to_scalar_vector(&first_frame.input);
+    let output_scalar = store.to_scalar_vector(output);
+
+    // uncompressed proof verifies
+    assert!(proof.verify(&pp, &input_scalar, &output_scalar).unwrap());
+
+    // compressed proof verifies
+    let proof = proof.compress(&pp).unwrap();
+    assert!(proof.verify(&pp, &input_scalar, &output_scalar).unwrap());
+}

--- a/src/public_parameters/instance.rs
+++ b/src/public_parameters/instance.rs
@@ -50,8 +50,9 @@ use crate::{
     coprocessor::Coprocessor,
     eval::lang::Lang,
     proof::{
-        nova::{self, CurveCycleEquipped},
-        supernova::{self},
+        nova::{self, CurveCycleEquipped, NovaProver},
+        supernova::{self, SuperNovaProver},
+        Prover,
     },
 };
 
@@ -132,6 +133,30 @@ impl<F: CurveCycleEquipped, C: Coprocessor<F>> Instance<F, C> {
             cache_key,
             kind,
         }
+    }
+
+    /// Returns an `Instance` for Nova public parameters with the prover's
+    /// reduction count and lang
+    #[inline]
+    pub fn new_nova(prover: &NovaProver<'_, F, C>, abomonated: bool) -> Self {
+        Self::new(
+            prover.reduction_count(),
+            prover.lang().clone(),
+            abomonated,
+            Kind::NovaPublicParams,
+        )
+    }
+
+    /// Returns an `Instance` for SuperNova public parameters with the prover's
+    /// reduction count and lang
+    #[inline]
+    pub fn new_supernova(prover: &SuperNovaProver<'_, F, C>, abomonated: bool) -> Self {
+        Self::new(
+            prover.reduction_count(),
+            prover.lang().clone(),
+            abomonated,
+            Kind::SuperNovaAuxParams,
+        )
     }
 
     /// If this [Instance] is of [Kind::SuperNovaAuxParams], then generate the `num_circuits + 1`


### PR DESCRIPTION
Uncovered a weird bug where a coprocessor returning a regular value would work most times, but a list would fail as if it was trying to be interpreted. After a debugging session with @arthurpaulino, we managed to narrow down that it didn't happen with `--backend=nova` and identified the issue:

In NIVC, the Lurk circuit calls out to the coprocessor circuit (since it cannot know the value of evaluating the coprocessor in its own circuit), and then on the next fold step calls back into the main Lurk circuit with the result of the coprocessor for an extra frame. If the coprocessor returns a single value, there is no issue (since `5` evaluates to `5`), but if the coprocessor returns a list like `(1 2)`, then the lurk circuit attempts to evaluate that expression instead of simply returning it.

To fix it, this PR wraps the coprocessor return expr with a thunk in `run_cproc`.

I've confirmed the fix locally with my own coprocessor, but we should add some tests for this, a problem seems to be that current coprocessor tests run on the nova backend so this wasn't caught (I think @arthurpaulino will push some commits to this branch on that front)

Side note: the Thunk was used as an alternative to transforming it into `(quote expr)` since that would require making a symbol and two `cons2` Ops, whereas the Thunk is its own single Op