### PR TITLE
chore: use `RawPtr::Env` to signal raw pointers for environments

### DIFF
--- a/benches/common/fib.rs
+++ b/benches/common/fib.rs
@@ -58,8 +58,8 @@ fn lurk_fib<F: LurkField>(store: &Store<F>, n: usize) -> Ptr {
     //               saved_env: (((.lurk.user.next . <FUNCTION (.lurk.user.a .lurk.user.b) (.lurk.user.next .lurk.user.b (+ .lurk.user.a .lurk.user.b))>))),
     //               body: (.lurk.user.fib), continuation: Outermost }
 
-    let [_, _, rest_bindings] = store.pop_binding(*target_env).unwrap();
-    let [_, val, _] = store.pop_binding(rest_bindings).unwrap();
+    let [_, _, rest_bindings] = store.pop_binding(target_env).unwrap();
+    let [_, val, _] = store.pop_binding(&rest_bindings).unwrap();
     val
 }
 

--- a/foil/src/coil.rs
+++ b/foil/src/coil.rs
@@ -81,7 +81,7 @@ pub struct Context {
 /// Look up `var` in `env`, where `env` is a list of bindings from `Symbol` to `U64` representing bindings of variables to vertices
 /// by id.
 fn lookup_vertex_id<F: LurkField>(store: &Store<F>, env: &Ptr, var: &Ptr) -> Result<Option<Id>> {
-    let Some([bound_var, id, rest_env]) = store.pop_binding(*env) else {
+    let Some([bound_var, id, rest_env]) = store.pop_binding(env) else {
         return Ok(None);
     };
 
@@ -125,7 +125,7 @@ impl Context {
 
     fn pop_binding<F: LurkField>(&mut self, store: &Store<F>) -> Result<Id> {
         let [_var, id, rest_env] = store
-            .pop_binding(self.env)
+            .pop_binding(&self.env)
             .ok_or(anyhow!("failed to pop binding"))?;
         self.env = rest_env;
 

--- a/src/coprocessor/gadgets.rs
+++ b/src/coprocessor/gadgets.rs
@@ -215,7 +215,7 @@ pub(crate) fn deconstruct_env<F: LurkField, CS: ConstraintSystem<F>>(
     let env_ptr = s.to_ptr(&env_zptr);
 
     let (a, b, c, d) = {
-        if let Some([v, val, new_env]) = s.pop_binding(env_ptr) {
+        if let Some([v, val, new_env]) = s.pop_binding(&env_ptr) {
             let v_zptr = s.hash_ptr(&v);
             let val_zptr = s.hash_ptr(&val);
             let new_env_zptr = s.hash_ptr(&new_env);

--- a/src/coroutine/memoset/env.rs
+++ b/src/coroutine/memoset/env.rs
@@ -33,7 +33,7 @@ impl<F: LurkField> Query<F> for EnvQuery<F> {
         let s = scope.store.as_ref();
         match self {
             Self::Lookup(var, env) => {
-                if let Some([v, val, new_env]) = s.pop_binding(*env) {
+                if let Some([v, val, new_env]) = s.pop_binding(env) {
                     if s.ptr_eq(var, &v) {
                         let t = s.intern_t();
                         s.cons(val, t)

--- a/src/lem/coroutine/eval.rs
+++ b/src/lem/coroutine/eval.rs
@@ -279,7 +279,7 @@ fn run<F: LurkField>(
                 let img_ptr = bindings.get_ptr(img)?;
                 let preimg_ptrs = scope
                     .store
-                    .pop_binding(img_ptr)
+                    .pop_binding(&img_ptr)
                     .context("cannot extract {img}'s binding")?;
                 for (var, ptr) in preimg.iter().zip(preimg_ptrs.iter()) {
                     bindings.insert_ptr(var.clone(), *ptr);

--- a/src/lem/interpreter.rs
+++ b/src/lem/interpreter.rs
@@ -423,7 +423,7 @@ impl Block {
                 Op::PopBinding(preimg, img) => {
                     let img_ptr = bindings.get_ptr(img)?;
                     let preimg_ptrs = store
-                        .pop_binding(img_ptr)
+                        .pop_binding(&img_ptr)
                         .context("cannot extract {img}'s binding")?;
                     for (var, ptr) in preimg.iter().zip(preimg_ptrs.iter()) {
                         bindings.insert_ptr(var.clone(), *ptr);


### PR DESCRIPTION
It's safer to use a new variant `RawPtr::Env` to signal raw pointers for environments than relying solely on tag checks. This would probably have avoided the bug introduced in #1183, whose fix was implemented in #1200