### PR TITLE
chore: handle emitted pointers on the REPL

### DIFF
--- a/src/dual_channel.rs
+++ b/src/dual_channel.rs
@@ -1,10 +1,12 @@
+#![deny(missing_docs)]
+
 //! This module implements `ChannelTerminal`, meant to be used in pairs of its
 //! instances with crossed `Sender`s and `Receiver` from `mpsc::channel`. This
 //! crossing is performed in `pair_terminals`. The idea is that one terminal can
 //! send/receive messages to/from the other.
 
 use anyhow::{anyhow, Result};
-use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::mpsc::{channel, Iter, Receiver, Sender};
 
 /// Holds a `Sender` and a `Receiver` which are not expected to be paired with
 /// each other
@@ -32,6 +34,12 @@ impl<T> ChannelTerminal<T> {
     #[inline]
     pub fn collect(&self) -> Vec<T> {
         self.receiver.try_iter().collect()
+    }
+
+    #[inline]
+    /// Returns a thread-blocking iterator for the received messages
+    pub fn iter(&self) -> Iter<'_, T> {
+        self.receiver.iter()
     }
 }
 

--- a/src/lem/interpreter.rs
+++ b/src/lem/interpreter.rs
@@ -330,12 +330,7 @@ impl Block {
                     bindings.insert_ptr(tgt[1].clone(), c2);
                 }
                 Op::Emit(a) => {
-                    let a = bindings.get_ptr(a)?;
-                    // TODO: remove this printing from here as it should be done
-                    // by receiving messages on the terminal that pairs up with
-                    // `ch_terminal`
-                    println!("{}", a.fmt_to_string_simple(store));
-                    ch_terminal.send(a)?;
+                    ch_terminal.send(bindings.get_ptr(a)?)?;
                 }
                 Op::Cons2(img, tag, preimg) => {
                     let preimg_ptrs = bindings.get_many_ptr(preimg)?;

--- a/src/lem/mod.rs
+++ b/src/lem/mod.rs
@@ -256,7 +256,7 @@ pub enum Op {
     Trunc(Var, Var, u32),
     /// `DivRem64(ys, a, b)` binds `ys` to `(a / b, a % b)` as if they were u64
     DivRem64([Var; 2], Var, Var),
-    /// `Emit(v)` simply prints out the value of `v` when interpreting the code
+    /// `Emit(v)` sends the value of `v` through the channel during interpretation
     Emit(Var),
     /// `Cons2(x, t, ys)` binds `x` to a `Ptr` with tag `t` and 2 children `ys`
     Cons2(Var, Tag, [Var; 2]),


### PR DESCRIPTION
* Remove inner printing from the interpretation of LEM's `Op::Emit`
* Receive and handle emitted pointers in threads spawned in the REPL
* Refactor and document the REPL's evaluation functions