### PR TITLE
feat: arm LEM interpretation with dual channel communitation

### DIFF
--- a/benches/common/fib.rs
+++ b/benches/common/fib.rs
@@ -2,6 +2,7 @@
 #![allow(dead_code)]
 
 use lurk::{
+    dual_channel::dummy_terminal,
     field::LurkField,
     lang::{Coproc, Lang},
     lem::{
@@ -42,7 +43,8 @@ fn lurk_fib<F: LurkField>(store: &Store<F>, n: usize) -> Ptr {
     let limit = frame_idx;
     let fib_expr = fib_expr(store);
 
-    let (output, ..) = evaluate_simple::<F, Coproc<F>>(None, fib_expr, store, limit).unwrap();
+    let (output, ..) =
+        evaluate_simple::<F, Coproc<F>>(None, fib_expr, store, limit, &dummy_terminal()).unwrap();
 
     let target_env = &output[1];
 

--- a/benches/end2end.rs
+++ b/benches/end2end.rs
@@ -5,6 +5,7 @@ use halo2curves::bn256::Fr as Bn;
 use std::{sync::Arc, time::Duration};
 
 use lurk::{
+    dual_channel::dummy_terminal,
     field::LurkField,
     lang::{Coproc, Lang},
     lem::{
@@ -77,7 +78,8 @@ fn end2end_benchmark(c: &mut Criterion) {
     group.bench_with_input(benchmark_id, &size, |b, &s| {
         b.iter(|| {
             let ptr = go_base::<Bn>(&store, state.clone(), s.0, s.1);
-            let frames = evaluate::<Bn, Coproc<Bn>>(None, ptr, &store, limit).unwrap();
+            let frames =
+                evaluate::<Bn, Coproc<Bn>>(None, ptr, &store, limit, &dummy_terminal()).unwrap();
             let _result = prover.prove_from_frames(&pp, &frames, &store).unwrap();
         })
     });
@@ -167,7 +169,9 @@ fn eval_benchmark(c: &mut Criterion) {
             let benchmark_id = BenchmarkId::new("eval_go_base", &parameter_string);
             group.bench_with_input(benchmark_id, &size, |b, &s| {
                 let ptr = go_base::<Bn>(&store, state.clone(), s.0, s.1);
-                b.iter(|| evaluate_simple::<Bn, Coproc<Bn>>(None, ptr, &store, limit))
+                b.iter(|| {
+                    evaluate_simple::<Bn, Coproc<Bn>>(None, ptr, &store, limit, &dummy_terminal())
+                })
             });
         }
     }
@@ -212,7 +216,8 @@ fn prove_benchmark(c: &mut Criterion) {
         let ptr = go_base::<Bn>(&store, state.clone(), s.0, s.1);
         let prover: NovaProver<'_, Bn, Coproc<Bn>> =
             NovaProver::new(reduction_count, lang_rc.clone());
-        let frames = evaluate::<Bn, Coproc<Bn>>(None, ptr, &store, limit).unwrap();
+        let frames =
+            evaluate::<Bn, Coproc<Bn>>(None, ptr, &store, limit, &dummy_terminal()).unwrap();
 
         b.iter(|| {
             let result = prover.prove_from_frames(&pp, &frames, &store).unwrap();
@@ -259,7 +264,8 @@ fn prove_compressed_benchmark(c: &mut Criterion) {
     group.bench_with_input(benchmark_id, &size, |b, &s| {
         let ptr = go_base::<Bn>(&store, state.clone(), s.0, s.1);
         let prover = NovaProver::new(reduction_count, lang_rc.clone());
-        let frames = evaluate::<Bn, Coproc<Bn>>(None, ptr, &store, limit).unwrap();
+        let frames =
+            evaluate::<Bn, Coproc<Bn>>(None, ptr, &store, limit, &dummy_terminal()).unwrap();
 
         b.iter(|| {
             let (proof, _, _, _) = prover.prove_from_frames(&pp, &frames, &store).unwrap();
@@ -305,7 +311,8 @@ fn verify_benchmark(c: &mut Criterion) {
         group.bench_with_input(benchmark_id, &size, |b, &s| {
             let ptr = go_base(&store, state.clone(), s.0, s.1);
             let prover = NovaProver::new(reduction_count, lang_rc.clone());
-            let frames = evaluate::<Bn, Coproc<Bn>>(None, ptr, &store, limit).unwrap();
+            let frames =
+                evaluate::<Bn, Coproc<Bn>>(None, ptr, &store, limit, &dummy_terminal()).unwrap();
             let (proof, z0, zi, _num_steps) =
                 prover.prove_from_frames(&pp, &frames, &store).unwrap();
 
@@ -358,7 +365,8 @@ fn verify_compressed_benchmark(c: &mut Criterion) {
         group.bench_with_input(benchmark_id, &size, |b, &s| {
             let ptr = go_base(&store, state.clone(), s.0, s.1);
             let prover = NovaProver::new(reduction_count, lang_rc.clone());
-            let frames = evaluate::<Bn, Coproc<Bn>>(None, ptr, &store, limit).unwrap();
+            let frames =
+                evaluate::<Bn, Coproc<Bn>>(None, ptr, &store, limit, &dummy_terminal()).unwrap();
             let (proof, z0, zi, _num_steps) =
                 prover.prove_from_frames(&pp, &frames, &store).unwrap();
 

--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -7,6 +7,7 @@ use halo2curves::bn256::Fr as Bn;
 use std::{sync::Arc, time::Duration};
 
 use lurk::{
+    dual_channel::dummy_terminal,
     lang::{Coproc, Lang},
     lem::{eval::evaluate, store::Store},
     proof::nova::NovaProver,
@@ -107,7 +108,8 @@ fn fibonacci_prove<M: measurement::Measurement>(
             let ptr = fib_expr::<Bn>(&store);
             let prover = NovaProver::new(prove_params.reduction_count, lang_rc.clone());
 
-            let frames = &evaluate::<Bn, Coproc<Bn>>(None, ptr, &store, limit).unwrap();
+            let frames =
+                &evaluate::<Bn, Coproc<Bn>>(None, ptr, &store, limit, &dummy_terminal()).unwrap();
 
             b.iter_batched(
                 || frames,

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -15,6 +15,7 @@ use std::{sync::Arc, time::Duration};
 
 use lurk::{
     coprocessor::sha256::{Sha256Coproc, Sha256Coprocessor},
+    dual_channel::dummy_terminal,
     field::LurkField,
     lang::Lang,
     lem::{
@@ -133,7 +134,14 @@ fn sha256_ivc_prove<M: measurement::Measurement>(
 
             let prover = NovaProver::new(prove_params.reduction_count, lang_rc.clone());
 
-            let frames = &evaluate(Some((&lurk_step, &[], &lang)), ptr, store, limit).unwrap();
+            let frames = &evaluate(
+                Some((&lurk_step, &[], &lang)),
+                ptr,
+                store,
+                limit,
+                &dummy_terminal(),
+            )
+            .unwrap();
 
             b.iter_batched(
                 || frames,
@@ -214,7 +222,14 @@ fn sha256_ivc_prove_compressed<M: measurement::Measurement>(
 
             let prover = NovaProver::new(prove_params.reduction_count, lang_rc.clone());
 
-            let frames = &evaluate(Some((&lurk_step, &[], &lang)), ptr, store, limit).unwrap();
+            let frames = &evaluate(
+                Some((&lurk_step, &[], &lang)),
+                ptr,
+                store,
+                limit,
+                &dummy_terminal(),
+            )
+            .unwrap();
 
             b.iter_batched(
                 || frames,
@@ -298,7 +313,14 @@ fn sha256_nivc_prove<M: measurement::Measurement>(
 
             let prover = SuperNovaProver::new(prove_params.reduction_count, lang_rc.clone());
 
-            let frames = &evaluate(Some((&lurk_step, &cprocs, &lang)), ptr, store, limit).unwrap();
+            let frames = &evaluate(
+                Some((&lurk_step, &cprocs, &lang)),
+                ptr,
+                store,
+                limit,
+                &dummy_terminal(),
+            )
+            .unwrap();
 
             b.iter_batched(
                 || frames,

--- a/benches/synthesis.rs
+++ b/benches/synthesis.rs
@@ -9,6 +9,7 @@ use criterion::{
 use halo2curves::bn256::Fr as Bn;
 
 use lurk::{
+    dual_channel::dummy_terminal,
     field::LurkField,
     lang::{Coproc, Lang},
     lem::{eval::evaluate, multiframe::MultiFrame, pointers::Ptr, store::Store},
@@ -50,7 +51,8 @@ fn synthesize<M: measurement::Measurement>(
             let store = Store::default();
             let fib_n = (reduction_count / 3) as u64; // Heuristic, since one fib is 35 iterations.
             let ptr = fib::<Bn>(&store, state.clone(), black_box(fib_n));
-            let frames = evaluate::<Bn, Coproc<Bn>>(None, ptr, &store, limit).unwrap();
+            let frames =
+                evaluate::<Bn, Coproc<Bn>>(None, ptr, &store, limit, &dummy_terminal()).unwrap();
 
             let folding_config =
                 Arc::new(FoldingConfig::new_ivc(lang_rc.clone(), *reduction_count));

--- a/examples/circom.rs
+++ b/examples/circom.rs
@@ -39,6 +39,7 @@ use lurk::circuit::gadgets::pointer::AllocatedPtr;
 use lurk::coprocessor::circom::non_wasm::CircomCoprocessor;
 
 use halo2curves::bn256::Fr as Bn;
+use lurk::dual_channel::dummy_terminal;
 use lurk::field::LurkField;
 use lurk::lang::Lang;
 use lurk::lem::{pointers::Ptr, store::Store};
@@ -124,7 +125,14 @@ fn main() {
 
     let proof_start = Instant::now();
     let (proof, z0, zi, _num_steps) = nova_prover
-        .evaluate_and_prove(&pp, ptr, store.intern_empty_env(), store, 10000)
+        .evaluate_and_prove(
+            &pp,
+            ptr,
+            store.intern_empty_env(),
+            store,
+            10000,
+            &dummy_terminal(),
+        )
         .unwrap();
     let proof_end = proof_start.elapsed();
 

--- a/examples/sha256_ivc.rs
+++ b/examples/sha256_ivc.rs
@@ -5,6 +5,7 @@ use tracing_texray::TeXRayLayer;
 
 use lurk::{
     coprocessor::sha256::{Sha256Coproc, Sha256Coprocessor},
+    dual_channel::dummy_terminal,
     field::LurkField,
     lang::Lang,
     lem::{pointers::Ptr, store::Store},
@@ -87,7 +88,14 @@ fn main() {
     let (proof, z0, zi, _num_steps) = tracing_texray::examine(tracing::info_span!("bang!"))
         .in_scope(|| {
             nova_prover
-                .evaluate_and_prove(&pp, call, store.intern_empty_env(), store, 10000)
+                .evaluate_and_prove(
+                    &pp,
+                    call,
+                    store.intern_empty_env(),
+                    store,
+                    10000,
+                    &dummy_terminal(),
+                )
                 .unwrap()
         });
     let proof_end = proof_start.elapsed();

--- a/examples/sha256_nivc.rs
+++ b/examples/sha256_nivc.rs
@@ -5,6 +5,7 @@ use tracing_texray::TeXRayLayer;
 
 use lurk::{
     coprocessor::sha256::{Sha256Coproc, Sha256Coprocessor},
+    dual_channel::dummy_terminal,
     field::LurkField,
     lang::Lang,
     lem::{
@@ -77,7 +78,14 @@ fn main() {
 
     let lurk_step = make_eval_step_from_config(&EvalConfig::new_nivc(&lang));
     let cprocs = make_cprocs_funcs_from_lang(&lang);
-    let frames = evaluate(Some((&lurk_step, &cprocs, &lang)), call, store, 1000).unwrap();
+    let frames = evaluate(
+        Some((&lurk_step, &cprocs, &lang)),
+        call,
+        store,
+        1000,
+        &dummy_terminal(),
+    )
+    .unwrap();
 
     let supernova_prover =
         SuperNovaProver::<Bn, Sha256Coproc<Bn>>::new(REDUCTION_COUNT, lang_rc.clone());

--- a/examples/tp_table.rs
+++ b/examples/tp_table.rs
@@ -3,6 +3,7 @@ use ascii_table::{Align, AsciiTable};
 use criterion::black_box;
 use halo2curves::bn256::Fr as Bn;
 use lurk::{
+    dual_channel::dummy_terminal,
     lang::{Coproc, Lang},
     lem::{eval::evaluate, store::Store},
     proof::nova::{public_params, NovaProver, PublicParams},
@@ -154,7 +155,8 @@ fn main() {
     let store = Store::default();
     let program = store.read_with_default_state(PROGRAM).unwrap();
 
-    let frames = evaluate::<Bn, Coproc<Bn>>(None, program, &store, limit).unwrap();
+    let frames =
+        evaluate::<Bn, Coproc<Bn>>(None, program, &store, limit, &dummy_terminal()).unwrap();
 
     let lang = Lang::<Bn>::new();
     let lang_arc = Arc::new(lang.clone());

--- a/src/coroutine/memoset/prove.rs
+++ b/src/coroutine/memoset/prove.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 use crate::{
     circuit::gadgets::pointer::AllocatedPtr,
+    dual_channel::ChannelTerminal,
     error::ProofError,
     field::LurkField,
     lem::{pointers::Ptr, store::Store},
@@ -224,6 +225,7 @@ impl<'a, F: CurveCycleEquipped, Q: Query<F> + Send + Sync> Prover<'a, F>
         _env: Ptr,
         _store: &'a Store<F>,
         _limit: usize,
+        _ch_terminal: &ChannelTerminal<Ptr>,
     ) -> Result<(Self::RecursiveSnark, Vec<F>, Vec<F>, usize), ProofError> {
         unimplemented!()
     }

--- a/src/dual_channel.rs
+++ b/src/dual_channel.rs
@@ -1,0 +1,74 @@
+//! This module implements `ChannelTerminal`, meant to be used in pairs of its
+//! instances with crossed `Sender`s and `Receiver` from `mpsc::channel`. This
+//! crossing is performed in `pair_terminals`. The idea is that one terminal can
+//! send/receive messages to/from the other.
+
+use anyhow::{anyhow, Result};
+use std::sync::mpsc::{channel, Receiver, Sender};
+
+/// Holds a `Sender` and a `Receiver` which are not expected to be paired with
+/// each other
+pub struct ChannelTerminal<T> {
+    sender: Sender<T>,
+    receiver: Receiver<T>,
+}
+
+impl<T> ChannelTerminal<T> {
+    /// Sends a message through its inner `Sender`
+    #[inline]
+    pub fn send(&self, t: T) -> Result<()> {
+        self.sender.send(t).map_err(|e| anyhow!(e.to_string()))
+    }
+
+    /// Receives a message through its inner `Receiver`, blocking the current thread
+    #[inline]
+    #[allow(dead_code)]
+    pub fn recv(&self) -> Result<T> {
+        self.receiver.recv().map_err(|e| anyhow!(e.to_string()))
+    }
+
+    /// Collects all the messages received so far and materializes them in a
+    /// vector without blocking the current thread
+    #[inline]
+    pub fn collect(&self) -> Vec<T> {
+        self.receiver.try_iter().collect()
+    }
+}
+
+/// Creates a pair of `ChannelTerminal` with crossed senders and receivers such
+/// that one terminal can send/receive messages to/from the other
+pub fn pair_terminals<T>() -> (ChannelTerminal<T>, ChannelTerminal<T>) {
+    let (sender_terminal_1, receiver_terminal_2) = channel();
+    let (sender_terminal_2, receiver_terminal_1) = channel();
+    (
+        ChannelTerminal {
+            sender: sender_terminal_1,
+            receiver: receiver_terminal_1,
+        },
+        ChannelTerminal {
+            sender: sender_terminal_2,
+            receiver: receiver_terminal_2,
+        },
+    )
+}
+
+/// Creates a dummy `ChannelTerminal` that just sends messages to itself
+#[inline]
+pub fn dummy_terminal<T>() -> ChannelTerminal<T> {
+    let (sender, receiver) = channel();
+    ChannelTerminal { sender, receiver }
+}
+
+#[cfg(test)]
+pub mod tests {
+    #[test]
+    fn test_terminals() {
+        let (t1, t2) = super::pair_terminals::<&str>();
+
+        t1.send("hi from t1").unwrap();
+        t2.send("hi from t2").unwrap();
+
+        assert_eq!(t1.recv().unwrap(), "hi from t2");
+        assert_eq!(t2.recv().unwrap(), "hi from t1");
+    }
+}

--- a/src/lem/tests/misc.rs
+++ b/src/lem/tests/misc.rs
@@ -3,6 +3,7 @@ use bellpepper_core::{test_cs::TestConstraintSystem, Delta};
 use halo2curves::bn256::Fr;
 
 use crate::{
+    dual_channel::dummy_terminal,
     field::LurkField,
     func,
     lang::{DummyCoprocessor, Lang},
@@ -34,7 +35,14 @@ fn synthesize_test_helper(
     for input in inputs {
         let input = [input, nil, outermost];
         let frame = func
-            .call(&input, store, Default::default(), &mut vec![], &lang, 0)
+            .call(
+                &input,
+                store,
+                Default::default(),
+                &dummy_terminal(),
+                &lang,
+                0,
+            )
             .unwrap();
 
         let mut cs = TestConstraintSystem::<Fr>::new();

--- a/src/lem/tests/nivc_steps.rs
+++ b/src/lem/tests/nivc_steps.rs
@@ -2,6 +2,7 @@ use halo2curves::bn256::Fr;
 
 use crate::{
     coprocessor::test::DumbCoprocessor,
+    dual_channel::dummy_terminal,
     lang::Lang,
     lem::{
         eval::{evaluate, make_cprocs_funcs_from_lang, make_eval_step_from_config, EvalConfig},
@@ -31,7 +32,14 @@ fn test_nivc_steps() {
     // 9^2 + 8 = 89
     let expr = store.read_with_default_state("(cproc-dumb 9 8)").unwrap();
 
-    let frames = evaluate(Some((&lurk_step, &cprocs, &lang)), expr, &store, 10).unwrap();
+    let frames = evaluate(
+        Some((&lurk_step, &cprocs, &lang)),
+        expr,
+        &store,
+        10,
+        &dummy_terminal(),
+    )
+    .unwrap();
 
     // Iteration 1: evaluate first argument
     // Iteration 2: evaluate second argument

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod cli;
 pub mod config;
 pub mod coprocessor;
 pub mod coroutine;
+pub mod dual_channel;
 pub mod error;
 pub mod field;
 mod hash;

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 
 use crate::{
     coprocessor::Coprocessor,
+    dual_channel::ChannelTerminal,
     error::ProofError,
     field::LurkField,
     lang::Lang,
@@ -191,6 +192,7 @@ pub trait Prover<'a, F: CurveCycleEquipped> {
         env: Ptr,
         store: &'a Store<F>,
         limit: usize,
+        ch_terminal: &ChannelTerminal<Ptr>,
     ) -> Result<(Self::RecursiveSnark, Vec<F>, Vec<F>, usize), ProofError>;
 
     /// Returns the expected total number of steps for the prover given raw iterations.

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -23,6 +23,7 @@ use tracing::info;
 use crate::{
     config::lurk_config,
     coprocessor::Coprocessor,
+    dual_channel::ChannelTerminal,
     error::ProofError,
     field::LurkField,
     lang::Lang,
@@ -427,9 +428,11 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a> Prover<'a, F> for NovaPr
         env: Ptr,
         store: &'a Store<F>,
         limit: usize,
+        ch_terminal: &ChannelTerminal<Ptr>,
     ) -> Result<(Self::RecursiveSnark, Vec<F>, Vec<F>, usize), ProofError> {
         let eval_config = self.folding_mode().eval_config(self.lang());
-        let frames = C1LEM::<'a, F, C>::build_frames(expr, env, store, limit, &eval_config)?;
+        let frames =
+            C1LEM::<'a, F, C>::build_frames(expr, env, store, limit, &eval_config, ch_terminal)?;
         self.prove_from_frames(pp, &frames, store)
     }
 }

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -23,6 +23,7 @@ use tracing::info;
 use crate::{
     config::lurk_config,
     coprocessor::Coprocessor,
+    dual_channel::ChannelTerminal,
     error::ProofError,
     field::LurkField,
     lang::Lang,
@@ -346,9 +347,11 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> Prover<'a, F> for SuperNovaPr
         env: Ptr,
         store: &'a Store<F>,
         limit: usize,
+        ch_terminal: &ChannelTerminal<Ptr>,
     ) -> Result<(Self::RecursiveSnark, Vec<F>, Vec<F>, usize), ProofError> {
         let eval_config = self.folding_mode().eval_config(self.lang());
-        let frames = C1LEM::<'a, F, C>::build_frames(expr, env, store, limit, &eval_config)?;
+        let frames =
+            C1LEM::<'a, F, C>::build_frames(expr, env, store, limit, &eval_config, ch_terminal)?;
         self.prove_from_frames(pp, &frames, store)
     }
 }

--- a/src/proof/tests/supernova_tests.rs
+++ b/src/proof/tests/supernova_tests.rs
@@ -2,6 +2,7 @@ use halo2curves::bn256::Fr;
 use std::sync::Arc;
 
 use crate::{
+    dual_channel::dummy_terminal,
     lang::Lang,
     lem::{
         eval::{evaluate, make_cprocs_funcs_from_lang, make_eval_step_from_config, EvalConfig},
@@ -24,7 +25,14 @@ fn test_nil_nil_lang() {
 
     let store = Store::default();
     let expr = store.read_with_default_state("(nil-nil)").unwrap();
-    let frames = evaluate(Some((&lurk_step, &cprocs, &lang)), expr, &store, 50).unwrap();
+    let frames = evaluate(
+        Some((&lurk_step, &cprocs, &lang)),
+        expr,
+        &store,
+        50,
+        &dummy_terminal(),
+    )
+    .unwrap();
 
     // iteration 1: main circuit sets up a call to the coprocessor
     // iteration 2: coprocessor does its job


### PR DESCRIPTION
Use `std::sync::mpsc` API to define `ChannelTerminal`, meant to work in pairs. `pair_terminals` returns a pair of such terminals such that one can send/receive messages to/from the other. Then use this to revamp LEM's `Op::Emit` so we don't need to accumulate messages on a vector internally.

This improvement also targets the future implementation of streamed proofs, which will require the CEK machine to, nondeterministically, receive data from outside.