### PR TITLE
feat: support for streamed computations and their proofs

### DIFF
--- a/benches/common/fib.rs
+++ b/benches/common/fib.rs
@@ -90,7 +90,9 @@ fn compute_coeffs<F: LurkField>(store: &Store<F>) -> (usize, usize) {
                 }
             }
         }
-        let frame = step_func.call_simple(&input, store, &lang, 0).unwrap();
+        let frame = step_func
+            .call_simple(&input, store, &lang, 0, &dummy_terminal())
+            .unwrap();
         input = frame.output.clone();
         iteration += 1;
     }

--- a/benches/end2end.rs
+++ b/benches/end2end.rs
@@ -80,7 +80,9 @@ fn end2end_benchmark(c: &mut Criterion) {
             let ptr = go_base::<Bn>(&store, state.clone(), s.0, s.1);
             let frames =
                 evaluate::<Bn, Coproc<Bn>>(None, ptr, &store, limit, &dummy_terminal()).unwrap();
-            let _result = prover.prove_from_frames(&pp, &frames, &store).unwrap();
+            let _result = prover
+                .prove_from_frames(&pp, &frames, &store, None)
+                .unwrap();
         })
     });
 
@@ -220,7 +222,9 @@ fn prove_benchmark(c: &mut Criterion) {
             evaluate::<Bn, Coproc<Bn>>(None, ptr, &store, limit, &dummy_terminal()).unwrap();
 
         b.iter(|| {
-            let result = prover.prove_from_frames(&pp, &frames, &store).unwrap();
+            let result = prover
+                .prove_from_frames(&pp, &frames, &store, None)
+                .unwrap();
             black_box(result);
         })
     });
@@ -268,7 +272,9 @@ fn prove_compressed_benchmark(c: &mut Criterion) {
             evaluate::<Bn, Coproc<Bn>>(None, ptr, &store, limit, &dummy_terminal()).unwrap();
 
         b.iter(|| {
-            let (proof, _, _, _) = prover.prove_from_frames(&pp, &frames, &store).unwrap();
+            let (proof, _, _, _) = prover
+                .prove_from_frames(&pp, &frames, &store, None)
+                .unwrap();
 
             let compressed_result = proof.compress(&pp).unwrap();
             black_box(compressed_result);
@@ -313,8 +319,9 @@ fn verify_benchmark(c: &mut Criterion) {
             let prover = NovaProver::new(reduction_count, lang_rc.clone());
             let frames =
                 evaluate::<Bn, Coproc<Bn>>(None, ptr, &store, limit, &dummy_terminal()).unwrap();
-            let (proof, z0, zi, _num_steps) =
-                prover.prove_from_frames(&pp, &frames, &store).unwrap();
+            let (proof, z0, zi, _num_steps) = prover
+                .prove_from_frames(&pp, &frames, &store, None)
+                .unwrap();
 
             b.iter_batched(
                 || z0.clone(),
@@ -367,8 +374,9 @@ fn verify_compressed_benchmark(c: &mut Criterion) {
             let prover = NovaProver::new(reduction_count, lang_rc.clone());
             let frames =
                 evaluate::<Bn, Coproc<Bn>>(None, ptr, &store, limit, &dummy_terminal()).unwrap();
-            let (proof, z0, zi, _num_steps) =
-                prover.prove_from_frames(&pp, &frames, &store).unwrap();
+            let (proof, z0, zi, _num_steps) = prover
+                .prove_from_frames(&pp, &frames, &store, None)
+                .unwrap();
 
             let compressed_proof = proof.compress(&pp).unwrap();
 

--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -114,7 +114,7 @@ fn fibonacci_prove<M: measurement::Measurement>(
             b.iter_batched(
                 || frames,
                 |frames| {
-                    let result = prover.prove_from_frames(&pp, frames, &store);
+                    let result = prover.prove_from_frames(&pp, frames, &store, None);
                     let _ = black_box(result);
                 },
                 BatchSize::LargeInput,

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -146,7 +146,7 @@ fn sha256_ivc_prove<M: measurement::Measurement>(
             b.iter_batched(
                 || frames,
                 |frames| {
-                    let result = prover.prove_from_frames(&pp, frames, store);
+                    let result = prover.prove_from_frames(&pp, frames, store, None);
                     let _ = black_box(result);
                 },
                 BatchSize::LargeInput,
@@ -234,7 +234,8 @@ fn sha256_ivc_prove_compressed<M: measurement::Measurement>(
             b.iter_batched(
                 || frames,
                 |frames| {
-                    let (proof, _, _, _) = prover.prove_from_frames(&pp, frames, store).unwrap();
+                    let (proof, _, _, _) =
+                        prover.prove_from_frames(&pp, frames, store, None).unwrap();
                     let compressed_result = proof.compress(&pp).unwrap();
 
                     let _ = black_box(compressed_result);
@@ -325,7 +326,7 @@ fn sha256_nivc_prove<M: measurement::Measurement>(
             b.iter_batched(
                 || frames,
                 |frames| {
-                    let result = prover.prove_from_frames(&pp, frames, store);
+                    let result = prover.prove_from_frames(&pp, frames, store, None);
                     let _ = black_box(result);
                 },
                 BatchSize::LargeInput,

--- a/chain-server/src/server.rs
+++ b/chain-server/src/server.rs
@@ -156,7 +156,7 @@ where
                 // prove then compress the proof
                 let (proof, ..) = self
                     .prover
-                    .prove_from_frames(pp, &frames, &self.store)
+                    .prove_from_frames(pp, &frames, &self.store, None)
                     .map_err(|e| Status::internal(e.to_string()))?;
                 let proof = proof
                     .compress(pp)

--- a/examples/keccak.rs
+++ b/examples/keccak.rs
@@ -395,7 +395,7 @@ fn main() {
     let proof_start = Instant::now();
 
     let (proof, z0, zi, _) = supernova_prover
-        .prove_from_frames(&pp, &frames, store)
+        .prove_from_frames(&pp, &frames, store, None)
         .unwrap();
 
     let proof_end = proof_start.elapsed();

--- a/examples/sha256_nivc.rs
+++ b/examples/sha256_nivc.rs
@@ -104,7 +104,7 @@ fn main() {
     let (proof, z0, zi, _num_steps) = tracing_texray::examine(tracing::info_span!("bang!"))
         .in_scope(|| {
             supernova_prover
-                .prove_from_frames(&pp, &frames, store)
+                .prove_from_frames(&pp, &frames, store, None)
                 .unwrap()
         });
     let proof_end = proof_start.elapsed();

--- a/examples/tp_table.rs
+++ b/examples/tp_table.rs
@@ -176,7 +176,7 @@ fn main() {
                 let mut timings = Vec::with_capacity(n_samples);
                 for _ in 0..n_samples {
                     let start = Instant::now();
-                    let result = prover.prove_from_frames(&pp, frames, &store);
+                    let result = prover.prove_from_frames(&pp, frames, &store, None);
                     let _ = black_box(result);
                     let end = start.elapsed().as_secs_f64();
                     timings.push(end);

--- a/src/cli/repl/mod.rs
+++ b/src/cli/repl/mod.rs
@@ -355,7 +355,7 @@ where
 
                     info!("Proving with NovaProver");
                     let (proof, public_inputs, public_outputs, num_steps) =
-                        prover.prove_from_frames(&pp, frames, &self.store)?;
+                        prover.prove_from_frames(&pp, frames, &self.store, None)?;
                     info!("Compressing Nova proof");
                     let proof = proof.compress(&pp)?;
                     assert_eq!(self.rc * num_steps, pad(n_frames, self.rc));
@@ -370,7 +370,7 @@ where
 
                     info!("Proving with SuperNovaProver");
                     let (proof, public_inputs, public_outputs, _num_steps) =
-                        prover.prove_from_frames(&pp, frames, &self.store)?;
+                        prover.prove_from_frames(&pp, frames, &self.store, None)?;
                     info!("Compressing SuperNova proof");
                     let proof = proof.compress(&pp)?;
                     assert!(proof.verify(&pp, &public_inputs, &public_outputs)?);

--- a/src/coroutine/memoset/prove.rs
+++ b/src/coroutine/memoset/prove.rs
@@ -96,7 +96,7 @@ impl<'a, F: CurveCycleEquipped, Q: Query<F> + Send + Sync>
     RecursiveSNARKTrait<F, Coroutine<'a, F, Q>> for Proof<F, Coroutine<'a, F, Q>>
 {
     type PublicParams = PublicParams<F>;
-
+    type BaseRecursiveSNARK = RecursiveSNARK<E1<F>>;
     type ErrorType = SuperNovaError;
 
     #[tracing::instrument(skip_all, name = "supernova::prove_recursively")]
@@ -105,8 +105,9 @@ impl<'a, F: CurveCycleEquipped, Q: Query<F> + Send + Sync>
         z0: &[F],
         steps: Vec<Coroutine<'a, F, Q>>,
         _store: &Store<F>,
+        init: Option<RecursiveSNARK<E1<F>>>,
     ) -> Result<Self, ProofError> {
-        let mut recursive_snark_option: Option<RecursiveSNARK<E1<F>>> = None;
+        let mut recursive_snark_option = init;
 
         let z0_primary = z0;
         let z0_secondary = Self::z0_secondary();
@@ -251,7 +252,7 @@ impl<'a, F: CurveCycleEquipped, Q: Query<F> + Send + Sync> MemosetProver<'a, F, 
 
         let num_steps = steps.len();
 
-        let prove_output = Proof::prove_recursively(pp, &z0, steps, store)?;
+        let prove_output = Proof::prove_recursively(pp, &z0, steps, store, None)?;
         let zi = match prove_output {
             Proof::Recursive(ref snark, ..) => snark.zi_primary().clone(),
             Proof::Compressed(..) => unreachable!(),

--- a/src/lem/coroutine/eval.rs
+++ b/src/lem/coroutine/eval.rs
@@ -200,9 +200,11 @@ fn run<F: LurkField>(
                 bindings.insert_ptr(tgt[1].clone(), c2);
             }
             Op::Emit(a) => {
+                // TODO: send `a` through a channel as in the original interpreter
                 let a = bindings.get_ptr(a)?;
                 println!("{}", a.fmt_to_string_simple(&scope.store));
             }
+            Op::Recv(_) => todo!("not supported yet"),
             Op::Cons2(img, tag, preimg) => {
                 let preimg_ptrs = bindings.get_many_ptr(preimg)?;
                 let tgt_ptr = intern_ptrs!(scope.store, *tag, preimg_ptrs[0], preimg_ptrs[1]);

--- a/src/lem/coroutine/synthesis.rs
+++ b/src/lem/coroutine/synthesis.rs
@@ -458,6 +458,7 @@ fn synthesize_run<'a, F: LurkField, CS: ConstraintSystem<F>>(
                 bound_allocations.insert_ptr(tgt[1].clone(), rem_ptr);
             }
             Op::Emit(_) | Op::Unit(_) => (),
+            Op::Recv(_) => todo!("not supported yet"),
             Op::Hide(tgt, sec, pay) => {
                 let sec = bound_allocations.get_ptr(sec)?;
                 let pay = bound_allocations.get_ptr(pay)?;

--- a/src/lem/macros.rs
+++ b/src/lem/macros.rs
@@ -159,6 +159,9 @@ macro_rules! op {
     ( emit($v:ident) ) => {
         $crate::lem::Op::Emit($crate::var!($v))
     };
+    ( let $v:ident =! recv() ) => {
+        $crate::lem::Op::Recv($crate::var!($v))
+    };
     ( let $tgt:ident : $kind:ident::$tag:ident = cons2($src1:ident, $src2:ident) ) => {
         $crate::lem::Op::Cons2(
             $crate::var!($tgt),
@@ -498,6 +501,16 @@ macro_rules! block {
             {
                 $($limbs)*
                 $crate::op!(emit($v))
+            },
+            $($tail)*
+        )
+    };
+    (@seq {$($limbs:expr)*}, let $v:ident =! recv() ; $($tail:tt)*) => {
+        $crate::block! (
+            @seq
+            {
+                $($limbs)*
+                $crate::op!(let $v =! recv())
             },
             $($tail)*
         )

--- a/src/lem/multiframe.rs
+++ b/src/lem/multiframe.rs
@@ -720,7 +720,7 @@ fn pad_frames<F: LurkField, C: Coprocessor<F>>(
     size: usize,
     store: &Store<F>,
 ) {
-    let padding_frame = if matches!(input[2].tag(), Tag::Cont(ContTag::StreamOut)) {
+    let padding_frame = if matches!(input[2].tag(), Tag::Cont(ContTag::StreamPause)) {
         // we need to allow stuttering for the padding frame
         let (t1, t2) = pair_terminals();
         t2.send(store.intern_t()).unwrap(); // anything but `nil` to allow stuttering

--- a/src/lem/multiframe.rs
+++ b/src/lem/multiframe.rs
@@ -11,7 +11,7 @@ use crate::{
     circuit::gadgets::pointer::AllocatedPtr,
     config::lurk_config,
     coprocessor::Coprocessor,
-    dual_channel::ChannelTerminal,
+    dual_channel::{dummy_terminal, pair_terminals, ChannelTerminal},
     error::{ProofError, ReductionError},
     field::{LanguageField, LurkField},
     lang::Lang,
@@ -720,9 +720,18 @@ fn pad_frames<F: LurkField, C: Coprocessor<F>>(
     size: usize,
     store: &Store<F>,
 ) {
-    let padding_frame = lurk_step
-        .call_simple(input, store, lang, 0)
-        .expect("reduction step failed");
+    let padding_frame = if matches!(input[2].tag(), Tag::Cont(ContTag::StreamOut)) {
+        // we need to allow stuttering for the padding frame
+        let (t1, t2) = pair_terminals();
+        t2.send(store.intern_t()).unwrap(); // anything but `nil` to allow stuttering
+        lurk_step
+            .call_simple(input, store, lang, 0, &t1)
+            .expect("reduction step failed")
+    } else {
+        lurk_step
+            .call_simple(input, store, lang, 0, &dummy_terminal())
+            .expect("reduction step failed")
+    };
     assert_eq!(padding_frame.pc, 0);
     assert_eq!(input, padding_frame.output);
     frames.resize(size, padding_frame);

--- a/src/lem/slot.rs
+++ b/src/lem/slot.rs
@@ -103,6 +103,8 @@
 //! STEP 2 will need as many iterations as it takes to evaluate the Lurk
 //! expression and so will STEP 3.
 
+use match_opt::match_opt;
+
 use super::{
     pointers::{Ptr, RawPtr},
     Block, Ctrl, Op,
@@ -246,6 +248,13 @@ pub enum Val {
     Pointer(Ptr),
     Num(RawPtr),
     Boolean(bool),
+}
+
+impl Val {
+    #[inline]
+    pub(crate) fn get_ptr(&self) -> Option<&Ptr> {
+        match_opt!(self, Self::Pointer(ptr) => ptr)
+    }
 }
 
 /// Holds data to feed the slots

--- a/src/lem/store.rs
+++ b/src/lem/store.rs
@@ -22,7 +22,7 @@ use crate::{
     syntax::Syntax,
     tag::ContTag::{
         self, Binop, Binop2, Call, Call0, Call2, Dummy, Emit, If, Let, LetRec, Lookup, Outermost,
-        StreamDispatch, StreamIn, StreamOut, Tail, Terminal, Unop,
+        StreamDispatch, StreamPause, StreamStart, Tail, Terminal, Unop,
     },
     tag::ExprTag::{
         Char, Comm, Cons, Cproc, Env, Fun, Key, Nil, Num, Prov, Rec, Str, Sym, Thunk, U64,
@@ -757,8 +757,8 @@ impl<F: LurkField> Store<F> {
     }
 
     #[inline]
-    pub fn cont_stream_in(&self) -> Ptr {
-        Ptr::new(Tag::Cont(StreamIn), RawPtr::Atom(self.hash8zeros_idx))
+    pub fn cont_stream_start(&self) -> Ptr {
+        Ptr::new(Tag::Cont(StreamStart), RawPtr::Atom(self.hash8zeros_idx))
     }
 
     /// Function specialized on deconstructing `Cons` pointers into their car/cdr
@@ -1379,9 +1379,9 @@ impl Ptr {
                     store,
                     state,
                 ),
-                StreamIn => "StreamIn".into(),
+                StreamStart => "StreamStart".into(),
                 StreamDispatch => "StreamDispatch".into(),
-                StreamOut => "StreamOut".into(),
+                StreamPause => "StreamPause".into(),
             },
             Tag::Op1(op) => op.to_string(),
             Tag::Op2(op) => op.to_string(),

--- a/src/lem/store.rs
+++ b/src/lem/store.rs
@@ -22,7 +22,7 @@ use crate::{
     syntax::Syntax,
     tag::ContTag::{
         self, Binop, Binop2, Call, Call0, Call2, Dummy, Emit, If, Let, LetRec, Lookup, Outermost,
-        Tail, Terminal, Unop,
+        StreamDispatch, StreamIn, StreamOut, Tail, Terminal, Unop,
     },
     tag::ExprTag::{
         Char, Comm, Cons, Cproc, Env, Fun, Key, Nil, Num, Prov, Rec, Str, Sym, Thunk, U64,
@@ -756,6 +756,11 @@ impl<F: LurkField> Store<F> {
         Ptr::new(Tag::Cont(Terminal), RawPtr::Atom(self.hash8zeros_idx))
     }
 
+    #[inline]
+    pub fn cont_stream_in(&self) -> Ptr {
+        Ptr::new(Tag::Cont(StreamIn), RawPtr::Atom(self.hash8zeros_idx))
+    }
+
     /// Function specialized on deconstructing `Cons` pointers into their car/cdr
     pub fn fetch_cons(&self, ptr: &Ptr) -> Option<(Ptr, Ptr)> {
         match_opt!((ptr.tag(), ptr.raw()), (Tag::Expr(Cons), RawPtr::Hash4(idx)) => {
@@ -1374,6 +1379,9 @@ impl Ptr {
                     store,
                     state,
                 ),
+                StreamIn => "StreamIn".into(),
+                StreamDispatch => "StreamDispatch".into(),
+                StreamOut => "StreamOut".into(),
             },
             Tag::Op1(op) => op.to_string(),
             Tag::Op2(op) => op.to_string(),

--- a/src/lem/tests/mod.rs
+++ b/src/lem/tests/mod.rs
@@ -1,3 +1,4 @@
 mod eval_tests;
 mod misc;
 mod nivc_steps;
+mod stream;

--- a/src/lem/tests/nivc_steps.rs
+++ b/src/lem/tests/nivc_steps.rs
@@ -54,9 +54,13 @@ fn test_nivc_steps() {
         Tag::Cont(ContTag::Terminal)
     ));
 
+    let dt = &dummy_terminal();
+
     // `cproc` can't reduce the first input, which is meant for `lurk_step`
     let first_input = &frames[0].input;
-    assert!(cproc.call_simple(first_input, &store, &lang, 0).is_err());
+    assert!(cproc
+        .call_simple(first_input, &store, &lang, 0, dt)
+        .is_err());
 
     // the fourth frame is the one reduced by the coprocessor
     let cproc_frame = &frames[3];
@@ -66,14 +70,14 @@ fn test_nivc_steps() {
 
     // `lurk_step` stutters on the cproc input
     let output = &lurk_step
-        .call_simple(&cproc_input, &store, &lang, 0)
+        .call_simple(&cproc_input, &store, &lang, 0, dt)
         .unwrap()
         .output;
     assert_eq!(&cproc_input, output);
 
     // `cproc` *can* reduce the cproc input
     let output = &cproc
-        .call_simple(&cproc_input, &store, &lang, 1)
+        .call_simple(&cproc_input, &store, &lang, 1, dt)
         .unwrap()
         .output;
     assert_ne!(&cproc_input, output);
@@ -97,5 +101,7 @@ fn test_nivc_steps() {
 
     // `cproc` can't reduce the altered cproc input (with the wrong name)
     let cproc_input = vec![new_expr, env, cont];
-    assert!(cproc.call_simple(&cproc_input, &store, &lang, 0).is_err());
+    assert!(cproc
+        .call_simple(&cproc_input, &store, &lang, 0, dt)
+        .is_err());
 }

--- a/src/lem/tests/stream.rs
+++ b/src/lem/tests/stream.rs
@@ -68,27 +68,28 @@ fn test_comm_callable() {
         (add 0)))";
     let store = Store::<Fr>::default();
     let callable = get_callable(callable_str, &store);
+    let expected_iterations = &expect!["16"];
 
     let output = assert_start_stream(
         callable,
         store.num_u64(123),
         &store,
         store.num_u64(123),
-        &expect!["16"],
+        expected_iterations,
     );
     let output = assert_resume_stream(
         output,
         store.num_u64(321),
         &store,
         store.num_u64(444),
-        &expect!["17"],
+        expected_iterations,
     );
     assert_resume_stream(
         output,
         store.num_u64(111),
         &store,
         store.num_u64(555),
-        &expect!["17"],
+        expected_iterations,
     );
 }
 
@@ -100,26 +101,27 @@ fn test_fun_callable() {
         (add 0))";
     let store = Store::<Fr>::default();
     let callable = get_callable(callable_str, &store);
+    let expected_iterations = &expect!["14"];
 
     let output = assert_start_stream(
         callable,
         store.num_u64(123),
         &store,
         store.num_u64(123),
-        &expect!["14"],
+        expected_iterations,
     );
     let output = assert_resume_stream(
         output,
         store.num_u64(321),
         &store,
         store.num_u64(444),
-        &expect!["15"],
+        expected_iterations,
     );
     assert_resume_stream(
         output,
         store.num_u64(111),
         &store,
         store.num_u64(555),
-        &expect!["15"],
+        expected_iterations,
     );
 }

--- a/src/lem/tests/stream.rs
+++ b/src/lem/tests/stream.rs
@@ -1,0 +1,125 @@
+use expect_test::{expect, Expect};
+use halo2curves::bn256::Fr;
+
+use crate::{
+    dual_channel::{dummy_terminal, pair_terminals},
+    lang::Coproc,
+    lem::{
+        eval::{evaluate_simple, resume_stream_simple, start_stream_simple},
+        pointers::Ptr,
+        store::Store,
+    },
+};
+
+const LIMIT: usize = 200;
+
+fn get_callable(callable_str: &str, store: &Store<Fr>) -> Ptr {
+    let callable = store.read_with_default_state(callable_str).unwrap();
+    let (io, _) =
+        evaluate_simple::<Fr, Coproc<Fr>>(None, callable, store, LIMIT, &dummy_terminal()).unwrap();
+    io[0]
+}
+
+#[inline]
+fn expect_eq(computed: usize, expected: &Expect) {
+    expected.assert_eq(&computed.to_string());
+}
+
+fn assert_start_stream(
+    callable: Ptr,
+    arg: Ptr,
+    store: &Store<Fr>,
+    expected_result: Ptr,
+    expected_iterations: &Expect,
+) -> Vec<Ptr> {
+    let (t1, t2) = pair_terminals();
+    t2.send(arg).unwrap();
+    let (output, iterations) =
+        start_stream_simple::<Fr, Coproc<Fr>>(None, callable, store, LIMIT, &t1).unwrap();
+    let (result, _) = store.fetch_cons(&output[0]).unwrap();
+    assert_eq!(result, expected_result);
+    expect_eq(iterations, expected_iterations);
+    output
+}
+
+fn assert_resume_stream(
+    input: Vec<Ptr>,
+    arg: Ptr,
+    store: &Store<Fr>,
+    expected_result: Ptr,
+    expected_iterations: &Expect,
+) -> Vec<Ptr> {
+    let (t1, t2) = pair_terminals();
+    t2.send(store.intern_nil()).unwrap(); // send nil to skip stuttering
+    t2.send(arg).unwrap();
+    let (output, iterations) =
+        resume_stream_simple::<Fr, Coproc<Fr>>(None, input, store, LIMIT, &t1).unwrap();
+    let (result, _) = store.fetch_cons(&output[0]).unwrap();
+    assert_eq!(result, expected_result);
+    expect_eq(iterations, expected_iterations);
+    output
+}
+
+#[test]
+fn test_comm_callable() {
+    let callable_str = "(commit (letrec ((add (lambda (counter x)
+            (let ((counter (+ counter x)))
+            (cons counter (commit (add counter)))))))
+        (add 0)))";
+    let store = Store::<Fr>::default();
+    let callable = get_callable(callable_str, &store);
+
+    let output = assert_start_stream(
+        callable,
+        store.num_u64(123),
+        &store,
+        store.num_u64(123),
+        &expect!["16"],
+    );
+    let output = assert_resume_stream(
+        output,
+        store.num_u64(321),
+        &store,
+        store.num_u64(444),
+        &expect!["17"],
+    );
+    assert_resume_stream(
+        output,
+        store.num_u64(111),
+        &store,
+        store.num_u64(555),
+        &expect!["17"],
+    );
+}
+
+#[test]
+fn test_fun_callable() {
+    let callable_str = "(letrec ((add (lambda (counter x)
+            (let ((counter (+ counter x)))
+            (cons counter (add counter))))))
+        (add 0))";
+    let store = Store::<Fr>::default();
+    let callable = get_callable(callable_str, &store);
+
+    let output = assert_start_stream(
+        callable,
+        store.num_u64(123),
+        &store,
+        store.num_u64(123),
+        &expect!["14"],
+    );
+    let output = assert_resume_stream(
+        output,
+        store.num_u64(321),
+        &store,
+        store.num_u64(444),
+        &expect!["15"],
+    );
+    assert_resume_stream(
+        output,
+        store.num_u64(111),
+        &store,
+        store.num_u64(555),
+        &expect!["15"],
+    );
+}

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -147,10 +147,16 @@ pub enum Proof<F: CurveCycleEquipped, S> {
 }
 
 impl<F: CurveCycleEquipped, S> Proof<F, S> {
-    /// todo
+    /// Extracts the original `CompressedSNARK`
     #[inline]
     pub fn get_compressed(self) -> Option<CompressedSNARK<E1<F>, SS1<F>, SS2<F>>> {
         match_opt::match_opt!(self, Self::Compressed(proof, _) => *proof)
+    }
+
+    /// Extracts the original `RecursiveSNARK`
+    #[inline]
+    pub fn get_recursive(self) -> Option<RecursiveSNARK<E1<F>>> {
+        match_opt::match_opt!(self, Self::Recursive(proof, _) => *proof)
     }
 }
 
@@ -183,12 +189,13 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a> SuperNovaProver<'a, F, C
         pp: &PublicParams<F>,
         frames: &[Frame],
         store: &'a Store<F>,
+        init: Option<RecursiveSNARK<E1<F>>>,
     ) -> Result<(Proof<F, C1LEM<'a, F, C>>, Vec<F>, Vec<F>, usize), ProofError> {
         let folding_config = self
             .folding_mode()
             .folding_config(self.lang().clone(), self.reduction_count());
         let steps = C1LEM::<'a, F, C>::from_frames(frames, store, &folding_config.into());
-        self.prove(pp, steps, store)
+        self.prove(pp, steps, store, init)
     }
 
     #[inline]
@@ -202,7 +209,7 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<F, C1LEM<
     for Proof<F, C1LEM<'a, F, C>>
 {
     type PublicParams = PublicParams<F>;
-
+    type BaseRecursiveSNARK = RecursiveSNARK<E1<F>>;
     type ErrorType = SuperNovaError;
 
     #[tracing::instrument(skip_all, name = "supernova::prove_recursively")]
@@ -211,12 +218,13 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<F, C1LEM<
         z0: &[F],
         steps: Vec<C1LEM<'a, F, C>>,
         store: &Store<F>,
+        init: Option<RecursiveSNARK<E1<F>>>,
     ) -> Result<Self, ProofError> {
         let debug = false;
 
         info!("proving {} steps", steps.len());
 
-        let mut recursive_snark_option: Option<RecursiveSNARK<E1<F>>> = None;
+        let mut recursive_snark_option = init;
 
         let prove_step =
             |i: usize, step: &C1LEM<'a, F, C>, rs: &mut Option<RecursiveSNARK<E1<F>>>| {
@@ -336,7 +344,7 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<F, C1LEM<
 impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> Prover<'a, F> for SuperNovaProver<'a, F, C> {
     type Frame = C1LEM<'a, F, C>;
     type PublicParams = PublicParams<F>;
-    type RecursiveSnark = Proof<F, C1LEM<'a, F, C>>;
+    type RecursiveSNARK = Proof<F, C1LEM<'a, F, C>>;
 
     #[inline]
     fn reduction_count(&self) -> usize {
@@ -356,11 +364,11 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> Prover<'a, F> for SuperNovaPr
         store: &'a Store<F>,
         limit: usize,
         ch_terminal: &ChannelTerminal<Ptr>,
-    ) -> Result<(Self::RecursiveSnark, Vec<F>, Vec<F>, usize), ProofError> {
+    ) -> Result<(Self::RecursiveSNARK, Vec<F>, Vec<F>, usize), ProofError> {
         let eval_config = self.folding_mode().eval_config(self.lang());
         let frames =
             C1LEM::<'a, F, C>::build_frames(expr, env, store, limit, &eval_config, ch_terminal)?;
-        self.prove_from_frames(pp, &frames, store)
+        self.prove_from_frames(pp, &frames, store, None)
     }
 }
 

--- a/src/proof/tests/mod.rs
+++ b/src/proof/tests/mod.rs
@@ -1,4 +1,5 @@
 mod nova_tests;
+mod stream;
 mod supernova_tests;
 
 use bellpepper::util_cs::{metric_cs::MetricCS, witness_cs::WitnessCS, Comparable};
@@ -183,7 +184,9 @@ fn nova_test_full_aux2<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a>(
 
     if check_nova {
         let pp = public_params(reduction_count, lang.clone());
-        let (proof, z0, zi, _num_steps) = nova_prover.prove_from_frames(&pp, &frames, s).unwrap();
+        let (proof, z0, zi, _num_steps) = nova_prover
+            .prove_from_frames(&pp, &frames, s, None)
+            .unwrap();
 
         let res = proof.verify(&pp, &z0, &zi);
         if res.is_err() {

--- a/src/proof/tests/stream.rs
+++ b/src/proof/tests/stream.rs
@@ -1,0 +1,92 @@
+use expect_test::{expect, Expect};
+use halo2curves::bn256::Fr;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use std::sync::Arc;
+
+use crate::{
+    dual_channel::{dummy_terminal, pair_terminals},
+    lang::{Coproc, Lang},
+    lem::{
+        eval::{evaluate_simple, resume_stream, start_stream},
+        pointers::Ptr,
+        store::Store,
+    },
+    proof::{supernova::SuperNovaProver, RecursiveSNARKTrait},
+    public_parameters::{instance::Instance, supernova_public_params},
+};
+
+const LIMIT: usize = 200;
+
+fn get_callable(callable_str: &str, store: &Store<Fr>) -> Ptr {
+    let callable = store.read_with_default_state(callable_str).unwrap();
+    let (io, _) =
+        evaluate_simple::<Fr, Coproc<Fr>>(None, callable, store, LIMIT, &dummy_terminal()).unwrap();
+    io[0]
+}
+
+#[inline]
+fn expect_eq(computed: usize, expected: &Expect) {
+    expected.assert_eq(&computed.to_string());
+}
+
+#[test]
+fn test_continued_proof() {
+    let callable_str = "(letrec ((add (lambda (counter x)
+            (let ((counter (+ counter x)))
+            (cons counter (add counter))))))
+        (add 0))";
+    let store = Store::<Fr>::default();
+    let callable = get_callable(callable_str, &store);
+
+    let lang = Arc::new(Lang::<Fr, Coproc<Fr>>::new());
+
+    [1, 3, 5].into_par_iter().for_each(|rc| {
+        let prover = SuperNovaProver::new(rc, lang.clone());
+        let instance = Instance::new_supernova(&prover, true);
+        let pp = supernova_public_params(&instance).unwrap();
+
+        let (t1, t2) = pair_terminals();
+        t2.send(store.num_u64(123)).unwrap();
+        let frames = start_stream::<Fr, Coproc<Fr>>(None, callable, &store, LIMIT, &t1).unwrap();
+
+        // this input will be used to construct the public input of every proof
+        let z0 = store.to_scalar_vector(&frames.first().unwrap().input);
+
+        expect_eq(frames.len(), &expect!["14"]);
+        let output = &frames.last().unwrap().output;
+        let (result, _) = store.fetch_cons(&output[0]).unwrap();
+        assert_eq!(result, store.num_u64(123));
+
+        let (proof, ..) = prover
+            .prove_from_frames(&pp, &frames, &store, None)
+            .unwrap();
+
+        proof
+            .verify(&pp, &z0, &store.to_scalar_vector(output))
+            .unwrap();
+
+        let base_snark = proof.get_recursive();
+        assert!(base_snark.is_some());
+
+        // into the next stream cycle
+        t2.send(store.intern_nil()).unwrap(); // send nil to skip stuttering
+        t2.send(store.num_u64(321)).unwrap();
+        let frames =
+            resume_stream::<Fr, Coproc<Fr>>(None, output.clone(), &store, LIMIT, &t1).unwrap();
+
+        expect_eq(frames.len(), &expect!["15"]);
+        let output = &frames.last().unwrap().output;
+        let (result, _) = store.fetch_cons(&output[0]).unwrap();
+        assert_eq!(result, store.num_u64(444));
+
+        let (proof, ..) = prover
+            .prove_from_frames(&pp, &frames, &store, base_snark)
+            .unwrap();
+
+        let zi = store.to_scalar_vector(output);
+        proof.verify(&pp, &z0, &zi).unwrap();
+
+        let proof = proof.compress(&pp).unwrap();
+        proof.verify(&pp, &z0, &zi).unwrap();
+    });
+}

--- a/src/proof/tests/stream.rs
+++ b/src/proof/tests/stream.rs
@@ -37,6 +37,7 @@ fn test_continued_proof() {
         (add 0))";
     let store = Store::<Fr>::default();
     let callable = get_callable(callable_str, &store);
+    let expected_iterations = &expect!["14"];
 
     let lang = Arc::new(Lang::<Fr, Coproc<Fr>>::new());
 
@@ -52,7 +53,7 @@ fn test_continued_proof() {
         // this input will be used to construct the public input of every proof
         let z0 = store.to_scalar_vector(&frames.first().unwrap().input);
 
-        expect_eq(frames.len(), &expect!["14"]);
+        expect_eq(frames.len(), expected_iterations);
         let output = &frames.last().unwrap().output;
         let (result, _) = store.fetch_cons(&output[0]).unwrap();
         assert_eq!(result, store.num_u64(123));
@@ -74,7 +75,7 @@ fn test_continued_proof() {
         let frames =
             resume_stream::<Fr, Coproc<Fr>>(None, output.clone(), &store, LIMIT, &t1).unwrap();
 
-        expect_eq(frames.len(), &expect!["15"]);
+        expect_eq(frames.len(), expected_iterations);
         let output = &frames.last().unwrap().output;
         let (result, _) = store.fetch_cons(&output[0]).unwrap();
         assert_eq!(result, store.num_u64(444));

--- a/src/proof/tests/supernova_tests.rs
+++ b/src/proof/tests/supernova_tests.rs
@@ -55,7 +55,7 @@ fn test_nil_nil_lang() {
     let pp = supernova_public_params(&instance).unwrap();
 
     let (proof, ..) = supernova_prover
-        .prove_from_frames(&pp, &frames, &store)
+        .prove_from_frames(&pp, &frames, &store, None)
         .unwrap();
 
     let input_scalar = store.to_scalar_vector(&first_frame.input);

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -142,6 +142,9 @@ pub enum ContTag {
     Terminal,
     Emit,
     Cproc,
+    StreamIn,
+    StreamDispatch,
+    StreamOut,
 }
 
 impl From<ContTag> for u16 {
@@ -193,6 +196,9 @@ impl fmt::Display for ContTag {
             ContTag::Terminal => write!(f, "terminal#"),
             ContTag::Emit => write!(f, "emit#"),
             ContTag::Cproc => write!(f, "cproc#"),
+            ContTag::StreamIn => write!(f, "stream-in#"),
+            ContTag::StreamDispatch => write!(f, "stream-dispatch#"),
+            ContTag::StreamOut => write!(f, "stream-out#"),
         }
     }
 }
@@ -539,6 +545,9 @@ pub(crate) mod tests {
             (ContTag::Terminal, 4110),
             (ContTag::Emit, 4111),
             (ContTag::Cproc, 4112),
+            (ContTag::StreamIn, 4113),
+            (ContTag::StreamDispatch, 4114),
+            (ContTag::StreamOut, 4115),
         ]);
         assert_eq!(map.len(), ContTag::COUNT);
         assert_tags_u16s(map)

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -142,9 +142,9 @@ pub enum ContTag {
     Terminal,
     Emit,
     Cproc,
-    StreamIn,
+    StreamStart,
     StreamDispatch,
-    StreamOut,
+    StreamPause,
 }
 
 impl From<ContTag> for u16 {
@@ -196,9 +196,9 @@ impl fmt::Display for ContTag {
             ContTag::Terminal => write!(f, "terminal#"),
             ContTag::Emit => write!(f, "emit#"),
             ContTag::Cproc => write!(f, "cproc#"),
-            ContTag::StreamIn => write!(f, "stream-in#"),
+            ContTag::StreamStart => write!(f, "stream-start#"),
             ContTag::StreamDispatch => write!(f, "stream-dispatch#"),
-            ContTag::StreamOut => write!(f, "stream-out#"),
+            ContTag::StreamPause => write!(f, "stream-pause#"),
         }
     }
 }
@@ -545,9 +545,9 @@ pub(crate) mod tests {
             (ContTag::Terminal, 4110),
             (ContTag::Emit, 4111),
             (ContTag::Cproc, 4112),
-            (ContTag::StreamIn, 4113),
+            (ContTag::StreamStart, 4113),
             (ContTag::StreamDispatch, 4114),
-            (ContTag::StreamOut, 4115),
+            (ContTag::StreamPause, 4115),
         ]);
         assert_eq!(map.len(), ContTag::COUNT);
         assert_tags_u16s(map)


### PR DESCRIPTION
Introduce the `Op::Recv` LEM operator, which awaits for data to be received by the channel terminal at LEM interpretation time.

This operator is used to implement the logic for the `StreamIn` continuation, which receives the argument to be applied to the (chaining) callable object.

The result will be available once the (new) `StreamOut` continuation is reached. When that happens, the computation can be resumed by supplying two pieces of data through the channel:
* A flag to tell if the machine should stutter while in `StreamOut`
* The next argument to be consumed in the incoming `StreamIn` state

Note: the second message should not be be sent if the machine is set to stutter with the first message.

There is a test to show that we're now able to construct proofs of computations that grow incrementally by starting from where we had stopped. We don't need to start the folding process from the beginning.

### Optimizing
From the second commit in this PR:
```
optimize: skip new `StreamIn` ocurrences

Prepare the next call directly from `StreamOut` without having to
go through `StreamIn` again.

Since `StreamIn` only occurs in the very first frame after this
optimization, it was renamed to `StreamStart`. And `StreamOut`,
which now serves as literal point for pause while supporting both
input and output, was renamed to `StreamPause`.
```

This optimization makes starting and resuming streams consume the same number of Lurk iterations.