### PR TITLE
refactor: Refactor proof handling for ownership and borrowing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ clap = "4.3.17"
 ff = "0.13"
 metrics = "0.22.0"
 neptune = { git = "https://github.com/lurk-lab/neptune", branch = "dev", default-features = false, features = ["abomonation"] }
-nova = { git = "https://github.com/lurk-lab/arecibo", branch = "dev", package = "arecibo", features = ["abomonate"]}
+nova = { git = "https://github.com/huitseeker/arecibo", branch = "cloneable_proofs", package = "arecibo", features = ["abomonate"]}
 once_cell = "1.18.0"
 pairing = { version = "0.23" }
 pasta_curves = { version = "0.5.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ clap = "4.3.17"
 ff = "0.13"
 metrics = "0.22.0"
 neptune = { git = "https://github.com/lurk-lab/neptune", branch = "dev", default-features = false, features = ["abomonation"] }
-nova = { git = "https://github.com/huitseeker/arecibo", branch = "cloneable_proofs", package = "arecibo", features = ["abomonate"]}
+nova = { git = "https://github.com/lurk-lab/arecibo", branch = "dev", package = "arecibo", features = ["abomonate"]}
 once_cell = "1.18.0"
 pairing = { version = "0.23" }
 pasta_curves = { version = "0.5.0" }

--- a/chain-server/Cargo.toml
+++ b/chain-server/Cargo.toml
@@ -17,18 +17,18 @@ name = "client"
 path = "src/client.rs"
 
 [dependencies]
-abomonation = "0.7.3"
-anyhow = "1.0.72"
-camino = "1.1.6"
-clap = "4.3.17"
-ff = "0.13"
+abomonation = { workspace = true }
+anyhow = { workspace = true }
+camino = { workspace = true}
+clap = { workspace = true}
+ff = { workspace = true }
 lurk = { path = "../" }
 halo2curves = { version = "0.6.0", features = ["bits", "derive_serde"] }
-nova = { git = "https://github.com/lurk-lab/arecibo", branch = "dev", package = "arecibo", features = ["abomonate"]}
-once_cell = "1.18.0"
+nova = { workspace = true }
+once_cell = {workspace = true }
 prost = "0.12"
 rustyline = "14.0"
-serde = "1.0"
+serde = { workspace = true }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 tonic = "0.11"
 

--- a/chain-server/src/server.rs
+++ b/chain-server/src/server.rs
@@ -161,7 +161,10 @@ where
                 let proof = proof
                     .compress(pp)
                     .map_err(|e| Status::internal(e.to_string()))?;
+                // the above compression operated on a recursive proof, so the following `into_owned()` should
+                // not involve cloning
                 let proof = proof
+                    .into_owned()
                     .get_compressed()
                     .ok_or(Status::internal("Failed to retrieve the compressed SNARK"))?;
 

--- a/src/cli/repl/mod.rs
+++ b/src/cli/repl/mod.rs
@@ -360,7 +360,11 @@ where
                     let proof = proof.compress(&pp)?;
                     assert_eq!(self.rc * num_steps, pad(n_frames, self.rc));
                     assert!(proof.verify(&pp, &public_inputs, &public_outputs)?);
-                    (LurkProofWrapper::Nova(proof), public_inputs, public_outputs)
+                    (
+                        LurkProofWrapper::Nova(proof.into_owned()),
+                        public_inputs,
+                        public_outputs,
+                    )
                 }
                 Backend::SuperNova => {
                     let prover = SuperNovaProver::<_, C>::new(self.rc, self.lang.clone());
@@ -375,7 +379,7 @@ where
                     let proof = proof.compress(&pp)?;
                     assert!(proof.verify(&pp, &public_inputs, &public_outputs)?);
                     (
-                        LurkProofWrapper::SuperNova(proof),
+                        LurkProofWrapper::SuperNova(proof.into_owned()),
                         public_inputs,
                         public_outputs,
                     )

--- a/src/coroutine/memoset/prove.rs
+++ b/src/coroutine/memoset/prove.rs
@@ -146,7 +146,7 @@ impl<'a, F: CurveCycleEquipped, Q: Query<F> + Send + Sync>
         ))
     }
 
-    fn compress(&self, pp: &PublicParams<F>) -> Result<Cow<Self>, ProofError> {
+    fn compress(&self, pp: &PublicParams<F>) -> Result<Cow<'_, Self>, ProofError> {
         match self {
             Self::Recursive(recursive_snark, _) => {
                 let snark = CompressedSNARK::prove(&pp.pp, pp.pk(), recursive_snark)?;

--- a/src/coroutine/memoset/prove.rs
+++ b/src/coroutine/memoset/prove.rs
@@ -28,7 +28,7 @@ use nova::{
         Dual as DualEng,
     },
 };
-use std::marker::PhantomData;
+use std::{borrow::Cow, marker::PhantomData};
 
 /// Number of arguments a coroutine takes: CEK arguments + memoset arguments
 const COROUTINE_ARITY: usize = 12;
@@ -146,13 +146,13 @@ impl<'a, F: CurveCycleEquipped, Q: Query<F> + Send + Sync>
         ))
     }
 
-    fn compress(self, pp: &PublicParams<F>) -> Result<Self, ProofError> {
-        match &self {
+    fn compress(&self, pp: &PublicParams<F>) -> Result<Cow<Self>, ProofError> {
+        match self {
             Self::Recursive(recursive_snark, _) => {
                 let snark = CompressedSNARK::prove(&pp.pp, pp.pk(), recursive_snark)?;
-                Ok(Self::Compressed(Box::new(snark), PhantomData))
+                Ok(Cow::Owned(Self::Compressed(Box::new(snark), PhantomData)))
             }
-            Self::Compressed(..) => Ok(self),
+            Self::Compressed(..) => Ok(Cow::Borrowed(self)),
         }
     }
 

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -16,7 +16,7 @@ pub mod supernova;
 mod tests;
 
 use ff::Field;
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
 
 use crate::{
     coprocessor::Coprocessor,
@@ -88,7 +88,7 @@ pub trait Provable<F: LurkField> {
 /// Trait to abstract Nova and SuperNova proofs
 pub trait RecursiveSNARKTrait<F: CurveCycleEquipped, M>
 where
-    Self: Sized,
+    Self: Sized + Clone,
 {
     /// Associated type for public parameters
     type PublicParams;
@@ -110,7 +110,7 @@ where
     ) -> Result<Self, ProofError>;
 
     /// Compress a proof
-    fn compress(self, pp: &Self::PublicParams) -> Result<Self, ProofError>;
+    fn compress(&self, pp: &Self::PublicParams) -> Result<Cow<Self>, ProofError>;
 
     /// Verify the proof given the public parameters, the input and output values
     fn verify(&self, pp: &Self::PublicParams, z0: &[F], zi: &[F]) -> Result<bool, Self::ErrorType>;

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -110,7 +110,7 @@ where
     ) -> Result<Self, ProofError>;
 
     /// Compress a proof
-    fn compress(&self, pp: &Self::PublicParams) -> Result<Cow<Self>, ProofError>;
+    fn compress(&self, pp: &Self::PublicParams) -> Result<Cow<'_, Self>, ProofError>;
 
     /// Verify the proof given the public parameters, the input and output values
     fn verify(&self, pp: &Self::PublicParams, z0: &[F], zi: &[F]) -> Result<bool, Self::ErrorType>;

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -332,14 +332,14 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<F, C1LEM<
         ))
     }
 
-    fn compress(&self, pp: &PublicParams<F>) -> Result<Cow<Self>, ProofError> {
+    fn compress(&self, pp: &PublicParams<F>) -> Result<Cow<'_, Self>, ProofError> {
         match self {
             Self::Recursive(recursive_snark, num_steps, _phantom) => {
                 Ok(Cow::Owned(Self::Compressed(
                     Box::new(CompressedSNARK::<_, SS1<F>, SS2<F>>::prove(
                         &pp.pp,
                         pp.pk(),
-                        &recursive_snark,
+                        recursive_snark,
                     )?),
                     *num_steps,
                     PhantomData,

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -15,6 +15,7 @@ use once_cell::sync::OnceCell;
 use pasta_curves::pallas;
 use serde::{Deserialize, Serialize};
 use std::{
+    borrow::Cow,
     marker::PhantomData,
     sync::{Arc, Mutex},
 };
@@ -161,7 +162,7 @@ impl<F: CurveCycleEquipped> From<NovaPublicParams<F>> for PublicParams<F> {
 }
 
 /// An enum representing the two types of proofs that can be generated and verified.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(bound = "")]
 pub enum Proof<F: CurveCycleEquipped, S> {
     /// A proof for the intermediate steps of a recursive computation along with
@@ -331,18 +332,20 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<F, C1LEM<
         ))
     }
 
-    fn compress(self, pp: &PublicParams<F>) -> Result<Self, ProofError> {
+    fn compress(&self, pp: &PublicParams<F>) -> Result<Cow<Self>, ProofError> {
         match self {
-            Self::Recursive(recursive_snark, num_steps, _phantom) => Ok(Self::Compressed(
-                Box::new(CompressedSNARK::<_, SS1<F>, SS2<F>>::prove(
-                    &pp.pp,
-                    pp.pk(),
-                    &recursive_snark,
-                )?),
-                num_steps,
-                PhantomData,
-            )),
-            Self::Compressed(..) => Ok(self),
+            Self::Recursive(recursive_snark, num_steps, _phantom) => {
+                Ok(Cow::Owned(Self::Compressed(
+                    Box::new(CompressedSNARK::<_, SS1<F>, SS2<F>>::prove(
+                        &pp.pp,
+                        pp.pk(),
+                        &recursive_snark,
+                    )?),
+                    *num_steps,
+                    PhantomData,
+                )))
+            }
+            Self::Compressed(..) => Ok(Cow::Borrowed(self)),
         }
     }
 

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -14,6 +14,7 @@ use once_cell::sync::OnceCell;
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
 use std::{
+    borrow::Cow,
     marker::PhantomData,
     ops::Index,
     sync::{Arc, Mutex},
@@ -137,7 +138,7 @@ pub fn public_params<F: CurveCycleEquipped, C: Coprocessor<F>>(
 }
 
 /// An enum representing the two types of proofs that can be generated and verified.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(bound = "")]
 pub enum Proof<F: CurveCycleEquipped, S> {
     /// A proof for the intermediate steps of a recursive computation
@@ -314,14 +315,14 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<F, C1LEM<
         ))
     }
 
-    fn compress(self, pp: &PublicParams<F>) -> Result<Self, ProofError> {
+    fn compress(&self, pp: &PublicParams<F>) -> Result<Cow<Self>, ProofError> {
         match &self {
             Self::Recursive(recursive_snark, _phantom) => {
                 let snark =
                     CompressedSNARK::<_, SS1<F>, SS2<F>>::prove(&pp.pp, pp.pk(), recursive_snark)?;
-                Ok(Self::Compressed(Box::new(snark), PhantomData))
+                Ok(Cow::Owned(Self::Compressed(Box::new(snark), PhantomData)))
             }
-            Self::Compressed(..) => Ok(self),
+            Self::Compressed(..) => Ok(Cow::Borrowed(self)),
         }
     }
 

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -315,7 +315,7 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<F, C1LEM<
         ))
     }
 
-    fn compress(&self, pp: &PublicParams<F>) -> Result<Cow<Self>, ProofError> {
+    fn compress(&self, pp: &PublicParams<F>) -> Result<Cow<'_, Self>, ProofError> {
         match &self {
             Self::Recursive(recursive_snark, _phantom) => {
                 let snark =

--- a/src/proof/tests/mod.rs
+++ b/src/proof/tests/mod.rs
@@ -195,7 +195,7 @@ fn nova_test_full_aux2<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a>(
         assert!(res.unwrap());
 
         let compressed: crate::proof::nova::Proof<F, C1LEM<'a, F, C>> =
-            proof.compress(&pp).unwrap();
+            proof.compress(&pp).unwrap().into_owned();
         let res2 = compressed.verify(&pp, &z0, &zi);
 
         assert!(res2.unwrap());


### PR DESCRIPTION
On a long enough timeline, we'll want to generate compressed proofs without dropping the associated `RecursiveProof`. This is for the purpose of re-starting the proof using the prior `RecursiveProof`, which at the moment can only be obtained through cloning prior to compression (which itself would be impossible prior to the companion PR used here).

The current approach witnesses that compression only requires a reference to the current proof, and returns a `Cow`: the only situation in which this would result in a clone is if:
- we create a `CompressedProof`,
- we call `compress()` on it,
- we further perform a modification of the resulting `CompressedProof` that requires an owned value.
=> this flow seems unlikely.

In detail:
- Updated `compress` function across various files to take `&self` instead of `self`, avoiding the drop of the `RecursiveProof`;
- Adjusted dependencies in chain-server's `Cargo.toml` to use workspace versions, streamlining dependency management and increasing project consistency.

> [!NOTE]
> This depends on and requires the companion PR https://github.com/lurk-lab/arecibo/pull/364. CI is fully expected to fail on the `cargo-deny` job due to use of a fork (until companion PR is merged).