### PR TITLE
fix: make environments roundtrip as Z data

### DIFF
--- a/src/lem/store.rs
+++ b/src/lem/store.rs
@@ -881,6 +881,17 @@ impl<F: LurkField> Store<F> {
         }
     }
 
+    pub fn expect_env_components(&self, idx: usize) -> [Ptr; 3] {
+        let [sym_pay, val_tag, val_pay, env_pay] = self.expect_raw_ptrs(idx);
+        let sym = Ptr::new(Tag::Expr(Sym), *sym_pay);
+        let val = Ptr::new(
+            self.fetch_tag(val_tag).expect("Couldn't fetch tag"),
+            *val_pay,
+        );
+        let env = Ptr::new(Tag::Expr(Env), *env_pay);
+        [sym, val, env]
+    }
+
     /// Fetches an environment
     pub fn fetch_env(&self, ptr: &Ptr) -> Option<Vec<(Ptr, Ptr)>> {
         if *ptr.tag() != Tag::Expr(Env) {


### PR DESCRIPTION
PR #1183 didn't include the logic for environments when collecting the children of pointers. We didn't see the error because our tests weren't checking for environment roundtrip through Z data.

Here we fix that bug and also enhance the tests to avoid future regressions.