### PR TITLE
chore: several QOL improvements

### DIFF
--- a/benches/end2end.rs
+++ b/benches/end2end.rs
@@ -2,7 +2,7 @@ use criterion::{
     black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, SamplingMode,
 };
 use halo2curves::bn256::Fr as Bn;
-use std::{cell::RefCell, rc::Rc, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use lurk::{
     eval::lang::{Coproc, Lang},
@@ -17,7 +17,7 @@ use lurk::{
         self,
         instance::{Instance, Kind},
     },
-    state::State,
+    state::{State, StateRcCell},
 };
 
 mod common;
@@ -25,7 +25,7 @@ use common::set_bench_config;
 
 const DEFAULT_REDUCTION_COUNT: usize = 10;
 
-fn go_base<F: LurkField>(store: &Store<F>, state: Rc<RefCell<State>>, a: u64, b: u64) -> Ptr {
+fn go_base<F: LurkField>(store: &Store<F>, state: StateRcCell, a: u64, b: u64) -> Ptr {
     let program = format!(
         r#"
 (let ((foo (lambda (a b)

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -11,7 +11,7 @@ use criterion::{
     BenchmarkId, Criterion, SamplingMode,
 };
 use halo2curves::bn256::Fr as Bn;
-use std::{cell::RefCell, rc::Rc, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use lurk::{
     coprocessor::sha256::{Sha256Coproc, Sha256Coprocessor},
@@ -27,7 +27,7 @@ use lurk::{
         instance::{Instance, Kind},
         public_params, supernova_public_params,
     },
-    state::{user_sym, State},
+    state::{user_sym, State, StateRcCell},
 };
 
 mod common;
@@ -35,7 +35,7 @@ use common::set_bench_config;
 
 fn sha256_ivc<F: LurkField>(
     store: &Store<F>,
-    state: Rc<RefCell<State>>,
+    state: StateRcCell,
     arity: usize,
     n: usize,
     input: &[usize],
@@ -91,7 +91,7 @@ impl ProveParams {
 fn sha256_ivc_prove<M: measurement::Measurement>(
     prove_params: ProveParams,
     c: &mut BenchmarkGroup<'_, M>,
-    state: &Rc<RefCell<State>>,
+    state: &StateRcCell,
 ) {
     let ProveParams {
         arity,
@@ -172,7 +172,7 @@ fn ivc_prove_benchmarks(c: &mut Criterion) {
 fn sha256_ivc_prove_compressed<M: measurement::Measurement>(
     prove_params: ProveParams,
     c: &mut BenchmarkGroup<'_, M>,
-    state: &Rc<RefCell<State>>,
+    state: &StateRcCell,
 ) {
     let ProveParams {
         arity,
@@ -255,7 +255,7 @@ fn ivc_prove_compressed_benchmarks(c: &mut Criterion) {
 fn sha256_nivc_prove<M: measurement::Measurement>(
     prove_params: ProveParams,
     c: &mut BenchmarkGroup<'_, M>,
-    state: &Rc<RefCell<State>>,
+    state: &StateRcCell,
 ) {
     let ProveParams {
         arity,

--- a/benches/synthesis.rs
+++ b/benches/synthesis.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, rc::Rc, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use bellpepper::util_cs::witness_cs::WitnessCS;
 use bellpepper_core::{Circuit, ConstraintSystem};
@@ -13,10 +13,10 @@ use lurk::{
     field::LurkField,
     lem::{eval::evaluate, multiframe::MultiFrame, pointers::Ptr, store::Store},
     proof::supernova::FoldingConfig,
-    state::State,
+    state::{State, StateRcCell},
 };
 
-fn fib<F: LurkField>(store: &Store<F>, state: Rc<RefCell<State>>, a: u64) -> Ptr {
+fn fib<F: LurkField>(store: &Store<F>, state: StateRcCell, a: u64) -> Ptr {
     let program = format!(
         r#"
 (let ((fib (lambda (target)

--- a/src/cli/repl/mod.rs
+++ b/src/cli/repl/mod.rs
@@ -12,14 +12,7 @@ use rustyline::{
 };
 use rustyline_derive::{Completer, Helper, Highlighter, Hinter};
 use serde::{de::DeserializeOwned, Serialize};
-use std::{
-    cell::{OnceCell, RefCell},
-    collections::HashMap,
-    fs::read_to_string,
-    io::Write,
-    rc::Rc,
-    sync::Arc,
-};
+use std::{cell::OnceCell, collections::HashMap, fs::read_to_string, io::Write, sync::Arc};
 use tracing::info;
 
 use crate::{
@@ -44,7 +37,7 @@ use crate::{
         RecursiveSNARKTrait,
     },
     public_parameters::{instance::Instance, public_params, supernova_public_params},
-    state::State,
+    state::{State, StateRcCell},
     tag::{ContTag, ExprTag},
     Symbol,
 };
@@ -87,7 +80,7 @@ impl Evaluation {
 #[allow(dead_code)]
 pub(crate) struct Repl<F: LurkField, C: Coprocessor<F> + Serialize + DeserializeOwned> {
     store: Store<F>,
-    state: Rc<RefCell<State>>,
+    state: StateRcCell,
     lang: Arc<Lang<F, C>>,
     lurk_step: Func,
     cprocs: Vec<Func>,

--- a/src/eval/lang.rs
+++ b/src/eval/lang.rs
@@ -87,13 +87,14 @@ impl<F: LurkField, C> Lang<F, C> {
         }
     }
 
-    pub fn new_with_bindings<B: Into<Binding<F, C>>>(bindings: Vec<B>) -> Self {
-        let mut new = Self::new();
-        for b in bindings {
-            new.add_binding(b.into());
-        }
-
-        new
+    #[inline]
+    pub fn new_with_bindings<B: Into<Binding<F, C>>, I: IntoIterator<Item = B>>(
+        bindings: I,
+    ) -> Self {
+        bindings.into_iter().fold(Self::new(), |mut acc, b| {
+            acc.add_binding(b.into());
+            acc
+        })
     }
 
     pub fn key(&self) -> String {
@@ -109,9 +110,9 @@ impl<F: LurkField, C> Lang<F, C> {
         key
     }
 
+    #[inline]
     pub fn add_coprocessor<T: Into<C>, S: Into<Symbol>>(&mut self, name: S, cproc: T) {
-        let name = name.into();
-        self.coprocessors.insert(name, cproc.into());
+        self.coprocessors.insert(name.into(), cproc.into());
     }
 
     pub fn add_binding<B: Into<Binding<F, C>>>(&mut self, binding: B) {
@@ -150,8 +151,8 @@ impl<F: LurkField, C> Lang<F, C> {
     }
 }
 
-/// A `Binding` associates a name (`Sym`) and `Coprocessor`. It facilitates modular construction of `Lang`s using
-/// `Coprocessor`s.
+/// A `Binding` associates a name (`Symbol`) and `Coprocessor`. It facilitates
+/// modular construction of `Lang`s using `Coprocessor`s.
 #[derive(Debug)]
 pub struct Binding<F, C> {
     name: Symbol,

--- a/src/lem/store.rs
+++ b/src/lem/store.rs
@@ -9,14 +9,14 @@ use indexmap::IndexSet;
 use neptune::Poseidon;
 use nom::{sequence::preceded, Parser};
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
-use std::{cell::RefCell, rc::Rc, sync::Arc};
+use std::sync::Arc;
 
 use crate::{
     field::{FWrap, LurkField},
     hash::{InversePoseidonCache, PoseidonCache},
     lem::Tag,
     parser::{syntax, Error, Span},
-    state::{lurk_sym, user_sym, State},
+    state::{lurk_sym, user_sym, State, StateRcCell},
     symbol::Symbol,
     syntax::Syntax,
     tag::ContTag::{
@@ -945,7 +945,7 @@ impl<F: LurkField> Store<F> {
         }
     }
 
-    pub fn read(&self, state: Rc<RefCell<State>>, input: &str) -> Result<Ptr> {
+    pub fn read(&self, state: StateRcCell, input: &str) -> Result<Ptr> {
         match preceded(
             syntax::parse_space,
             syntax::parse_syntax(state, false, false),
@@ -959,7 +959,7 @@ impl<F: LurkField> Store<F> {
 
     pub fn read_maybe_meta<'a>(
         &self,
-        state: Rc<RefCell<State>>,
+        state: StateRcCell,
         input: &'a str,
     ) -> Result<(usize, Span<'a>, Ptr, bool), Error> {
         match preceded(syntax::parse_space, syntax::parse_maybe_meta(state, false))

--- a/src/lem/tests/eval_tests.rs
+++ b/src/lem/tests/eval_tests.rs
@@ -1,6 +1,5 @@
 use expect_test::{expect, Expect};
 use halo2curves::bn256::Fr;
-use std::{cell::RefCell, rc::Rc};
 
 use crate::{
     coprocessor::Coprocessor,
@@ -13,7 +12,7 @@ use crate::{
         store::Store,
         Tag,
     },
-    state::State,
+    state::{State, StateRcCell},
     tag::Op,
 };
 
@@ -42,7 +41,7 @@ fn test_aux<C: Coprocessor<Fr>>(
 
 fn test_aux_with_state<C: Coprocessor<Fr>>(
     s: &Store<Fr>,
-    state: Rc<RefCell<State>>,
+    state: StateRcCell,
     expr: &str,
     expected_result: Option<Ptr>,
     expected_env: Option<Ptr>,
@@ -3390,14 +3389,14 @@ fn test_sym_hash_values() {
 
     let asdf_sym_package_name = state
         .borrow_mut()
-        .intern_path(&["asdf"], false, false)
+        .intern_path(["asdf"], false, false)
         .unwrap();
     let asdf_sym_package = Package::new(asdf_sym_package_name);
     state.borrow_mut().add_package(asdf_sym_package);
 
     let asdf_key_package_name = state
         .borrow_mut()
-        .intern_path(&["asdf"], true, false)
+        .intern_path(["asdf"], true, false)
         .unwrap();
     let asdf_key_package = Package::new(asdf_key_package_name);
     state.borrow_mut().add_package(asdf_key_package);
@@ -3847,12 +3846,11 @@ fn test_dumb_lang() {
 
 #[test]
 fn test_trie_lang() {
-    use crate::coprocessor::trie::{install, TrieCoproc};
+    use crate::coprocessor::trie::install;
 
     let s = &Store::<Fr>::default();
     let state = State::init_lurk_state().rccell();
-    let mut lang = Lang::<Fr, TrieCoproc<Fr>>::new();
-
+    let mut lang = Lang::new();
     install(&state, &mut lang);
 
     let expr = "(let ((trie (.lurk.trie.new)))

--- a/src/proof/tests/nova_tests.rs
+++ b/src/proof/tests/nova_tests.rs
@@ -1,6 +1,6 @@
 use expect_test::expect;
 use halo2curves::bn256::Fr;
-use std::{cell::RefCell, rc::Rc, sync::Arc};
+use std::sync::Arc;
 
 use crate::{
     eval::lang::{Coproc, Lang},
@@ -9,7 +9,7 @@ use crate::{
         tag::Tag,
     },
     num::Num,
-    state::{user_sym, State},
+    state::{user_sym, State, StateRcCell},
     tag::{ExprTag, Op, Op1, Op2},
 };
 
@@ -3877,7 +3877,7 @@ fn test_prove_head_with_sym_mimicking_value() {
     let s = &Store::<Fr>::default();
     let error = s.cont_error();
 
-    let mk_expr = |s: &Store<Fr>, state: Rc<RefCell<State>>, name, args| {
+    let mk_expr = |s: &Store<Fr>, state: StateRcCell, name, args| {
         let sym_as_char = s.intern_lurk_symbol(name).cast(Tag::Expr(ExprTag::Char));
         let args = s.read(state.clone(), args).unwrap();
         s.cons(sym_as_char, args)
@@ -4104,10 +4104,8 @@ fn test_trie_lang() {
 
     let s = &Store::<Fr>::default();
     let state = State::init_lurk_state().rccell();
-    let mut lang = Lang::<Fr, TrieCoproc<Fr>>::new();
-
+    let mut lang = Lang::new();
     install(&state, &mut lang);
-
     let lang = Arc::new(lang);
 
     let terminal = s.cont_terminal();


### PR DESCRIPTION
* Discourage hardcoded parsing of symbols in favor of proper interning
* Create an alias for `Rc<RefCell<State>>` and use it across the repo
* Use `IntoIterator` in a few places
* Rewrite some functions to one-liners
* Remove closed TODOs from the top of `src/coprocessor/trie/mod.rs`