### PR TITLE
feat: witness caching now operates on a bounded buffer

### DIFF
--- a/benches/end2end.rs
+++ b/benches/end2end.rs
@@ -63,8 +63,8 @@ fn end2end_benchmark(c: &mut Criterion) {
     let lang = Lang::<Bn>::new();
     let lang_rc = Arc::new(lang.clone());
 
-    let store = Store::default();
-    let prover: NovaProver<'_, Bn, Coproc<Bn>> = NovaProver::new(reduction_count, lang_rc.clone());
+    let store = Arc::new(Store::default());
+    let prover: NovaProver<Bn, Coproc<Bn>> = NovaProver::new(reduction_count, lang_rc.clone());
 
     // use cached public params
     let instance = Instance::new(reduction_count, lang_rc, true, Kind::NovaPublicParams);
@@ -195,7 +195,7 @@ fn prove_benchmark(c: &mut Criterion) {
     let limit = 1_000_000_000;
     let reduction_count = DEFAULT_REDUCTION_COUNT;
 
-    let store = Store::default();
+    let store = Arc::new(Store::default());
 
     let size = (10, 0);
     let benchmark_id = BenchmarkId::new("prove_go_base_nova", format!("_{}_{}", size.0, size.1));
@@ -216,8 +216,7 @@ fn prove_benchmark(c: &mut Criterion) {
 
     group.bench_with_input(benchmark_id, &size, |b, &s| {
         let ptr = go_base::<Bn>(&store, state.clone(), s.0, s.1);
-        let prover: NovaProver<'_, Bn, Coproc<Bn>> =
-            NovaProver::new(reduction_count, lang_rc.clone());
+        let prover: NovaProver<Bn, Coproc<Bn>> = NovaProver::new(reduction_count, lang_rc.clone());
         let frames =
             evaluate::<Bn, Coproc<Bn>>(None, ptr, &store, limit, &dummy_terminal()).unwrap();
 
@@ -242,7 +241,7 @@ fn prove_compressed_benchmark(c: &mut Criterion) {
 
     set_bench_config();
     let limit = 1_000_000_000;
-    let store = Store::default();
+    let store = Arc::new(Store::default());
     let reduction_count = DEFAULT_REDUCTION_COUNT;
 
     let size = (10, 0);
@@ -293,7 +292,7 @@ fn verify_benchmark(c: &mut Criterion) {
 
     set_bench_config();
     let limit = 1_000_000_000;
-    let store = Store::default();
+    let store = Arc::new(Store::default());
     let reduction_count = DEFAULT_REDUCTION_COUNT;
 
     let state = State::init_lurk_state().rccell();
@@ -348,7 +347,7 @@ fn verify_compressed_benchmark(c: &mut Criterion) {
 
     set_bench_config();
     let limit = 1_000_000_000;
-    let store = Store::default();
+    let store = Arc::new(Store::default());
     let reduction_count = DEFAULT_REDUCTION_COUNT;
 
     let state = State::init_lurk_state().rccell();

--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -91,7 +91,7 @@ fn fibonacci_prove<M: measurement::Measurement>(
         true,
         Kind::NovaPublicParams,
     );
-    let store = Store::default();
+    let store = Arc::new(Store::default());
     let pp = public_params(&instance).unwrap();
 
     // Track the number of `Lurk frames / sec`

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -102,7 +102,7 @@ fn sha256_ivc_prove<M: measurement::Measurement>(
 
     let limit = 10000;
 
-    let store = &Store::<Bn>::default();
+    let store = Arc::new(Store::<Bn>::default());
     let cproc_sym = user_sym(&format!("sha256_ivc_{arity}"));
 
     let mut lang = Lang::<Bn, Sha256Coproc<Bn>>::new();
@@ -125,7 +125,7 @@ fn sha256_ivc_prove<M: measurement::Measurement>(
         &prove_params,
         |b, prove_params| {
             let ptr = sha256_ivc(
-                store,
+                &*store,
                 state.clone(),
                 black_box(prove_params.arity),
                 black_box(prove_params.n),
@@ -137,7 +137,7 @@ fn sha256_ivc_prove<M: measurement::Measurement>(
             let frames = &evaluate(
                 Some((&lurk_step, &[], &lang)),
                 ptr,
-                store,
+                &*store,
                 limit,
                 &dummy_terminal(),
             )
@@ -146,7 +146,7 @@ fn sha256_ivc_prove<M: measurement::Measurement>(
             b.iter_batched(
                 || frames,
                 |frames| {
-                    let result = prover.prove_from_frames(&pp, frames, store, None);
+                    let result = prover.prove_from_frames(&pp, frames, &store, None);
                     let _ = black_box(result);
                 },
                 BatchSize::LargeInput,
@@ -190,7 +190,7 @@ fn sha256_ivc_prove_compressed<M: measurement::Measurement>(
 
     let limit = 10000;
 
-    let store = &Store::<Bn>::default();
+    let store = Arc::new(Store::<Bn>::default());
     let cproc_sym = user_sym(&format!("sha256_ivc_{arity}"));
 
     let mut lang = Lang::<Bn, Sha256Coproc<Bn>>::new();
@@ -213,7 +213,7 @@ fn sha256_ivc_prove_compressed<M: measurement::Measurement>(
         &prove_params,
         |b, prove_params| {
             let ptr = sha256_ivc(
-                store,
+                &*store,
                 state.clone(),
                 black_box(prove_params.arity),
                 black_box(prove_params.n),
@@ -225,7 +225,7 @@ fn sha256_ivc_prove_compressed<M: measurement::Measurement>(
             let frames = &evaluate(
                 Some((&lurk_step, &[], &lang)),
                 ptr,
-                store,
+                &*store,
                 limit,
                 &dummy_terminal(),
             )
@@ -235,7 +235,7 @@ fn sha256_ivc_prove_compressed<M: measurement::Measurement>(
                 || frames,
                 |frames| {
                     let (proof, _, _, _) =
-                        prover.prove_from_frames(&pp, frames, store, None).unwrap();
+                        prover.prove_from_frames(&pp, frames, &store, None).unwrap();
                     let compressed_result = proof.compress(&pp).unwrap();
 
                     let _ = black_box(compressed_result);
@@ -281,7 +281,7 @@ fn sha256_nivc_prove<M: measurement::Measurement>(
 
     let limit = 10000;
 
-    let store = &Store::<Bn>::default();
+    let store = Arc::new(Store::<Bn>::default());
     let cproc_sym = user_sym(&format!("sha256_ivc_{arity}"));
 
     let mut lang = Lang::<Bn, Sha256Coproc<Bn>>::new();
@@ -305,7 +305,7 @@ fn sha256_nivc_prove<M: measurement::Measurement>(
         &prove_params,
         |b, prove_params| {
             let ptr = sha256_ivc(
-                store,
+                &*store,
                 state.clone(),
                 black_box(prove_params.arity),
                 black_box(prove_params.n),
@@ -317,7 +317,7 @@ fn sha256_nivc_prove<M: measurement::Measurement>(
             let frames = &evaluate(
                 Some((&lurk_step, &cprocs, &lang)),
                 ptr,
-                store,
+                &*store,
                 limit,
                 &dummy_terminal(),
             )
@@ -326,7 +326,7 @@ fn sha256_nivc_prove<M: measurement::Measurement>(
             b.iter_batched(
                 || frames,
                 |frames| {
-                    let result = prover.prove_from_frames(&pp, frames, store, None);
+                    let result = prover.prove_from_frames(&pp, frames, &store, None);
                     let _ = black_box(result);
                 },
                 BatchSize::LargeInput,

--- a/benches/synthesis.rs
+++ b/benches/synthesis.rs
@@ -48,7 +48,7 @@ fn synthesize<M: measurement::Measurement>(
         BenchmarkId::new(name.to_string(), reduction_count),
         &reduction_count,
         |b, reduction_count| {
-            let store = Store::default();
+            let store = Arc::new(Store::default());
             let fib_n = (reduction_count / 3) as u64; // Heuristic, since one fib is 35 iterations.
             let ptr = fib::<Bn>(&store, state.clone(), black_box(fib_n));
             let frames =

--- a/benches/trie_nivc.rs
+++ b/benches/trie_nivc.rs
@@ -37,7 +37,7 @@ fn prove<M: measurement::Measurement>(
     name: &str,
     reduction_count: usize,
     lang: &Arc<Lang<Fr, TrieCoproc<Fr>>>,
-    store: &Store<Fr>,
+    store: &Arc<Store<Fr>>,
     frames: &[Frame],
     c: &mut BenchmarkGroup<'_, M>,
 ) {
@@ -67,7 +67,7 @@ fn trie_nivc(c: &mut Criterion) {
     install(&state, &mut lang);
     let lang = Arc::new(lang);
 
-    let store = Store::<Fr>::default();
+    let store = Arc::new(Store::<Fr>::default());
     let expr = store.read(state, CODE).unwrap();
 
     let lurk_step = make_eval_step_from_config(&EvalConfig::new_nivc(&lang));

--- a/examples/keccak.rs
+++ b/examples/keccak.rs
@@ -337,12 +337,12 @@ fn main() {
     let args = std::env::args().collect::<Vec<_>>();
 
     // Initialize store, responsible for handling variables in the lurk context
-    let store: &Store<pallas::Scalar> = &Store::default();
+    let store: Arc<Store<pallas::Scalar>> = Arc::new(Store::default());
 
     // Define the symbol that will call upon our Coprocessor
     let str_to_le_bits_sym = user_sym("str_to_le_bits");
     let keccak_sym = user_sym("keccak_hash");
-    let program = lurk_program(store, &args[1]);
+    let program = lurk_program(&*store, &args[1]);
 
     // Create the Lang. ie the list of corprocessor that will be accessible in our program
     let mut lang = Lang::<pallas::Scalar, KeccakExampleCoproc<pallas::Scalar>>::new();
@@ -360,7 +360,7 @@ fn main() {
     let frames = evaluate(
         Some((&lurk_step, &cprocs, &lang)),
         program,
-        store,
+        &*store,
         1000,
         &dummy_terminal(),
     )
@@ -395,7 +395,7 @@ fn main() {
     let proof_start = Instant::now();
 
     let (proof, z0, zi, _) = supernova_prover
-        .prove_from_frames(&pp, &frames, store, None)
+        .prove_from_frames(&pp, &frames, &store, None)
         .unwrap();
 
     let proof_end = proof_start.elapsed();

--- a/examples/sha256_ivc.rs
+++ b/examples/sha256_ivc.rs
@@ -63,10 +63,10 @@ fn main() {
     let args = std::env::args().collect::<Vec<_>>();
     let n = args.get(1).unwrap_or(&"1".into()).parse().unwrap();
 
-    let store = &Store::default();
+    let store = Arc::new(Store::default());
     let cproc_sym = user_sym(&format!("sha256_ivc_{n}"));
 
-    let call = sha256_ivc(store, n, &(0..n).collect::<Vec<_>>());
+    let call = sha256_ivc(&*store, n, &(0..n).collect::<Vec<_>>());
 
     let mut lang = Lang::<Bn, Sha256Coproc<Bn>>::new();
     lang.add_coprocessor(cproc_sym, Sha256Coprocessor::new(n));
@@ -92,7 +92,7 @@ fn main() {
                     &pp,
                     call,
                     store.intern_empty_env(),
-                    store,
+                    &store,
                     10000,
                     &dummy_terminal(),
                 )

--- a/examples/tp_table.rs
+++ b/examples/tp_table.rs
@@ -152,7 +152,7 @@ fn main() {
 
     let limit = n_iters(max_n_folds, *max_rc);
 
-    let store = Store::default();
+    let store = Arc::new(Store::default());
     let program = store.read_with_default_state(PROGRAM).unwrap();
 
     let frames =
@@ -164,7 +164,7 @@ fn main() {
     let mut data = Vec::with_capacity(rc_vec.len());
 
     for rc in rc_vec.clone() {
-        let prover: NovaProver<'_, _, _> = NovaProver::new(rc, lang_arc.clone());
+        let prover: NovaProver<_, _> = NovaProver::new(rc, lang_arc.clone());
         println!("Getting public params for rc={rc}");
         // TODO: use cache once it's fixed
         let pp: PublicParams<_> = public_params(rc, lang_arc.clone());

--- a/src/cli/lurk_proof.rs
+++ b/src/cli/lurk_proof.rs
@@ -122,40 +122,36 @@ impl<F: LurkField + DeserializeOwned> LurkProofMeta<F> {
 #[derive(Serialize, Deserialize)]
 #[serde(bound(serialize = "F: Serialize", deserialize = "F: DeserializeOwned"))]
 pub(crate) enum LurkProofWrapper<
-    'a,
     F: CurveCycleEquipped,
     C: Coprocessor<F> + Serialize + DeserializeOwned,
 > {
-    Nova(nova::Proof<F, C1LEM<'a, F, C>>),
-    SuperNova(supernova::Proof<F, C1LEM<'a, F, C>>),
+    Nova(nova::Proof<F, C1LEM<F, C>>),
+    SuperNova(supernova::Proof<F, C1LEM<F, C>>),
 }
 
 /// Minimal data structure containing just enough for proof verification
 #[non_exhaustive]
 #[derive(Serialize, Deserialize)]
 #[serde(bound(serialize = "F: Serialize", deserialize = "F: DeserializeOwned"))]
-pub(crate) struct LurkProof<
-    'a,
-    F: CurveCycleEquipped,
-    C: Coprocessor<F> + Serialize + DeserializeOwned,
-> {
-    pub(crate) proof: LurkProofWrapper<'a, F, C>,
+pub(crate) struct LurkProof<F: CurveCycleEquipped, C: Coprocessor<F> + Serialize + DeserializeOwned>
+{
+    pub(crate) proof: LurkProofWrapper<F, C>,
     pub(crate) public_inputs: Vec<F>,
     pub(crate) public_outputs: Vec<F>,
     pub(crate) rc: usize,
     pub(crate) lang: Lang<F, C>,
 }
 
-impl<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a + Serialize + DeserializeOwned>
-    HasFieldModulus for LurkProof<'a, F, C>
+impl<F: CurveCycleEquipped, C: Coprocessor<F> + Serialize + DeserializeOwned> HasFieldModulus
+    for LurkProof<F, C>
 {
     fn field_modulus() -> String {
         F::MODULUS.to_owned()
     }
 }
 
-impl<'a, F: CurveCycleEquipped + Serialize, C: Coprocessor<F> + Serialize + DeserializeOwned>
-    LurkProof<'a, F, C>
+impl<F: CurveCycleEquipped + Serialize, C: Coprocessor<F> + Serialize + DeserializeOwned>
+    LurkProof<F, C>
 {
     #[inline]
     pub(crate) fn persist(self, proof_key: &str) -> Result<()> {
@@ -167,7 +163,7 @@ impl<
         'a,
         F: CurveCycleEquipped + DeserializeOwned,
         C: Coprocessor<F> + Serialize + DeserializeOwned + 'a,
-    > LurkProof<'a, F, C>
+    > LurkProof<F, C>
 {
     #[inline]
     pub(crate) fn is_cached(proof_key: &str) -> bool {
@@ -179,7 +175,7 @@ impl<
         'a,
         F: CurveCycleEquipped + DeserializeOwned,
         C: Coprocessor<F> + Serialize + DeserializeOwned + 'a,
-    > LurkProof<'a, F, C>
+    > LurkProof<F, C>
 where
     F::Repr: Abomonation,
     <Dual<F> as PrimeField>::Repr: Abomonation,

--- a/src/cli/repl/meta_cmd.rs
+++ b/src/cli/repl/meta_cmd.rs
@@ -47,7 +47,6 @@ pub(super) struct MetaCmd<F: LurkField, C: Coprocessor<F> + Serialize + Deserial
 }
 
 impl<
-        'a,
         F: CurveCycleEquipped + Serialize + DeserializeOwned,
         C: Coprocessor<F> + Serialize + DeserializeOwned + 'static,
     > MetaCmd<F, C>
@@ -1010,7 +1009,7 @@ where
             let mut z_dag = ZDag::default();
             let z_ptr = z_dag.populate_with(&args, &repl.store, &mut Default::default());
             let args = LurkData { z_ptr, z_dag };
-            let LurkProof { proof, .. } = load::<LurkProof<'_, _, C>>(&proof_path(&proof_key))?;
+            let LurkProof { proof, .. } = load::<LurkProof<_, C>>(&proof_path(&proof_key))?;
             match proof {
                 LurkProofWrapper::Nova(proof) => {
                     assert_eq!(backend, Backend::Nova);
@@ -1054,7 +1053,7 @@ where
             let ProtocolProof {
                 args: LurkData { z_ptr, z_dag },
                 proof,
-            } = load::<ProtocolProof<F, C1LEM<'a, F, C>>>(&path)?;
+            } = load::<ProtocolProof<F, C1LEM<F, C>>>(&path)?;
 
             let args = z_dag.populate_store(&z_ptr, &repl.store, &mut Default::default())?;
 

--- a/src/coroutine/memoset/prove.rs
+++ b/src/coroutine/memoset/prove.rs
@@ -100,10 +100,10 @@ impl<'a, F: CurveCycleEquipped, Q: Query<F> + Send + Sync>
     type ErrorType = SuperNovaError;
 
     #[tracing::instrument(skip_all, name = "supernova::prove_recursively")]
-    fn prove_recursively(
+    fn prove_recursively<I: IntoIterator<Item = Coroutine<'a, F, Q>>>(
         pp: &PublicParams<F>,
         z0: &[F],
-        steps: Vec<Coroutine<'a, F, Q>>,
+        steps: I,
         _store: &Store<F>,
         init: Option<RecursiveSNARK<E1<F>>>,
     ) -> Result<Self, ProofError> {
@@ -136,8 +136,8 @@ impl<'a, F: CurveCycleEquipped, Q: Query<F> + Send + Sync>
 
             recursive_snark_option = Some(recursive_snark);
         };
-        for (i, step) in steps.iter().enumerate() {
-            prove_step(i, step);
+        for (i, step) in steps.into_iter().enumerate() {
+            prove_step(i, &step);
         }
         // This probably should be made unnecessary.
         Ok(Self::Recursive(

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -30,6 +30,9 @@ use crate::{
 
 use self::{nova::CurveCycleEquipped, supernova::FoldingConfig};
 
+/// A constant indicating the maximum amount of frames to buffer in memory while proving
+const MAX_BUFFERED_FRAMES: usize = 1000;
+
 /// The State of a CEK machine.
 pub trait CEKState<Ptr> {
     /// the expression, or control word (C)
@@ -109,7 +112,7 @@ where
         init: Option<Self::BaseRecursiveSNARK>,
     ) -> Result<Self, ProofError>
     where
-        <I as IntoIterator>::IntoIter: ExactSizeIterator;
+        <I as IntoIterator>::IntoIter: ExactSizeIterator + Send;
 
     /// Compress a proof
     fn compress(&self, pp: &Self::PublicParams) -> Result<Cow<'_, Self>, ProofError>;
@@ -159,7 +162,7 @@ impl FoldingMode {
 /// A trait for a prover that works with a field `F`.
 pub trait Prover<F: CurveCycleEquipped> {
     /// Associated type for a frame-like datatype
-    type Frame: FrameLike<Ptr, FrameIO = Vec<Ptr>>;
+    type Frame: FrameLike<Ptr, FrameIO = Vec<Ptr>> + Send;
 
     /// Associated type for public parameters
     type PublicParams;

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -101,13 +101,13 @@ where
     type ErrorType;
 
     /// Generate the recursive SNARK, encoded in `ProveOutput`
-    fn prove_recursively(
+    fn prove_recursively<I: IntoIterator<Item = M>>(
         pp: &Self::PublicParams,
         z0: &[F],
-        steps: Vec<M>,
+        steps: I,
         store: &Store<F>,
         init: Option<Self::BaseRecursiveSNARK>,
-    ) -> Result<Self, ProofError>;
+    ) -> Result<Self, ProofError> where <I as IntoIterator>::IntoIter: ExactSizeIterator;
 
     /// Compress a proof
     fn compress(&self, pp: &Self::PublicParams) -> Result<Cow<'_, Self>, ProofError>;

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -107,7 +107,9 @@ where
         steps: I,
         store: &Store<F>,
         init: Option<Self::BaseRecursiveSNARK>,
-    ) -> Result<Self, ProofError> where <I as IntoIterator>::IntoIter: ExactSizeIterator;
+    ) -> Result<Self, ProofError>
+    where
+        <I as IntoIterator>::IntoIter: ExactSizeIterator;
 
     /// Compress a proof
     fn compress(&self, pp: &Self::PublicParams) -> Result<Cow<'_, Self>, ProofError>;
@@ -155,7 +157,7 @@ impl FoldingMode {
 }
 
 /// A trait for a prover that works with a field `F`.
-pub trait Prover<'a, F: CurveCycleEquipped> {
+pub trait Prover<F: CurveCycleEquipped> {
     /// Associated type for a frame-like datatype
     type Frame: FrameLike<Ptr, FrameIO = Vec<Ptr>>;
 
@@ -176,7 +178,7 @@ pub trait Prover<'a, F: CurveCycleEquipped> {
         &self,
         pp: &Self::PublicParams,
         steps: Vec<Self::Frame>,
-        store: &'a Store<F>,
+        store: &Store<F>,
         init: Option<
             <Self::RecursiveSNARK as RecursiveSNARKTrait<F, Self::Frame>>::BaseRecursiveSNARK,
         >,
@@ -198,7 +200,7 @@ pub trait Prover<'a, F: CurveCycleEquipped> {
         pp: &Self::PublicParams,
         expr: Ptr,
         env: Ptr,
-        store: &'a Store<F>,
+        store: &Arc<Store<F>>,
         limit: usize,
         ch_terminal: &ChannelTerminal<Ptr>,
     ) -> Result<(Self::RecursiveSNARK, Vec<F>, Vec<F>, usize), ProofError>;

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -98,7 +98,7 @@ pub type SS2<F> = nova::spartan::snark::RelaxedR1CSSNARK<DualEng<E1<F>>, EE2<F>>
 /// Type alias for a MultiFrame with S1 field elements.
 /// This uses the <<F as CurveCycleEquipped>::G1 as Group>::Scalar type for the G1 scalar field elements
 /// to reflect it this should not be used outside the Nova context
-pub type C1LEM<'a, F, C> = crate::lem::multiframe::MultiFrame<'a, F, C>;
+pub type C1LEM<F, C> = crate::lem::multiframe::MultiFrame<F, C>;
 /// Type alias for a Trivial Test Circuit with G2 scalar field elements.
 pub type C2<F> = TrivialCircuit<Dual<F>>;
 
@@ -188,7 +188,7 @@ pub fn circuit_cache_key<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a>(
     lang: Arc<Lang<F, C>>,
 ) -> F {
     let folding_config = Arc::new(FoldingConfig::new_ivc(lang, 2));
-    let circuit = C1LEM::<'a, F, C>::blank(folding_config, 0);
+    let circuit = C1LEM::<F, C>::blank(folding_config, 0);
     F::from(rc as u64) * nova::circuit_digest::<F::E1, _>(&circuit)
 }
 
@@ -219,10 +219,10 @@ pub fn public_params<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a>(
 pub fn circuits<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a>(
     reduction_count: usize,
     lang: Arc<Lang<F, C>>,
-) -> (C1LEM<'a, F, C>, C2<F>) {
+) -> (C1LEM<F, C>, C2<F>) {
     let folding_config = Arc::new(FoldingConfig::new_ivc(lang, reduction_count));
     (
-        C1LEM::<'a, F, C>::blank(folding_config, 0),
+        C1LEM::<F, C>::blank(folding_config, 0),
         TrivialCircuit::default(),
     )
 }
@@ -231,7 +231,7 @@ pub fn circuits<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a>(
 /// system is satisfied
 #[inline]
 pub(crate) fn debug_step<F: LurkField, C: Coprocessor<F>>(
-    circuit: &MultiFrame<'_, F, C>,
+    circuit: &MultiFrame<F, C>,
     store: &Store<F>,
 ) -> Result<(), SynthesisError> {
     use bellpepper_core::test_cs::TestConstraintSystem;
@@ -250,24 +250,27 @@ pub(crate) fn debug_step<F: LurkField, C: Coprocessor<F>>(
     Ok(())
 }
 
-impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<F, C1LEM<'a, F, C>>
-    for Proof<F, C1LEM<'a, F, C>>
+impl<F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<F, C1LEM<F, C>>
+    for Proof<F, C1LEM<F, C>>
 {
     type PublicParams = PublicParams<F>;
     type BaseRecursiveSNARK = RecursiveSNARK<E1<F>>;
     type ErrorType = NovaError;
 
     #[tracing::instrument(skip_all, name = "nova::prove_recursively")]
-    fn prove_recursively<I: IntoIterator<Item = C1LEM<'a, F, C>>>(
+    fn prove_recursively<I: IntoIterator<Item = C1LEM<F, C>>>(
         pp: &PublicParams<F>,
         z0: &[F],
         steps: I,
         store: &Store<F>,
         init: Option<RecursiveSNARK<E1<F>>>,
-    ) -> Result<Self, ProofError> where <I as IntoIterator>::IntoIter: ExactSizeIterator{
+    ) -> Result<Self, ProofError>
+    where
+        <I as IntoIterator>::IntoIter: ExactSizeIterator,
+    {
         let debug = false;
         let mut steps = steps.into_iter().peekable();
-        assert_eq!(steps.peek().map(|s| s.arity()).unwrap_or(0), z0.len());
+        assert_eq!(steps.peek().map_or(0, |s| s.arity()), z0.len());
 
         let secondary_circuit = TrivialCircuit::default();
 
@@ -276,21 +279,20 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<F, C1LEM<
 
         let mut recursive_snark_option = init;
 
-        let prove_step =
-            |i: usize, step: &C1LEM<'a, F, C>, rs: &mut Option<RecursiveSNARK<E1<F>>>| {
-                if debug {
-                    debug_step(step, store).unwrap();
-                }
-                let mut recursive_snark = rs.take().unwrap_or_else(|| {
-                    RecursiveSNARK::new(&pp.pp, step, &secondary_circuit, z0, &Self::z0_secondary())
-                        .expect("failed to construct initial recursive SNARK")
-                });
-                info!("prove_step {i}");
-                recursive_snark
-                    .prove_step(&pp.pp, step, &secondary_circuit)
-                    .unwrap();
-                *rs = Some(recursive_snark);
-            };
+        let prove_step = |i: usize, step: &C1LEM<F, C>, rs: &mut Option<RecursiveSNARK<E1<F>>>| {
+            if debug {
+                debug_step(step, store).unwrap();
+            }
+            let mut recursive_snark = rs.take().unwrap_or_else(|| {
+                RecursiveSNARK::new(&pp.pp, step, &secondary_circuit, z0, &Self::z0_secondary())
+                    .expect("failed to construct initial recursive SNARK")
+            });
+            info!("prove_step {i}");
+            recursive_snark
+                .prove_step(&pp.pp, step, &secondary_circuit)
+                .unwrap();
+            *rs = Some(recursive_snark);
+        };
 
         recursive_snark_option = if lurk_config(None, None)
             .perf
@@ -298,7 +300,7 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<F, C1LEM<
             .wit_gen_vs_folding
             .is_parallel()
         {
-            let cc = steps.into_iter().map(Mutex::new).collect::<Vec<_>>();
+            let cc = steps.map(Mutex::new).collect::<Vec<_>>();
 
             std::thread::scope(|s| {
                 s.spawn(|| {
@@ -370,15 +372,14 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<F, C1LEM<
 
 /// A struct for the Nova prover that operates on field elements of type `F`.
 #[derive(Debug)]
-pub struct NovaProver<'a, F: CurveCycleEquipped, C: Coprocessor<F>> {
+pub struct NovaProver<F: CurveCycleEquipped, C: Coprocessor<F>> {
     /// The number of small-step reductions performed in each recursive step.
     reduction_count: usize,
     lang: Arc<Lang<F, C>>,
     folding_mode: FoldingMode,
-    _phantom: PhantomData<&'a ()>,
 }
 
-impl<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a> NovaProver<'a, F, C> {
+impl<F: CurveCycleEquipped, C: Coprocessor<F>> NovaProver<F, C> {
     /// Create a new NovaProver with a reduction count and a `Lang`
     #[inline]
     pub fn new(reduction_count: usize, lang: Arc<Lang<F, C>>) -> Self {
@@ -386,7 +387,6 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a> NovaProver<'a, F, C> {
             reduction_count,
             lang,
             folding_mode: FoldingMode::IVC,
-            _phantom: PhantomData,
         }
     }
 
@@ -395,13 +395,13 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a> NovaProver<'a, F, C> {
         &self,
         pp: &PublicParams<F>,
         frames: &[Frame],
-        store: &'a Store<F>,
+        store: &Arc<Store<F>>,
         init: Option<RecursiveSNARK<E1<F>>>,
-    ) -> Result<(Proof<F, C1LEM<'a, F, C>>, Vec<F>, Vec<F>, usize), ProofError> {
+    ) -> Result<(Proof<F, C1LEM<F, C>>, Vec<F>, Vec<F>, usize), ProofError> {
         let folding_config = self
             .folding_mode()
             .folding_config(self.lang().clone(), self.reduction_count());
-        let steps = C1LEM::<'a, F, C>::from_frames(frames, store, &folding_config.into());
+        let steps = C1LEM::<F, C>::from_frames(frames, store, &folding_config.into());
         self.prove(pp, steps, store, init)
     }
 
@@ -412,10 +412,10 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a> NovaProver<'a, F, C> {
     }
 }
 
-impl<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a> Prover<'a, F> for NovaProver<'a, F, C> {
-    type Frame = C1LEM<'a, F, C>;
+impl<F: CurveCycleEquipped, C: Coprocessor<F>> Prover<F> for NovaProver<F, C> {
+    type Frame = C1LEM<F, C>;
     type PublicParams = PublicParams<F>;
-    type RecursiveSNARK = Proof<F, C1LEM<'a, F, C>>;
+    type RecursiveSNARK = Proof<F, C1LEM<F, C>>;
 
     #[inline]
     fn reduction_count(&self) -> usize {
@@ -432,13 +432,13 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F> + 'a> Prover<'a, F> for NovaPr
         pp: &Self::PublicParams,
         expr: Ptr,
         env: Ptr,
-        store: &'a Store<F>,
+        store: &Arc<Store<F>>,
         limit: usize,
         ch_terminal: &ChannelTerminal<Ptr>,
     ) -> Result<(Self::RecursiveSNARK, Vec<F>, Vec<F>, usize), ProofError> {
         let eval_config = self.folding_mode().eval_config(self.lang());
         let frames =
-            C1LEM::<'a, F, C>::build_frames(expr, env, store, limit, &eval_config, ch_terminal)?;
+            C1LEM::<F, C>::build_frames(expr, env, store, limit, &eval_config, ch_terminal)?;
         self.prove_from_frames(pp, &frames, store, None)
     }
 }

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -214,14 +214,15 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<F, C1LEM<
     type ErrorType = SuperNovaError;
 
     #[tracing::instrument(skip_all, name = "supernova::prove_recursively")]
-    fn prove_recursively(
+    fn prove_recursively<I: IntoIterator<Item = C1LEM<'a, F, C>>>(
         pp: &PublicParams<F>,
         z0: &[F],
-        steps: Vec<C1LEM<'a, F, C>>,
+        steps: I,
         store: &Store<F>,
         init: Option<RecursiveSNARK<E1<F>>>,
-    ) -> Result<Self, ProofError> {
+    ) -> Result<Self, ProofError> where <I as IntoIterator>::IntoIter: ExactSizeIterator {
         let debug = false;
+        let steps = steps.into_iter();
 
         info!("proving {} steps", steps.len());
 
@@ -303,8 +304,8 @@ impl<'a, F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<F, C1LEM<
                 recursive_snark_option
             })
         } else {
-            for (i, step) in steps.iter().enumerate() {
-                prove_step(i, step, &mut recursive_snark_option);
+            for (i, step) in steps.enumerate() {
+                prove_step(i, &step, &mut recursive_snark_option);
             }
             recursive_snark_option
         };

--- a/src/proof/tests/nova_tests.rs
+++ b/src/proof/tests/nova_tests.rs
@@ -19,7 +19,7 @@ use super::{
 
 #[test]
 fn test_prove_self_evaluating() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr_num = "999";
     let expt_num = s.num_u64(999);
 
@@ -52,12 +52,12 @@ fn test_prove_self_evaluating() {
     ]
     .into_iter()
     {
-        test_aux::<_, Coproc<_>>(s, expr, Some(expt), None, None, None, &expect!["1"], &None);
+        test_aux::<_, Coproc<_>>(&s, expr, Some(expt), None, None, None, &expect!["1"], &None);
     }
 
     let fun = s.intern_fun(s.intern_user_symbol("x"), s.list(vec![expt_nil]), expt_nil);
     nova_test_full_aux2::<_, Coproc<_>>(
-        s,
+        &s,
         fun,
         Some(fun),
         None,
@@ -73,11 +73,11 @@ fn test_prove_self_evaluating() {
 
 #[test]
 fn test_prove_binop() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(3);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(+ 1 2)",
         Some(expected),
         None,
@@ -93,11 +93,11 @@ fn test_prove_binop() {
 // This tests the testing mechanism. Since the supplied expected value is wrong,
 // the test should panic on an assertion failure.
 fn test_prove_binop_fail() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(2);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(+ 1 2)",
         Some(expected),
         None,
@@ -111,11 +111,11 @@ fn test_prove_binop_fail() {
 #[test]
 #[ignore]
 fn test_prove_arithmetic_let() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(3);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(let ((a 5)
                   (b 1)
                   (c 2))
@@ -132,11 +132,11 @@ fn test_prove_arithmetic_let() {
 #[test]
 #[ignore]
 fn test_prove_eq() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.intern_lurk_symbol("t");
     let terminal = s.cont_terminal();
     nova_test_full_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(eq 5 5)",
         Some(expected),
         None,
@@ -153,11 +153,11 @@ fn test_prove_eq() {
 #[test]
 #[ignore]
 fn test_prove_num_equal() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.intern_lurk_symbol("t");
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(= 5 5)",
         Some(expected),
         None,
@@ -170,7 +170,7 @@ fn test_prove_num_equal() {
     let expected = s.intern_nil();
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(= 5 6)",
         Some(expected),
         None,
@@ -183,11 +183,11 @@ fn test_prove_num_equal() {
 
 #[test]
 fn test_prove_invalid_num_equal() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.intern_nil();
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(= 5 nil)",
         Some(expected),
         None,
@@ -199,7 +199,7 @@ fn test_prove_invalid_num_equal() {
 
     let expected = s.num_u64(5);
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(= nil 5)",
         Some(expected),
         None,
@@ -212,13 +212,13 @@ fn test_prove_invalid_num_equal() {
 
 #[test]
 fn test_prove_equal() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let nil = s.intern_nil();
     let t = s.intern_lurk_symbol("t");
     let terminal = s.cont_terminal();
 
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(eq 5 nil)",
         Some(nil),
         None,
@@ -228,7 +228,7 @@ fn test_prove_equal() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(eq nil 5)",
         Some(nil),
         None,
@@ -238,7 +238,7 @@ fn test_prove_equal() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(eq nil nil)",
         Some(t),
         None,
@@ -248,7 +248,7 @@ fn test_prove_equal() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(eq 5 5)",
         Some(t),
         None,
@@ -261,10 +261,10 @@ fn test_prove_equal() {
 
 #[test]
 fn test_prove_quote_end_is_nil_error() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(quote (1) (2))",
         None,
         None,
@@ -277,11 +277,11 @@ fn test_prove_quote_end_is_nil_error() {
 
 #[test]
 fn test_prove_if() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(5);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(if t 5 6)",
         Some(expected),
         None,
@@ -294,7 +294,7 @@ fn test_prove_if() {
     let expected = s.num_u64(6);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(if nil 5 6)",
         Some(expected),
         None,
@@ -307,11 +307,11 @@ fn test_prove_if() {
 
 #[test]
 fn test_prove_if_end_is_nil_error() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(5);
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(if nil 5 6 7)",
         Some(expected),
         None,
@@ -325,11 +325,11 @@ fn test_prove_if_end_is_nil_error() {
 #[test]
 #[ignore]
 fn test_prove_if_fully_evaluates() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(10);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(if t (+ 5 5) 6)",
         Some(expected),
         None,
@@ -343,11 +343,11 @@ fn test_prove_if_fully_evaluates() {
 #[test]
 #[ignore] // Skip expensive tests in CI for now. Do run these locally, please.
 fn test_prove_recursion1() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(25);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(letrec ((exp (lambda (base)
                            (lambda (exponent)
                              (if (= 0 exponent)
@@ -366,11 +366,11 @@ fn test_prove_recursion1() {
 #[test]
 #[ignore] // Skip expensive tests in CI for now. Do run these locally, please.
 fn test_prove_recursion2() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(25);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(letrec ((exp (lambda (base)
                               (lambda (exponent)
                                  (lambda (acc)
@@ -388,11 +388,11 @@ fn test_prove_recursion2() {
 }
 
 fn test_prove_unop_regression_aux(chunk_count: usize) {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.intern_lurk_symbol("t");
     let terminal = s.cont_terminal();
     nova_test_full_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(atom 123)",
         Some(expected),
         None,
@@ -407,7 +407,7 @@ fn test_prove_unop_regression_aux(chunk_count: usize) {
 
     let expected = s.num_u64(1);
     nova_test_full_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(car '(1 . 2))",
         Some(expected),
         None,
@@ -422,7 +422,7 @@ fn test_prove_unop_regression_aux(chunk_count: usize) {
 
     let expected = s.num_u64(2);
     nova_test_full_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(cdr '(1 . 2))",
         Some(expected),
         None,
@@ -437,7 +437,7 @@ fn test_prove_unop_regression_aux(chunk_count: usize) {
 
     let expected = s.num_u64(123);
     nova_test_full_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(emit 123)",
         Some(expected),
         None,
@@ -464,11 +464,11 @@ fn test_prove_unop_regression() {
 #[test]
 #[ignore]
 fn test_prove_emit_output() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(emit 123)",
         Some(expected),
         None,
@@ -482,11 +482,11 @@ fn test_prove_emit_output() {
 #[test]
 #[ignore]
 fn test_prove_evaluate() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(99);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "((lambda (x) x) 99)",
         Some(expected),
         None,
@@ -500,11 +500,11 @@ fn test_prove_evaluate() {
 #[test]
 #[ignore]
 fn test_prove_evaluate2() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(99);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "((lambda (y)
                 ((lambda (x) y) 888))
               99)",
@@ -520,11 +520,11 @@ fn test_prove_evaluate2() {
 #[test]
 #[ignore]
 fn test_prove_evaluate3() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(999);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "((lambda (y)
                  ((lambda (x)
                     ((lambda (z) z)
@@ -543,11 +543,11 @@ fn test_prove_evaluate3() {
 #[test]
 #[ignore]
 fn test_prove_evaluate4() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(888);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "((lambda (y)
                  ((lambda (x)
                     ((lambda (z) z)
@@ -567,11 +567,11 @@ fn test_prove_evaluate4() {
 #[test]
 #[ignore]
 fn test_prove_evaluate5() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(999);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(((lambda (fn)
                   (lambda (x) (fn x)))
                 (lambda (y) y))
@@ -588,11 +588,11 @@ fn test_prove_evaluate5() {
 #[test]
 #[ignore]
 fn test_prove_evaluate_sum() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(9);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(+ 2 (+ 3 4))",
         Some(expected),
         None,
@@ -605,11 +605,11 @@ fn test_prove_evaluate_sum() {
 
 #[test]
 fn test_prove_binop_rest_is_nil() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(9);
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(- 9 8 7)",
         Some(expected),
         None,
@@ -619,7 +619,7 @@ fn test_prove_binop_rest_is_nil() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(= 9 8 7)",
         Some(expected),
         None,
@@ -631,7 +631,7 @@ fn test_prove_binop_rest_is_nil() {
 }
 
 fn op_syntax_error<T: Op + Copy>() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let error = s.cont_error();
     let test = |op: T| {
         let name = op.symbol_name();
@@ -640,7 +640,7 @@ fn op_syntax_error<T: Op + Copy>() {
             let expr = format!("({name})");
             tracing::debug!("{:?}", &expr);
             test_aux::<_, Coproc<_>>(
-                s,
+                &s,
                 &expr,
                 None,
                 None,
@@ -654,7 +654,7 @@ fn op_syntax_error<T: Op + Copy>() {
             let expr = format!("({name} 123)");
             tracing::debug!("{:?}", &expr);
             test_aux::<_, Coproc<_>>(
-                s,
+                &s,
                 &expr,
                 None,
                 None,
@@ -668,7 +668,7 @@ fn op_syntax_error<T: Op + Copy>() {
             let expr = format!("({name} 123 456)");
             tracing::debug!("{:?}", &expr);
             test_aux::<_, Coproc<_>>(
-                s,
+                &s,
                 &expr,
                 None,
                 None,
@@ -687,7 +687,7 @@ fn op_syntax_error<T: Op + Copy>() {
             } else {
                 &expect!["1"]
             };
-            test_aux::<_, Coproc<_>>(s, &expr, None, None, Some(error), None, iterations, &None);
+            test_aux::<_, Coproc<_>>(&s, &expr, None, None, Some(error), None, iterations, &None);
         }
     };
 
@@ -710,11 +710,11 @@ fn test_prove_binop_syntax_error() {
 
 #[test]
 fn test_prove_diff() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(4);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(- 9 5)",
         Some(expected),
         None,
@@ -728,11 +728,11 @@ fn test_prove_diff() {
 #[test]
 #[ignore]
 fn test_prove_product() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(45);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(* 9 5)",
         Some(expected),
         None,
@@ -746,11 +746,11 @@ fn test_prove_product() {
 #[test]
 #[ignore]
 fn test_prove_quotient() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(7);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(/ 21 3)",
         Some(expected),
         None,
@@ -763,11 +763,11 @@ fn test_prove_quotient() {
 
 #[test]
 fn test_prove_error_div_by_zero() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(0);
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(/ 21 0)",
         Some(expected),
         None,
@@ -780,11 +780,11 @@ fn test_prove_error_div_by_zero() {
 
 #[test]
 fn test_prove_error_invalid_type_and_not_cons() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.intern_nil();
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(/ 21 nil)",
         Some(expected),
         None,
@@ -798,11 +798,11 @@ fn test_prove_error_invalid_type_and_not_cons() {
 #[test]
 #[ignore]
 fn test_prove_adder() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(5);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(((lambda (x)
                 (lambda (y)
                   (+ x y)))
@@ -819,11 +819,11 @@ fn test_prove_adder() {
 
 #[test]
 fn test_prove_current_env_simple() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.intern_empty_env();
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(current-env)",
         Some(expected),
         None,
@@ -836,11 +836,11 @@ fn test_prove_current_env_simple() {
 
 #[test]
 fn test_prove_current_env_rest_is_nil_error() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.read_with_default_state("(current-env a)").unwrap();
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(current-env a)",
         Some(expected),
         None,
@@ -854,11 +854,11 @@ fn test_prove_current_env_rest_is_nil_error() {
 #[test]
 #[ignore]
 fn test_prove_let_simple() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(1);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(let ((a 1))
               a)",
         Some(expected),
@@ -872,10 +872,10 @@ fn test_prove_let_simple() {
 
 #[test]
 fn test_prove_let_end_is_nil_error() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(let ((a 1 2)) a)",
         None,
         None,
@@ -888,10 +888,10 @@ fn test_prove_let_end_is_nil_error() {
 
 #[test]
 fn test_prove_letrec_end_is_nil_error() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(letrec ((a 1 2)) a)",
         None,
         None,
@@ -904,10 +904,10 @@ fn test_prove_letrec_end_is_nil_error() {
 
 #[test]
 fn test_prove_lambda_empty_error() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "((lambda (x)) 0)",
         None,
         None,
@@ -920,10 +920,10 @@ fn test_prove_lambda_empty_error() {
 
 #[test]
 fn test_prove_let_empty_error() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(let)",
         None,
         None,
@@ -936,10 +936,10 @@ fn test_prove_let_empty_error() {
 
 #[test]
 fn test_prove_let_empty_body_error() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(let ((a 1)))",
         None,
         None,
@@ -952,10 +952,10 @@ fn test_prove_let_empty_body_error() {
 
 #[test]
 fn test_prove_letrec_empty_error() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(letrec)",
         None,
         None,
@@ -968,10 +968,10 @@ fn test_prove_letrec_empty_error() {
 
 #[test]
 fn test_prove_letrec_empty_body_error() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(letrec ((a 1)))",
         None,
         None,
@@ -984,11 +984,11 @@ fn test_prove_letrec_empty_body_error() {
 
 #[test]
 fn test_prove_let_body_nil() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.intern_lurk_symbol("t");
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(eq nil (let () nil))",
         Some(expected),
         None,
@@ -1001,10 +1001,10 @@ fn test_prove_let_body_nil() {
 
 #[test]
 fn test_prove_let_rest_body_is_nil_error() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(let ((a 1)) a 1)",
         None,
         None,
@@ -1017,10 +1017,10 @@ fn test_prove_let_rest_body_is_nil_error() {
 
 #[test]
 fn test_prove_letrec_rest_body_is_nil_error() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(letrec ((a 1)) a 1)",
         None,
         None,
@@ -1034,11 +1034,11 @@ fn test_prove_letrec_rest_body_is_nil_error() {
 #[test]
 #[ignore]
 fn test_prove_let_null_bindings() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(3);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(let () (+ 1 2))",
         Some(expected),
         None,
@@ -1051,11 +1051,11 @@ fn test_prove_let_null_bindings() {
 #[test]
 #[ignore]
 fn test_prove_letrec_null_bindings() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(3);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(letrec () (+ 1 2))",
         Some(expected),
         None,
@@ -1069,11 +1069,11 @@ fn test_prove_letrec_null_bindings() {
 #[test]
 #[ignore]
 fn test_prove_let() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(6);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(let ((a 1)
                    (b 2)
                    (c 3))
@@ -1090,11 +1090,11 @@ fn test_prove_let() {
 #[test]
 #[ignore]
 fn test_prove_arithmetic() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(20);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "((((lambda (x)
                   (lambda (y)
                     (lambda (z)
@@ -1115,11 +1115,11 @@ fn test_prove_arithmetic() {
 #[test]
 #[ignore]
 fn test_prove_comparison() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.intern_lurk_symbol("t");
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(let ((x 2)
                    (y 3)
                    (z 4))
@@ -1137,11 +1137,11 @@ fn test_prove_comparison() {
 #[test]
 #[ignore]
 fn test_prove_conditional() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(5);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(let ((true (lambda (a)
                            (lambda (b)
                              a)))
@@ -1166,11 +1166,11 @@ fn test_prove_conditional() {
 #[test]
 #[ignore]
 fn test_prove_conditional2() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(6);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(let ((true (lambda (a)
                            (lambda (b)
                              a)))
@@ -1195,11 +1195,11 @@ fn test_prove_conditional2() {
 #[test]
 #[ignore]
 fn test_prove_fundamental_conditional_bug() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(5);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(let ((true (lambda (a)
                            (lambda (b)
                              a)))
@@ -1221,11 +1221,11 @@ fn test_prove_fundamental_conditional_bug() {
 #[test]
 #[ignore]
 fn test_prove_fully_evaluates() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(10);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(if t (+ 5 5) 6)",
         Some(expected),
         None,
@@ -1239,11 +1239,11 @@ fn test_prove_fully_evaluates() {
 #[test]
 #[ignore]
 fn test_prove_recursion() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(25);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(letrec ((exp (lambda (base)
                                (lambda (exponent)
                                  (if (= 0 exponent)
@@ -1262,11 +1262,11 @@ fn test_prove_recursion() {
 #[test]
 #[ignore]
 fn test_prove_recursion_multiarg() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(25);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(letrec ((exp (lambda (base exponent)
                                (if (= 0 exponent)
                                    1
@@ -1284,11 +1284,11 @@ fn test_prove_recursion_multiarg() {
 #[test]
 #[ignore]
 fn test_prove_recursion_optimized() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(25);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(let ((exp (lambda (base)
                             (letrec ((base-inner
                                        (lambda (exponent)
@@ -1309,11 +1309,11 @@ fn test_prove_recursion_optimized() {
 #[test]
 #[ignore]
 fn test_prove_tail_recursion() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(25);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(letrec ((exp (lambda (base)
                                (lambda (exponent-remaining)
                                  (lambda (acc)
@@ -1333,12 +1333,10 @@ fn test_prove_tail_recursion() {
 #[test]
 #[ignore]
 fn test_prove_tail_recursion_somewhat_optimized() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(25);
     let terminal = s.cont_terminal();
-    test_aux::<_, Coproc<_>>(
-        s,
-        "(letrec ((exp (lambda (base)
+    test_aux::<_, Coproc<_>>( &s, "(letrec ((exp (lambda (base)
                                (letrec ((base-inner
                                           (lambda (exponent-remaining)
                                             (lambda (acc)
@@ -1358,11 +1356,11 @@ fn test_prove_tail_recursion_somewhat_optimized() {
 #[test]
 #[ignore]
 fn test_prove_no_mutual_recursion() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.intern_lurk_symbol("t");
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(letrec ((even (lambda (n)
                               (if (= 0 n)
                                   t
@@ -1384,10 +1382,10 @@ fn test_prove_no_mutual_recursion() {
 #[test]
 #[ignore]
 fn test_prove_no_mutual_recursion_error() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(letrec ((even (lambda (n)
                               (if (= 0 n)
                                   t
@@ -1409,11 +1407,11 @@ fn test_prove_no_mutual_recursion_error() {
 #[test]
 #[ignore]
 fn test_prove_cons1() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(1);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(car (cons 1 2))",
         Some(expected),
         None,
@@ -1426,10 +1424,10 @@ fn test_prove_cons1() {
 
 #[test]
 fn test_prove_car_end_is_nil_error() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(car (1 2) 3)",
         None,
         None,
@@ -1442,10 +1440,10 @@ fn test_prove_car_end_is_nil_error() {
 
 #[test]
 fn test_prove_cdr_end_is_nil_error() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(cdr (1 2) 3)",
         None,
         None,
@@ -1458,10 +1456,10 @@ fn test_prove_cdr_end_is_nil_error() {
 
 #[test]
 fn test_prove_atom_end_is_nil_error() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(atom 123 4)",
         None,
         None,
@@ -1474,10 +1472,10 @@ fn test_prove_atom_end_is_nil_error() {
 
 #[test]
 fn test_prove_emit_end_is_nil_error() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(emit 123 4)",
         None,
         None,
@@ -1490,11 +1488,11 @@ fn test_prove_emit_end_is_nil_error() {
 
 #[test]
 fn test_prove_cons2() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(2);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(cdr (cons 1 2))",
         Some(expected),
         None,
@@ -1507,11 +1505,11 @@ fn test_prove_cons2() {
 
 #[test]
 fn test_prove_zero_arg_lambda1() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "((lambda () 123))",
         Some(expected),
         None,
@@ -1524,11 +1522,11 @@ fn test_prove_zero_arg_lambda1() {
 
 #[test]
 fn test_prove_zero_arg_lambda2() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(10);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(let ((x 9) (f (lambda () (+ x 1)))) (f))",
         Some(expected),
         None,
@@ -1541,7 +1539,7 @@ fn test_prove_zero_arg_lambda2() {
 
 #[test]
 fn test_prove_zero_arg_lambda3() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = {
         let args = s.list(vec![s.intern_user_symbol("x")]);
         let num = s.num_u64(123);
@@ -1550,7 +1548,7 @@ fn test_prove_zero_arg_lambda3() {
     };
     let terminal = s.cont_terminal();
     nova_test_full_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "((lambda (x) 123))",
         Some(expected),
         None,
@@ -1566,10 +1564,10 @@ fn test_prove_zero_arg_lambda3() {
 
 #[test]
 fn test_prove_zero_arg_lambda4() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "((lambda () 123) 1)",
         None,
         None,
@@ -1582,7 +1580,7 @@ fn test_prove_zero_arg_lambda4() {
 
 #[test]
 fn test_prove_nested_let_closure_regression() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let terminal = s.cont_terminal();
     let expected = s.num_u64(6);
     let expr = "(let ((data-function (lambda () 123))
@@ -1590,7 +1588,7 @@ fn test_prove_nested_let_closure_regression() {
                       (data (data-function)))
                   x)";
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(expected),
         None,
@@ -1604,11 +1602,11 @@ fn test_prove_nested_let_closure_regression() {
 #[test]
 #[ignore]
 fn test_prove_minimal_tail_call() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(letrec
                ((f (lambda (x)
                      (if (= x 3)
@@ -1627,11 +1625,11 @@ fn test_prove_minimal_tail_call() {
 #[test]
 #[ignore]
 fn test_prove_cons_in_function1() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(2);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(((lambda (a)
                 (lambda (b)
                   (car (cons a b))))
@@ -1649,11 +1647,11 @@ fn test_prove_cons_in_function1() {
 #[test]
 #[ignore]
 fn test_prove_cons_in_function2() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(3);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(((lambda (a)
                 (lambda (b)
                   (cdr (cons a b))))
@@ -1671,11 +1669,11 @@ fn test_prove_cons_in_function2() {
 #[test]
 #[ignore]
 fn test_prove_multiarg_eval_bug() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(2);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(car (cdr '(1 2 3 4)))",
         Some(expected),
         None,
@@ -1689,11 +1687,11 @@ fn test_prove_multiarg_eval_bug() {
 #[test]
 #[ignore]
 fn test_prove_multiple_letrec_bindings() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(letrec
                ((x 888)
                 (f (lambda (x)
@@ -1713,11 +1711,11 @@ fn test_prove_multiple_letrec_bindings() {
 #[test]
 #[ignore]
 fn test_prove_tail_call2() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(letrec
                ((f (lambda (x)
                      (if (= x 5)
@@ -1737,11 +1735,11 @@ fn test_prove_tail_call2() {
 #[test]
 #[ignore]
 fn test_prove_multiple_letrecstar_bindings() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(13);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(letrec ((double (lambda (x) (* 2 x)))
                        (square (lambda (x) (* x x))))
                       (+ (square 3) (double 2)))",
@@ -1757,11 +1755,11 @@ fn test_prove_multiple_letrecstar_bindings() {
 #[test]
 #[ignore]
 fn test_prove_multiple_letrecstar_bindings_referencing() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(11);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(letrec ((double (lambda (x) (* 2 x)))
                        (double-inc (lambda (x) (+ 1 (double x)))))
                       (+ (double 3) (double-inc 2)))",
@@ -1777,11 +1775,11 @@ fn test_prove_multiple_letrecstar_bindings_referencing() {
 #[test]
 #[ignore]
 fn test_prove_multiple_letrecstar_bindings_recursive() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(33);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(letrec ((exp (lambda (base exponent)
                               (if (= 0 exponent)
                                   1
@@ -1808,11 +1806,11 @@ fn test_prove_multiple_letrecstar_bindings_recursive() {
 #[test]
 #[ignore]
 fn test_prove_dont_discard_rest_env() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(18);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(let ((z 9))
                (letrec ((a 1)
                          (b 2)
@@ -1830,11 +1828,11 @@ fn test_prove_dont_discard_rest_env() {
 #[test]
 #[ignore]
 fn test_prove_fibonacci() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(1);
     let terminal = s.cont_terminal();
     nova_test_full_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(letrec ((next (lambda (a b n target)
                  (if (eq n target)
                      a
@@ -1861,11 +1859,11 @@ fn test_prove_fibonacci() {
 #[test]
 #[ignore]
 fn test_one_folding() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(4);
     let terminal = s.cont_terminal();
     nova_test_full_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(+ 1 (+ 1 (+ 1 1)))",
         Some(expected),
         None,
@@ -1881,10 +1879,10 @@ fn test_one_folding() {
 
 #[test]
 fn test_prove_terminal_continuation_regression() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(letrec ((a (lambda (x) (cons 2 2))))
            (a 1))",
         None,
@@ -1899,10 +1897,10 @@ fn test_prove_terminal_continuation_regression() {
 #[test]
 #[ignore]
 fn test_prove_chained_functional_commitment() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(letrec ((secret 12345)
                   (a (lambda (acc x)
                        (let ((acc (+ acc x)))
@@ -1919,11 +1917,11 @@ fn test_prove_chained_functional_commitment() {
 
 #[test]
 fn test_prove_begin_empty() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.intern_nil();
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(begin)",
         Some(expected),
         None,
@@ -1936,12 +1934,12 @@ fn test_prove_begin_empty() {
 
 #[test]
 fn test_prove_begin_emit() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(begin (emit 1) (emit 2) (emit 3))";
     let expected_expr = s.num_u64(3);
     let expected_emitted = vec![s.num_u64(1), s.num_u64(2), s.num_u64(3)];
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(expected_expr),
         None,
@@ -1954,11 +1952,11 @@ fn test_prove_begin_emit() {
 
 #[test]
 fn test_prove_str_car() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected_a = s.read_with_default_state(r"#\a").unwrap();
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r#"(car "apple")"#,
         Some(expected_a),
         None,
@@ -1971,11 +1969,11 @@ fn test_prove_str_car() {
 
 #[test]
 fn test_prove_str_cdr() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected_pple = s.read_with_default_state(r#" "pple" "#).unwrap();
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r#"(cdr "apple")"#,
         Some(expected_pple),
         None,
@@ -1988,11 +1986,11 @@ fn test_prove_str_cdr() {
 
 #[test]
 fn test_prove_str_car_empty() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected_nil = s.intern_nil();
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r#"(car "")"#,
         Some(expected_nil),
         None,
@@ -2005,11 +2003,11 @@ fn test_prove_str_car_empty() {
 
 #[test]
 fn test_prove_str_cdr_empty() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected_empty_str = s.intern_string("");
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r#"(cdr "")"#,
         Some(expected_empty_str),
         None,
@@ -2022,11 +2020,11 @@ fn test_prove_str_cdr_empty() {
 
 #[test]
 fn test_prove_strcons() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected_apple = s.read_with_default_state(r#" "apple" "#).unwrap();
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r#"(strcons #\a "pple")"#,
         Some(expected_apple),
         None,
@@ -2039,10 +2037,10 @@ fn test_prove_strcons() {
 
 #[test]
 fn test_prove_str_cons_error() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r"(strcons #\a 123)",
         None,
         None,
@@ -2055,10 +2053,10 @@ fn test_prove_str_cons_error() {
 
 #[test]
 fn test_prove_one_arg_cons_error() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r#"(cons "")"#,
         None,
         None,
@@ -2071,11 +2069,11 @@ fn test_prove_one_arg_cons_error() {
 
 #[test]
 fn test_prove_car_nil() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.intern_nil();
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r#"(car nil)"#,
         Some(expected),
         None,
@@ -2088,11 +2086,11 @@ fn test_prove_car_nil() {
 
 #[test]
 fn test_prove_cdr_nil() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.intern_nil();
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r#"(cdr nil)"#,
         Some(expected),
         None,
@@ -2105,10 +2103,10 @@ fn test_prove_cdr_nil() {
 
 #[test]
 fn test_prove_car_cdr_invalid_tag_error_sym() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r#"(car car)"#,
         None,
         None,
@@ -2118,7 +2116,7 @@ fn test_prove_car_cdr_invalid_tag_error_sym() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r#"(cdr car)"#,
         None,
         None,
@@ -2131,10 +2129,10 @@ fn test_prove_car_cdr_invalid_tag_error_sym() {
 
 #[test]
 fn test_prove_car_cdr_invalid_tag_error_char() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r"(car #\a)",
         None,
         None,
@@ -2144,7 +2142,7 @@ fn test_prove_car_cdr_invalid_tag_error_char() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r"(cdr #\a)",
         None,
         None,
@@ -2157,10 +2155,10 @@ fn test_prove_car_cdr_invalid_tag_error_char() {
 
 #[test]
 fn test_prove_car_cdr_invalid_tag_error_num() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r#"(car 42)"#,
         None,
         None,
@@ -2170,7 +2168,7 @@ fn test_prove_car_cdr_invalid_tag_error_num() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r#"(cdr 42)"#,
         None,
         None,
@@ -2183,12 +2181,12 @@ fn test_prove_car_cdr_invalid_tag_error_num() {
 
 #[test]
 fn test_prove_car_cdr_of_cons() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let res1 = s.num_u64(1);
     let res2 = s.num_u64(2);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r#"(car (cons 1 2))"#,
         Some(res1),
         None,
@@ -2198,7 +2196,7 @@ fn test_prove_car_cdr_of_cons() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r#"(cdr (cons 1 2))"#,
         Some(res2),
         None,
@@ -2211,10 +2209,10 @@ fn test_prove_car_cdr_of_cons() {
 
 #[test]
 fn test_prove_car_cdr_invalid_tag_error_lambda() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let error = s.cont_error();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r#"(car (lambda (x) x))"#,
         None,
         None,
@@ -2224,7 +2222,7 @@ fn test_prove_car_cdr_invalid_tag_error_lambda() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r#"(cdr (lambda (x) x))"#,
         None,
         None,
@@ -2237,12 +2235,12 @@ fn test_prove_car_cdr_invalid_tag_error_lambda() {
 
 #[test]
 fn test_prove_hide_open() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(open (hide 123 456))";
     let expected = s.num_u64(456);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(expected),
         None,
@@ -2255,20 +2253,29 @@ fn test_prove_hide_open() {
 
 #[test]
 fn test_prove_hide_wrong_secret_type() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(hide 'x 456)";
     let error = s.cont_error();
-    test_aux::<_, Coproc<_>>(s, expr, None, None, Some(error), None, &expect!["3"], &None);
+    test_aux::<_, Coproc<_>>(
+        &s,
+        expr,
+        None,
+        None,
+        Some(error),
+        None,
+        &expect!["3"],
+        &None,
+    );
 }
 
 #[test]
 fn test_prove_hide_secret() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(secret (hide 123 456))";
     let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(expected),
         None,
@@ -2281,12 +2288,12 @@ fn test_prove_hide_secret() {
 
 #[test]
 fn test_prove_hide_open_sym() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(open (hide 123 'x))";
     let x = s.intern_user_symbol("x");
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(x),
         None,
@@ -2299,12 +2306,12 @@ fn test_prove_hide_open_sym() {
 
 #[test]
 fn test_prove_commit_open_sym() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(open (commit 'x))";
     let x = s.intern_user_symbol("x");
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(x),
         None,
@@ -2317,12 +2324,12 @@ fn test_prove_commit_open_sym() {
 
 #[test]
 fn test_prove_commit_open() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(open (commit 123))";
     let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(expected),
         None,
@@ -2335,44 +2342,80 @@ fn test_prove_commit_open() {
 
 #[test]
 fn test_prove_commit_error() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(commit 123 456)";
     let error = s.cont_error();
-    test_aux::<_, Coproc<_>>(s, expr, None, None, Some(error), None, &expect!["1"], &None);
+    test_aux::<_, Coproc<_>>(
+        &s,
+        expr,
+        None,
+        None,
+        Some(error),
+        None,
+        &expect!["1"],
+        &None,
+    );
 }
 
 #[test]
 fn test_prove_open_error() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(open 123 456)";
     let error = s.cont_error();
-    test_aux::<_, Coproc<_>>(s, expr, None, None, Some(error), None, &expect!["1"], &None);
+    test_aux::<_, Coproc<_>>(
+        &s,
+        expr,
+        None,
+        None,
+        Some(error),
+        None,
+        &expect!["1"],
+        &None,
+    );
 }
 
 #[test]
 fn test_prove_open_wrong_type() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(open 'asdf)";
     let error = s.cont_error();
-    test_aux::<_, Coproc<_>>(s, expr, None, None, Some(error), None, &expect!["2"], &None);
+    test_aux::<_, Coproc<_>>(
+        &s,
+        expr,
+        None,
+        None,
+        Some(error),
+        None,
+        &expect!["2"],
+        &None,
+    );
 }
 
 #[test]
 fn test_prove_secret_wrong_type() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(secret 'asdf)";
     let error = s.cont_error();
-    test_aux::<_, Coproc<_>>(s, expr, None, None, Some(error), None, &expect!["2"], &None);
+    test_aux::<_, Coproc<_>>(
+        &s,
+        expr,
+        None,
+        None,
+        Some(error),
+        None,
+        &expect!["2"],
+        &None,
+    );
 }
 
 #[test]
 fn test_prove_commit_secret() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(secret (commit 123))";
     let expected = s.num_u64(0);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(expected),
         None,
@@ -2385,12 +2428,12 @@ fn test_prove_commit_secret() {
 
 #[test]
 fn test_prove_num() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(num 123)";
     let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(expected),
         None,
@@ -2403,12 +2446,12 @@ fn test_prove_num() {
 
 #[test]
 fn test_prove_num_char() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = r"(num #\a)";
     let expected = s.num_u64(97);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(expected),
         None,
@@ -2421,12 +2464,12 @@ fn test_prove_num_char() {
 
 #[test]
 fn test_prove_char_num() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = r#"(char 97)"#;
     let expected_a = s.read_with_default_state(r"#\a").unwrap();
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(expected_a),
         None,
@@ -2439,14 +2482,14 @@ fn test_prove_char_num() {
 
 #[test]
 fn test_prove_char_coercion() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = r#"(char (+ 4294967296 97))"#;
     let expr2 = r#"(char (+ 4294967296 98))"#;
     let expected_a = s.read_with_default_state(r"#\a").unwrap();
     let expected_b = s.read_with_default_state(r"#\b").unwrap();
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<Fr>>(
-        s,
+        &s,
         expr,
         Some(expected_a),
         None,
@@ -2456,7 +2499,7 @@ fn test_prove_char_coercion() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr2,
         Some(expected_b),
         None,
@@ -2469,11 +2512,11 @@ fn test_prove_char_coercion() {
 
 #[test]
 fn test_prove_commit_num() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(num (commit 123))";
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         None,
         None,
@@ -2486,12 +2529,12 @@ fn test_prove_commit_num() {
 
 #[test]
 fn test_prove_hide_open_comm_num() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(open (comm (num (hide 123 456))))";
     let expected = s.num_u64(456);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(expected),
         None,
@@ -2504,12 +2547,12 @@ fn test_prove_hide_open_comm_num() {
 
 #[test]
 fn test_prove_hide_secret_comm_num() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(secret (comm (num (hide 123 456))))";
     let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(expected),
         None,
@@ -2522,12 +2565,12 @@ fn test_prove_hide_secret_comm_num() {
 
 #[test]
 fn test_prove_commit_open_comm_num() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(open (comm (num (commit 123))))";
     let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(expected),
         None,
@@ -2540,12 +2583,12 @@ fn test_prove_commit_open_comm_num() {
 
 #[test]
 fn test_prove_commit_secret_comm_num() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(secret (comm (num (commit 123))))";
     let expected = s.num_u64(0);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(expected),
         None,
@@ -2558,12 +2601,12 @@ fn test_prove_commit_secret_comm_num() {
 
 #[test]
 fn test_prove_commit_num_open() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(open (num (commit 123)))";
     let expected = s.num_u64(123);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(expected),
         None,
@@ -2576,14 +2619,23 @@ fn test_prove_commit_num_open() {
 
 #[test]
 fn test_prove_num_invalid_tag() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(num (quote x))";
     let expr1 = "(num \"asdf\")";
     let expr2 = "(num '(1))";
     let error = s.cont_error();
-    test_aux::<_, Coproc<_>>(s, expr, None, None, Some(error), None, &expect!["2"], &None);
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
+        expr,
+        None,
+        None,
+        Some(error),
+        None,
+        &expect!["2"],
+        &None,
+    );
+    test_aux::<_, Coproc<_>>(
+        &s,
         expr1,
         None,
         None,
@@ -2593,7 +2645,7 @@ fn test_prove_num_invalid_tag() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr2,
         None,
         None,
@@ -2606,14 +2658,23 @@ fn test_prove_num_invalid_tag() {
 
 #[test]
 fn test_prove_comm_invalid_tag() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(comm (quote x))";
     let expr1 = "(comm \"asdf\")";
     let expr2 = "(comm '(1))";
     let error = s.cont_error();
-    test_aux::<_, Coproc<_>>(s, expr, None, None, Some(error), None, &expect!["2"], &None);
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
+        expr,
+        None,
+        None,
+        Some(error),
+        None,
+        &expect!["2"],
+        &None,
+    );
+    test_aux::<_, Coproc<_>>(
+        &s,
         expr1,
         None,
         None,
@@ -2623,7 +2684,7 @@ fn test_prove_comm_invalid_tag() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr2,
         None,
         None,
@@ -2636,14 +2697,23 @@ fn test_prove_comm_invalid_tag() {
 
 #[test]
 fn test_prove_char_invalid_tag() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(char (quote x))";
     let expr1 = "(char \"asdf\")";
     let expr2 = "(char '(1))";
     let error = s.cont_error();
-    test_aux::<_, Coproc<_>>(s, expr, None, None, Some(error), None, &expect!["2"], &None);
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
+        expr,
+        None,
+        None,
+        Some(error),
+        None,
+        &expect!["2"],
+        &None,
+    );
+    test_aux::<_, Coproc<_>>(
+        &s,
         expr1,
         None,
         None,
@@ -2653,7 +2723,7 @@ fn test_prove_char_invalid_tag() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr2,
         None,
         None,
@@ -2666,12 +2736,12 @@ fn test_prove_char_invalid_tag() {
 
 #[test]
 fn test_prove_terminal_sym() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(quote x)";
     let x = s.intern_user_symbol("x");
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(x),
         None,
@@ -2685,30 +2755,30 @@ fn test_prove_terminal_sym() {
 #[test]
 #[should_panic]
 fn test_prove_open_opaque_commit() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(open 123)";
-    test_aux::<_, Coproc<_>>(s, expr, None, None, None, None, &expect!["2"], &None);
+    test_aux::<_, Coproc<_>>(&s, expr, None, None, None, None, &expect!["2"], &None);
 }
 
 #[test]
 #[should_panic]
 fn test_prove_secret_invalid_tag() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(secret 123)";
-    test_aux::<_, Coproc<_>>(s, expr, None, None, None, None, &expect!["2"], &None);
+    test_aux::<_, Coproc<_>>(&s, expr, None, None, None, None, &expect!["2"], &None);
 }
 
 #[test]
 #[should_panic]
 fn test_prove_secret_opaque_commit() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(secret (comm 123))";
-    test_aux::<_, Coproc<_>>(s, expr, None, None, None, None, &expect!["2"], &None);
+    test_aux::<_, Coproc<_>>(&s, expr, None, None, None, None, &expect!["2"], &None);
 }
 
 #[test]
 fn test_str_car_cdr_cons() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let a = s.read_with_default_state(r"#\a").unwrap();
     let apple = s.read_with_default_state(r#" "apple" "#).unwrap();
     let a_pple = s.read_with_default_state(r#" (#\a . "pple") "#).unwrap();
@@ -2719,7 +2789,7 @@ fn test_str_car_cdr_cons() {
     let error = s.cont_error();
 
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r#"(car "apple")"#,
         Some(a),
         None,
@@ -2729,7 +2799,7 @@ fn test_str_car_cdr_cons() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r#"(cdr "apple")"#,
         Some(pple),
         None,
@@ -2739,7 +2809,7 @@ fn test_str_car_cdr_cons() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r#"(car "")"#,
         Some(nil),
         None,
@@ -2749,7 +2819,7 @@ fn test_str_car_cdr_cons() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r#"(cdr "")"#,
         Some(empty),
         None,
@@ -2759,7 +2829,7 @@ fn test_str_car_cdr_cons() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r#"(cons #\a "pple")"#,
         Some(a_pple),
         None,
@@ -2770,7 +2840,7 @@ fn test_str_car_cdr_cons() {
     );
 
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r#"(strcons #\a "pple")"#,
         Some(apple),
         None,
@@ -2781,7 +2851,7 @@ fn test_str_car_cdr_cons() {
     );
 
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r"(strcons #\a #\b)",
         None,
         None,
@@ -2792,7 +2862,7 @@ fn test_str_car_cdr_cons() {
     );
 
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r#"(strcons "a" "b")"#,
         None,
         None,
@@ -2803,7 +2873,7 @@ fn test_str_car_cdr_cons() {
     );
 
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         r#"(strcons 1 2)"#,
         None,
         None,
@@ -2814,7 +2884,7 @@ fn test_str_car_cdr_cons() {
     );
 }
 
-fn relational_aux(s: &Store<Fr>, op: &str, a: &str, b: &str, res: bool) {
+fn relational_aux(s: &Arc<Store<Fr>>, op: &str, a: &str, b: &str, res: bool) {
     let expr = &format!("({op} {a} {b})");
     let expected = if res {
         s.intern_lurk_symbol("t")
@@ -2838,7 +2908,7 @@ fn relational_aux(s: &Store<Fr>, op: &str, a: &str, b: &str, res: bool) {
 #[ignore]
 #[test]
 fn test_prove_test_relational() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let lt = "<";
     let gt = ">";
     let lte = "<=";
@@ -2851,105 +2921,105 @@ fn test_prove_test_relational() {
     let most_positive = &format!("{}", Num::<Fr>::most_positive());
     let neg_one = &format!("{}", Num::<Fr>::Scalar(Fr::zero() - Fr::one()));
 
-    relational_aux(s, lt, one, two, true);
-    relational_aux(s, gt, one, two, false);
-    relational_aux(s, lte, one, two, true);
-    relational_aux(s, gte, one, two, false);
+    relational_aux(&s, lt, one, two, true);
+    relational_aux(&s, gt, one, two, false);
+    relational_aux(&s, lte, one, two, true);
+    relational_aux(&s, gte, one, two, false);
 
-    relational_aux(s, lt, two, one, false);
-    relational_aux(s, gt, two, one, true);
-    relational_aux(s, lte, two, one, false);
-    relational_aux(s, gte, two, one, true);
+    relational_aux(&s, lt, two, one, false);
+    relational_aux(&s, gt, two, one, true);
+    relational_aux(&s, lte, two, one, false);
+    relational_aux(&s, gte, two, one, true);
 
-    relational_aux(s, lt, one, one, false);
-    relational_aux(s, gt, one, one, false);
-    relational_aux(s, lte, one, one, true);
-    relational_aux(s, gte, one, one, true);
+    relational_aux(&s, lt, one, one, false);
+    relational_aux(&s, gt, one, one, false);
+    relational_aux(&s, lte, one, one, true);
+    relational_aux(&s, gte, one, one, true);
 
-    relational_aux(s, lt, zero, two, true);
-    relational_aux(s, gt, zero, two, false);
-    relational_aux(s, lte, zero, two, true);
-    relational_aux(s, gte, zero, two, false);
+    relational_aux(&s, lt, zero, two, true);
+    relational_aux(&s, gt, zero, two, false);
+    relational_aux(&s, lte, zero, two, true);
+    relational_aux(&s, gte, zero, two, false);
 
-    relational_aux(s, lt, two, zero, false);
-    relational_aux(s, gt, two, zero, true);
-    relational_aux(s, lte, two, zero, false);
-    relational_aux(s, gte, two, zero, true);
+    relational_aux(&s, lt, two, zero, false);
+    relational_aux(&s, gt, two, zero, true);
+    relational_aux(&s, lte, two, zero, false);
+    relational_aux(&s, gte, two, zero, true);
 
-    relational_aux(s, lt, zero, zero, false);
-    relational_aux(s, gt, zero, zero, false);
-    relational_aux(s, lte, zero, zero, true);
-    relational_aux(s, gte, zero, zero, true);
+    relational_aux(&s, lt, zero, zero, false);
+    relational_aux(&s, gt, zero, zero, false);
+    relational_aux(&s, lte, zero, zero, true);
+    relational_aux(&s, gte, zero, zero, true);
 
-    relational_aux(s, lt, most_negative, zero, true);
-    relational_aux(s, gt, most_negative, zero, false);
-    relational_aux(s, lte, most_negative, zero, true);
-    relational_aux(s, gte, most_negative, zero, false);
+    relational_aux(&s, lt, most_negative, zero, true);
+    relational_aux(&s, gt, most_negative, zero, false);
+    relational_aux(&s, lte, most_negative, zero, true);
+    relational_aux(&s, gte, most_negative, zero, false);
 
-    relational_aux(s, lt, zero, most_negative, false);
-    relational_aux(s, gt, zero, most_negative, true);
-    relational_aux(s, lte, zero, most_negative, false);
-    relational_aux(s, gte, zero, most_negative, true);
+    relational_aux(&s, lt, zero, most_negative, false);
+    relational_aux(&s, gt, zero, most_negative, true);
+    relational_aux(&s, lte, zero, most_negative, false);
+    relational_aux(&s, gte, zero, most_negative, true);
 
-    relational_aux(s, lt, most_negative, most_positive, true);
-    relational_aux(s, gt, most_negative, most_positive, false);
-    relational_aux(s, lte, most_negative, most_positive, true);
-    relational_aux(s, gte, most_negative, most_positive, false);
+    relational_aux(&s, lt, most_negative, most_positive, true);
+    relational_aux(&s, gt, most_negative, most_positive, false);
+    relational_aux(&s, lte, most_negative, most_positive, true);
+    relational_aux(&s, gte, most_negative, most_positive, false);
 
-    relational_aux(s, lt, most_positive, most_negative, false);
-    relational_aux(s, gt, most_positive, most_negative, true);
-    relational_aux(s, lte, most_positive, most_negative, false);
-    relational_aux(s, gte, most_positive, most_negative, true);
+    relational_aux(&s, lt, most_positive, most_negative, false);
+    relational_aux(&s, gt, most_positive, most_negative, true);
+    relational_aux(&s, lte, most_positive, most_negative, false);
+    relational_aux(&s, gte, most_positive, most_negative, true);
 
-    relational_aux(s, lt, most_negative, most_negative, false);
-    relational_aux(s, gt, most_negative, most_negative, false);
-    relational_aux(s, lte, most_negative, most_negative, true);
-    relational_aux(s, gte, most_negative, most_negative, true);
+    relational_aux(&s, lt, most_negative, most_negative, false);
+    relational_aux(&s, gt, most_negative, most_negative, false);
+    relational_aux(&s, lte, most_negative, most_negative, true);
+    relational_aux(&s, gte, most_negative, most_negative, true);
 
-    relational_aux(s, lt, one, most_positive, true);
-    relational_aux(s, gt, one, most_positive, false);
-    relational_aux(s, lte, one, most_positive, true);
-    relational_aux(s, gte, one, most_positive, false);
+    relational_aux(&s, lt, one, most_positive, true);
+    relational_aux(&s, gt, one, most_positive, false);
+    relational_aux(&s, lte, one, most_positive, true);
+    relational_aux(&s, gte, one, most_positive, false);
 
-    relational_aux(s, lt, most_positive, one, false);
-    relational_aux(s, gt, most_positive, one, true);
-    relational_aux(s, lte, most_positive, one, false);
-    relational_aux(s, gte, most_positive, one, true);
+    relational_aux(&s, lt, most_positive, one, false);
+    relational_aux(&s, gt, most_positive, one, true);
+    relational_aux(&s, lte, most_positive, one, false);
+    relational_aux(&s, gte, most_positive, one, true);
 
-    relational_aux(s, lt, one, most_negative, false);
-    relational_aux(s, gt, one, most_negative, true);
-    relational_aux(s, lte, one, most_negative, false);
-    relational_aux(s, gte, one, most_negative, true);
+    relational_aux(&s, lt, one, most_negative, false);
+    relational_aux(&s, gt, one, most_negative, true);
+    relational_aux(&s, lte, one, most_negative, false);
+    relational_aux(&s, gte, one, most_negative, true);
 
-    relational_aux(s, lt, most_negative, one, true);
-    relational_aux(s, gt, most_negative, one, false);
-    relational_aux(s, lte, most_negative, one, true);
-    relational_aux(s, gte, most_negative, one, false);
+    relational_aux(&s, lt, most_negative, one, true);
+    relational_aux(&s, gt, most_negative, one, false);
+    relational_aux(&s, lte, most_negative, one, true);
+    relational_aux(&s, gte, most_negative, one, false);
 
-    relational_aux(s, lt, neg_one, most_positive, true);
-    relational_aux(s, gt, neg_one, most_positive, false);
-    relational_aux(s, lte, neg_one, most_positive, true);
-    relational_aux(s, gte, neg_one, most_positive, false);
+    relational_aux(&s, lt, neg_one, most_positive, true);
+    relational_aux(&s, gt, neg_one, most_positive, false);
+    relational_aux(&s, lte, neg_one, most_positive, true);
+    relational_aux(&s, gte, neg_one, most_positive, false);
 
-    relational_aux(s, lt, most_positive, neg_one, false);
-    relational_aux(s, gt, most_positive, neg_one, true);
-    relational_aux(s, lte, most_positive, neg_one, false);
-    relational_aux(s, gte, most_positive, neg_one, true);
+    relational_aux(&s, lt, most_positive, neg_one, false);
+    relational_aux(&s, gt, most_positive, neg_one, true);
+    relational_aux(&s, lte, most_positive, neg_one, false);
+    relational_aux(&s, gte, most_positive, neg_one, true);
 
-    relational_aux(s, lt, neg_one, most_negative, false);
-    relational_aux(s, gt, neg_one, most_negative, true);
-    relational_aux(s, lte, neg_one, most_negative, false);
-    relational_aux(s, gte, neg_one, most_negative, true);
+    relational_aux(&s, lt, neg_one, most_negative, false);
+    relational_aux(&s, gt, neg_one, most_negative, true);
+    relational_aux(&s, lte, neg_one, most_negative, false);
+    relational_aux(&s, gte, neg_one, most_negative, true);
 
-    relational_aux(s, lt, most_negative, neg_one, true);
-    relational_aux(s, gt, most_negative, neg_one, false);
-    relational_aux(s, lte, most_negative, neg_one, true);
-    relational_aux(s, gte, most_negative, neg_one, false);
+    relational_aux(&s, lt, most_negative, neg_one, true);
+    relational_aux(&s, gt, most_negative, neg_one, false);
+    relational_aux(&s, lte, most_negative, neg_one, true);
+    relational_aux(&s, gte, most_negative, neg_one, false);
 }
 
 #[test]
 fn test_relational_edge_case_identity() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     // Normally, a value cannot be less than the result of incrementing it.
     // However, the most positive field element (when viewed as signed)
     // is the exception. Incrementing it yields the most negative element,
@@ -2961,7 +3031,7 @@ fn test_relational_edge_case_identity() {
     let terminal = s.cont_terminal();
 
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(t),
         None,
@@ -2974,7 +3044,7 @@ fn test_relational_edge_case_identity() {
 
 #[test]
 fn test_prove_test_eval() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(* 3 (eval  (cons '+ (cons 1 (cons 2 nil)))))";
     let expr2 = "(* 5 (eval '(+ 1 a) (let ((a 3)) (current-env))))"; // two-arg eval, optional second arg is env.
     let res = s.num_u64(9);
@@ -2982,7 +3052,7 @@ fn test_prove_test_eval() {
     let terminal = s.cont_terminal();
 
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(res),
         None,
@@ -2992,7 +3062,7 @@ fn test_prove_test_eval() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr2,
         Some(res2),
         None,
@@ -3005,7 +3075,7 @@ fn test_prove_test_eval() {
 
 #[test]
 fn test_prove_test_keyword() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
 
     let expr = ":asdf";
     let expr2 = "(eq :asdf :asdf)";
@@ -3017,7 +3087,7 @@ fn test_prove_test_keyword() {
     let terminal = s.cont_terminal();
 
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(res),
         None,
@@ -3027,7 +3097,7 @@ fn test_prove_test_keyword() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr2,
         Some(res2),
         None,
@@ -3037,7 +3107,7 @@ fn test_prove_test_keyword() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr3,
         Some(res3),
         None,
@@ -3053,7 +3123,7 @@ fn test_prove_test_keyword() {
 
 #[test]
 fn test_prove_functional_commitment() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
 
     let expr = "(let ((f (commit (let ((num 9)) (lambda (f) (f num)))))
                       (inc (lambda (x) (+ x 1))))
@@ -3062,7 +3132,7 @@ fn test_prove_functional_commitment() {
     let terminal = s.cont_terminal();
 
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(res),
         None,
@@ -3076,7 +3146,7 @@ fn test_prove_functional_commitment() {
 #[test]
 #[ignore]
 fn test_prove_complicated_functional_commitment() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
 
     let expr = "(let ((f (commit (let ((nums '(1 2 3))) (lambda (f) (f nums)))))
                       (in (letrec ((sum-aux (lambda (acc nums)
@@ -3092,7 +3162,7 @@ fn test_prove_complicated_functional_commitment() {
     let terminal = s.cont_terminal();
 
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(res),
         None,
@@ -3105,7 +3175,7 @@ fn test_prove_complicated_functional_commitment() {
 
 #[test]
 fn test_prove_test_fold_cons_regression() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(letrec ((fold (lambda (op acc l)
                                  (if l
                                      (fold op (op acc (car l)) (cdr l))
@@ -3115,7 +3185,7 @@ fn test_prove_test_fold_cons_regression() {
     let terminal = s.cont_terminal();
 
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(res),
         None,
@@ -3128,13 +3198,13 @@ fn test_prove_test_fold_cons_regression() {
 
 #[test]
 fn test_prove_test_lambda_args_regression() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
 
     let expr = "(cons (lambda (x y) nil) nil)";
     let terminal = s.cont_terminal();
 
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         None,
         None,
@@ -3147,17 +3217,26 @@ fn test_prove_test_lambda_args_regression() {
 
 #[test]
 fn test_prove_reduce_sym_contradiction_regression() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
 
     let expr = "(eval 'a '(nil))";
     let error = s.cont_error();
 
-    test_aux::<_, Coproc<_>>(s, expr, None, None, Some(error), None, &expect!["3"], &None);
+    test_aux::<_, Coproc<_>>(
+        &s,
+        expr,
+        None,
+        None,
+        Some(error),
+        None,
+        &expect!["3"],
+        &None,
+    );
 }
 
 #[test]
 fn test_prove_test_self_eval_env_not_nil() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
 
     // NOTE: cond1 shouldn't depend on env-is-not-nil
     // therefore this unit test is not very useful
@@ -3168,7 +3247,7 @@ fn test_prove_test_self_eval_env_not_nil() {
 
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         None,
         None,
@@ -3181,14 +3260,14 @@ fn test_prove_test_self_eval_env_not_nil() {
 
 #[test]
 fn test_prove_test_self_eval_nil() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
 
     // nil doesn't have SYM tag
     let expr = "nil";
 
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         None,
         None,
@@ -3201,26 +3280,44 @@ fn test_prove_test_self_eval_nil() {
 
 #[test]
 fn test_prove_test_env_not_nil_and_binding_nil() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
 
     let expr = "(let ((a 1) (b 2)) c)";
 
     let error = s.cont_error();
-    test_aux::<_, Coproc<_>>(s, expr, None, None, Some(error), None, &expect!["5"], &None);
+    test_aux::<_, Coproc<_>>(
+        &s,
+        expr,
+        None,
+        None,
+        Some(error),
+        None,
+        &expect!["5"],
+        &None,
+    );
 }
 
 #[test]
 fn test_prove_test_eval_bad_form() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(* 5 (eval '(+ 1 a) '((0 . 3))))"; // two-arg eval, optional second arg is env. This tests for error on malformed env.
     let error = s.cont_error();
 
-    test_aux::<_, Coproc<_>>(s, expr, None, None, Some(error), None, &expect!["5"], &None);
+    test_aux::<_, Coproc<_>>(
+        &s,
+        expr,
+        None,
+        None,
+        Some(error),
+        None,
+        &expect!["5"],
+        &None,
+    );
 }
 
 #[test]
 fn test_prove_test_u64_mul() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
 
     let expr = "(* (u64 18446744073709551615) (u64 2))";
     let expr2 = "(* 18446744073709551615u64 2u64)";
@@ -3231,7 +3328,7 @@ fn test_prove_test_u64_mul() {
     let terminal = s.cont_terminal();
 
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(res),
         None,
@@ -3241,7 +3338,7 @@ fn test_prove_test_u64_mul() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr2,
         Some(res),
         None,
@@ -3251,7 +3348,7 @@ fn test_prove_test_u64_mul() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr3,
         Some(res),
         None,
@@ -3261,7 +3358,7 @@ fn test_prove_test_u64_mul() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr4,
         Some(res2),
         None,
@@ -3274,7 +3371,7 @@ fn test_prove_test_u64_mul() {
 
 #[test]
 fn test_prove_test_u64_add() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
 
     let expr = "(+ 18446744073709551615u64 2u64)";
     let expr2 = "(+ (- 0u64 1u64) 2u64)";
@@ -3282,7 +3379,7 @@ fn test_prove_test_u64_add() {
     let terminal = s.cont_terminal();
 
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(res),
         None,
@@ -3292,7 +3389,7 @@ fn test_prove_test_u64_add() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr2,
         Some(res),
         None,
@@ -3305,7 +3402,7 @@ fn test_prove_test_u64_add() {
 
 #[test]
 fn test_prove_test_u64_sub() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
 
     let expr = "(- 2u64 1u64)";
     let expr2 = "(- 0u64 1u64)";
@@ -3316,7 +3413,7 @@ fn test_prove_test_u64_sub() {
     let terminal = s.cont_terminal();
 
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(res),
         None,
@@ -3326,7 +3423,7 @@ fn test_prove_test_u64_sub() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr2,
         Some(res2),
         None,
@@ -3336,7 +3433,7 @@ fn test_prove_test_u64_sub() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr3,
         Some(res3),
         None,
@@ -3349,7 +3446,7 @@ fn test_prove_test_u64_sub() {
 
 #[test]
 fn test_prove_test_u64_div() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
 
     let expr = "(/ 100u64 2u64)";
     let res = s.u64(50);
@@ -3363,7 +3460,7 @@ fn test_prove_test_u64_div() {
     let error = s.cont_error();
 
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(res),
         None,
@@ -3373,7 +3470,7 @@ fn test_prove_test_u64_div() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr2,
         Some(res2),
         None,
@@ -3383,7 +3480,7 @@ fn test_prove_test_u64_div() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr3,
         None,
         None,
@@ -3396,7 +3493,7 @@ fn test_prove_test_u64_div() {
 
 #[test]
 fn test_prove_test_u64_mod() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
 
     let expr = "(% 100u64 2u64)";
     let res = s.u64(0);
@@ -3410,7 +3507,7 @@ fn test_prove_test_u64_mod() {
     let error = s.cont_error();
 
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(res),
         None,
@@ -3420,7 +3517,7 @@ fn test_prove_test_u64_mod() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr2,
         Some(res2),
         None,
@@ -3430,7 +3527,7 @@ fn test_prove_test_u64_mod() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr3,
         None,
         None,
@@ -3443,7 +3540,7 @@ fn test_prove_test_u64_mod() {
 
 #[test]
 fn test_prove_test_num_mod() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
 
     let expr = "(% 100 3)";
     let expr2 = "(% 100 3u64)";
@@ -3451,9 +3548,18 @@ fn test_prove_test_num_mod() {
 
     let error = s.cont_error();
 
-    test_aux::<_, Coproc<_>>(s, expr, None, None, Some(error), None, &expect!["3"], &None);
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
+        expr,
+        None,
+        None,
+        Some(error),
+        None,
+        &expect!["3"],
+        &None,
+    );
+    test_aux::<_, Coproc<_>>(
+        &s,
         expr2,
         None,
         None,
@@ -3463,7 +3569,7 @@ fn test_prove_test_num_mod() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr3,
         None,
         None,
@@ -3476,7 +3582,7 @@ fn test_prove_test_num_mod() {
 
 #[test]
 fn test_prove_test_u64_comp() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
 
     let expr = "(< 0u64 1u64)";
     let expr2 = "(< 1u64 0u64)";
@@ -3496,7 +3602,7 @@ fn test_prove_test_u64_comp() {
     let terminal = s.cont_terminal();
 
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(t),
         None,
@@ -3506,7 +3612,7 @@ fn test_prove_test_u64_comp() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr2,
         Some(nil),
         None,
@@ -3516,7 +3622,7 @@ fn test_prove_test_u64_comp() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr3,
         Some(t),
         None,
@@ -3526,7 +3632,7 @@ fn test_prove_test_u64_comp() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr4,
         Some(nil),
         None,
@@ -3537,7 +3643,7 @@ fn test_prove_test_u64_comp() {
     );
 
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr5,
         Some(nil),
         None,
@@ -3547,7 +3653,7 @@ fn test_prove_test_u64_comp() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr6,
         Some(t),
         None,
@@ -3557,7 +3663,7 @@ fn test_prove_test_u64_comp() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr7,
         Some(nil),
         None,
@@ -3567,7 +3673,7 @@ fn test_prove_test_u64_comp() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr8,
         Some(t),
         None,
@@ -3578,7 +3684,7 @@ fn test_prove_test_u64_comp() {
     );
 
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr9,
         Some(t),
         None,
@@ -3588,7 +3694,7 @@ fn test_prove_test_u64_comp() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr10,
         Some(t),
         None,
@@ -3601,7 +3707,7 @@ fn test_prove_test_u64_comp() {
 
 #[test]
 fn test_prove_test_u64_conversion() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
 
     let expr = "(+ 0 1u64)";
     let expr2 = "(num 1u64)";
@@ -3613,7 +3719,7 @@ fn test_prove_test_u64_conversion() {
     let terminal = s.cont_terminal();
 
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(res),
         None,
@@ -3623,7 +3729,7 @@ fn test_prove_test_u64_conversion() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr2,
         Some(res),
         None,
@@ -3633,7 +3739,7 @@ fn test_prove_test_u64_conversion() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr3,
         Some(res2),
         None,
@@ -3643,7 +3749,7 @@ fn test_prove_test_u64_conversion() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr4,
         Some(res3),
         None,
@@ -3656,7 +3762,7 @@ fn test_prove_test_u64_conversion() {
 
 #[test]
 fn test_prove_test_u64_num_comparison() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
 
     let expr = "(= 1 1u64)";
     let expr2 = "(= 1 2u64)";
@@ -3665,7 +3771,7 @@ fn test_prove_test_u64_num_comparison() {
     let terminal = s.cont_terminal();
 
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(t),
         None,
@@ -3675,7 +3781,7 @@ fn test_prove_test_u64_num_comparison() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr2,
         Some(nil),
         None,
@@ -3688,7 +3794,7 @@ fn test_prove_test_u64_num_comparison() {
 
 #[test]
 fn test_prove_test_u64_num_cons() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
 
     let expr = "(cons 1 1u64)";
     let expr2 = "(cons 1u64 1)";
@@ -3697,7 +3803,7 @@ fn test_prove_test_u64_num_cons() {
     let terminal = s.cont_terminal();
 
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(res),
         None,
@@ -3707,7 +3813,7 @@ fn test_prove_test_u64_num_cons() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         expr2,
         Some(res2),
         None,
@@ -3720,36 +3826,63 @@ fn test_prove_test_u64_num_cons() {
 
 #[test]
 fn test_prove_test_hide_u64_secret() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
 
     let expr = "(hide 0u64 123)";
     let error = s.cont_error();
 
-    test_aux::<_, Coproc<_>>(s, expr, None, None, Some(error), None, &expect!["3"], &None);
+    test_aux::<_, Coproc<_>>(
+        &s,
+        expr,
+        None,
+        None,
+        Some(error),
+        None,
+        &expect!["3"],
+        &None,
+    );
 }
 
 #[test]
 fn test_prove_test_mod_by_zero_error() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
 
     let expr = "(% 0 0)";
     let error = s.cont_error();
 
-    test_aux::<_, Coproc<_>>(s, expr, None, None, Some(error), None, &expect!["3"], &None);
+    test_aux::<_, Coproc<_>>(
+        &s,
+        expr,
+        None,
+        None,
+        Some(error),
+        None,
+        &expect!["3"],
+        &None,
+    );
 }
 
 #[test]
 fn test_prove_dotted_syntax_error() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expr = "(let ((a (lambda (x) (+ x 1)))) (a . 1))";
     let error = s.cont_error();
 
-    test_aux::<_, Coproc<_>>(s, expr, None, None, Some(error), None, &expect!["3"], &None);
+    test_aux::<_, Coproc<_>>(
+        &s,
+        expr,
+        None,
+        None,
+        Some(error),
+        None,
+        &expect!["3"],
+        &None,
+    );
 }
 
 #[test]
 fn test_prove_call_literal_fun() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let empty_env = s.intern_empty_env();
     let args = s.list(vec![s.intern_user_symbol("x")]);
     let body = s.read_with_default_state("(+ x 1)").unwrap();
@@ -3761,7 +3894,7 @@ fn test_prove_call_literal_fun() {
     let lang: Arc<Lang<Fr, Coproc<Fr>>> = Arc::new(Lang::new());
 
     nova_test_full_aux2::<_, Coproc<_>>(
-        s,
+        &s,
         expr,
         Some(res),
         None,
@@ -3777,11 +3910,11 @@ fn test_prove_call_literal_fun() {
 
 #[test]
 fn test_prove_lambda_body_syntax() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let error = s.cont_error();
 
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "((lambda ()))",
         None,
         None,
@@ -3791,7 +3924,7 @@ fn test_prove_lambda_body_syntax() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "((lambda () 1 2))",
         None,
         None,
@@ -3801,7 +3934,7 @@ fn test_prove_lambda_body_syntax() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "((lambda (x)) 1)",
         None,
         None,
@@ -3811,7 +3944,7 @@ fn test_prove_lambda_body_syntax() {
         &None,
     );
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "((lambda (x) 1 2) 1)",
         None,
         None,
@@ -3825,7 +3958,7 @@ fn test_prove_lambda_body_syntax() {
 #[test]
 #[ignore]
 fn test_prove_non_symbol_binding_error() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let error = s.cont_error();
 
     let test = |x| {
@@ -3834,7 +3967,7 @@ fn test_prove_non_symbol_binding_error() {
         let expr3 = format!("(lambda ({x}) {x})");
 
         test_aux::<_, Coproc<_>>(
-            s,
+            &s,
             &expr,
             None,
             None,
@@ -3844,7 +3977,7 @@ fn test_prove_non_symbol_binding_error() {
             &None,
         );
         test_aux::<_, Coproc<_>>(
-            s,
+            &s,
             &expr2,
             None,
             None,
@@ -3854,7 +3987,7 @@ fn test_prove_non_symbol_binding_error() {
             &None,
         );
         test_aux::<_, Coproc<_>>(
-            s,
+            &s,
             &expr3,
             None,
             None,
@@ -3874,7 +4007,7 @@ fn test_prove_non_symbol_binding_error() {
 
 #[test]
 fn test_prove_head_with_sym_mimicking_value() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let error = s.cont_error();
 
     let mk_expr = |s: &Store<Fr>, state: StateRcCell, name, args| {
@@ -3886,38 +4019,101 @@ fn test_prove_head_with_sym_mimicking_value() {
     let state = State::init_lurk_state().rccell();
     {
         // binop
-        let expr = mk_expr(s, state.clone(), "+", "(1 1)");
-        test_aux_ptr::<_, Coproc<_>>(s, expr, None, None, Some(error), None, &expect!["1"], &None);
+        let expr = mk_expr(&s, state.clone(), "+", "(1 1)");
+        test_aux_ptr::<_, Coproc<_>>(
+            &s,
+            expr,
+            None,
+            None,
+            Some(error),
+            None,
+            &expect!["1"],
+            &None,
+        );
     }
     {
         // unop
-        let expr = mk_expr(s, state.clone(), "car", "('(1 . 2))");
-        test_aux_ptr::<_, Coproc<_>>(s, expr, None, None, Some(error), None, &expect!["1"], &None);
+        let expr = mk_expr(&s, state.clone(), "car", "('(1 . 2))");
+        test_aux_ptr::<_, Coproc<_>>(
+            &s,
+            expr,
+            None,
+            None,
+            Some(error),
+            None,
+            &expect!["1"],
+            &None,
+        );
     }
     {
         // let_or_letrec
-        let expr = mk_expr(s, state.clone(), "let", "(((a 1)) a)");
-        test_aux_ptr::<_, Coproc<_>>(s, expr, None, None, Some(error), None, &expect!["1"], &None);
+        let expr = mk_expr(&s, state.clone(), "let", "(((a 1)) a)");
+        test_aux_ptr::<_, Coproc<_>>(
+            &s,
+            expr,
+            None,
+            None,
+            Some(error),
+            None,
+            &expect!["1"],
+            &None,
+        );
     }
     {
         // current-env
-        let expr = mk_expr(s, state.clone(), "current-env", "nil");
-        test_aux_ptr::<_, Coproc<_>>(s, expr, None, None, Some(error), None, &expect!["1"], &None);
+        let expr = mk_expr(&s, state.clone(), "current-env", "nil");
+        test_aux_ptr::<_, Coproc<_>>(
+            &s,
+            expr,
+            None,
+            None,
+            Some(error),
+            None,
+            &expect!["1"],
+            &None,
+        );
     }
     {
         // lambda
-        let expr = mk_expr(s, state.clone(), "lambda", "((x) 123)");
-        test_aux_ptr::<_, Coproc<_>>(s, expr, None, None, Some(error), None, &expect!["1"], &None);
+        let expr = mk_expr(&s, state.clone(), "lambda", "((x) 123)");
+        test_aux_ptr::<_, Coproc<_>>(
+            &s,
+            expr,
+            None,
+            None,
+            Some(error),
+            None,
+            &expect!["1"],
+            &None,
+        );
     }
     {
         // quote
-        let expr = mk_expr(s, state.clone(), "quote", "(asdf)");
-        test_aux_ptr::<_, Coproc<_>>(s, expr, None, None, Some(error), None, &expect!["1"], &None);
+        let expr = mk_expr(&s, state.clone(), "quote", "(asdf)");
+        test_aux_ptr::<_, Coproc<_>>(
+            &s,
+            expr,
+            None,
+            None,
+            Some(error),
+            None,
+            &expect!["1"],
+            &None,
+        );
     }
     {
         // if
-        let expr = mk_expr(s, state.clone(), "if", "(t 123 456)");
-        test_aux_ptr::<_, Coproc<_>>(s, expr, None, None, Some(error), None, &expect!["1"], &None);
+        let expr = mk_expr(&s, state.clone(), "if", "(t 123 456)");
+        test_aux_ptr::<_, Coproc<_>>(
+            &s,
+            expr,
+            None,
+            None,
+            Some(error),
+            None,
+            &expect!["1"],
+            &None,
+        );
     }
 }
 
@@ -3925,7 +4121,7 @@ fn test_prove_head_with_sym_mimicking_value() {
 fn test_dumb_lang() {
     use crate::coprocessor::test::DumbCoprocessor;
 
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
 
     let mut lang = Lang::<Fr, DumbCoprocessor<Fr>>::new();
     let name = user_sym("cproc-dumb");
@@ -3963,7 +4159,7 @@ fn test_dumb_lang() {
     let lang = Arc::new(lang);
 
     test_aux::<_, DumbCoprocessor<_>>(
-        s,
+        &s,
         expr,
         Some(res),
         None,
@@ -3973,7 +4169,7 @@ fn test_dumb_lang() {
         &Some(lang.clone()),
     );
     test_aux::<_, DumbCoprocessor<_>>(
-        s,
+        &s,
         expr2,
         Some(res),
         None,
@@ -3983,7 +4179,7 @@ fn test_dumb_lang() {
         &Some(lang.clone()),
     );
     test_aux::<_, DumbCoprocessor<_>>(
-        s,
+        &s,
         expr3,
         Some(res),
         None,
@@ -3993,7 +4189,7 @@ fn test_dumb_lang() {
         &Some(lang.clone()),
     );
     test_aux::<_, DumbCoprocessor<_>>(
-        s,
+        &s,
         expr4,
         Some(error4),
         None,
@@ -4003,7 +4199,7 @@ fn test_dumb_lang() {
         &Some(lang.clone()),
     );
     test_aux::<_, DumbCoprocessor<_>>(
-        s,
+        &s,
         expr5,
         Some(error5),
         None,
@@ -4013,7 +4209,7 @@ fn test_dumb_lang() {
         &Some(lang.clone()),
     );
     test_aux::<_, DumbCoprocessor<_>>(
-        s,
+        &s,
         expr6,
         Some(error6),
         None,
@@ -4023,7 +4219,7 @@ fn test_dumb_lang() {
         &Some(lang.clone()),
     );
     test_aux::<_, DumbCoprocessor<_>>(
-        s,
+        &s,
         expr6_,
         Some(error6),
         None,
@@ -4033,7 +4229,7 @@ fn test_dumb_lang() {
         &Some(lang.clone()),
     );
     test_aux::<_, DumbCoprocessor<_>>(
-        s,
+        &s,
         expr7,
         Some(error7),
         None,
@@ -4052,7 +4248,7 @@ fn test_terminator_lang() {
     let dumb = Terminator::new();
     let name = user_sym("terminate");
 
-    let s = &Store::default();
+    let s = Arc::new(Store::default());
     lang.add_coprocessor(name, dumb);
 
     let expr = "(terminate)";
@@ -4061,7 +4257,7 @@ fn test_terminator_lang() {
     let terminal = s.cont_terminal();
 
     test_aux::<_, Terminator<_>>(
-        s,
+        &s,
         expr,
         Some(res),
         None,
@@ -4080,14 +4276,14 @@ fn test_hello_world_lang() {
     let hello_world = HelloWorld::new();
     let name = user_sym("hello-world");
 
-    let s = &Store::default();
+    let s = Arc::new(Store::default());
     lang.add_coprocessor(name, hello_world);
 
-    let res = HelloWorld::intern_hello_world(s);
+    let res = HelloWorld::intern_hello_world(&*s);
     let terminal = s.cont_terminal();
 
     test_aux::<_, HelloWorld<_>>(
-        s,
+        &s,
         "(hello-world)",
         Some(res),
         None,
@@ -4102,7 +4298,7 @@ fn test_hello_world_lang() {
 fn test_trie_lang() {
     use crate::coprocessor::trie::{install, TrieCoproc};
 
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let state = State::init_lurk_state().rccell();
     let mut lang = Lang::new();
     install(&state, &mut lang);
@@ -4119,7 +4315,7 @@ fn test_trie_lang() {
         )
         .unwrap();
     nova_test_full_aux2::<_, TrieCoproc<_>>(
-        s,
+        &s,
         expr,
         Some(res),
         None,
@@ -4137,7 +4333,7 @@ fn test_trie_lang() {
     let expr2 = s.read(state.clone(), expr2).unwrap();
     let res2 = s.comm(Fr::zero());
     nova_test_full_aux2::<_, TrieCoproc<_>>(
-        s,
+        &s,
         expr2,
         Some(res2),
         None,
@@ -4159,7 +4355,7 @@ fn test_trie_lang() {
         )
         .unwrap();
     nova_test_full_aux2::<_, TrieCoproc<_>>(
-        s,
+        &s,
         expr3,
         Some(res3),
         None,
@@ -4177,7 +4373,7 @@ fn test_trie_lang() {
     let expr4 = s.read(state.clone(), expr4).unwrap();
     let res4 = s.comm(Fr::from(456));
     nova_test_full_aux2::<_, TrieCoproc<_>>(
-        s,
+        &s,
         expr4,
         Some(res4),
         None,
@@ -4190,7 +4386,7 @@ fn test_trie_lang() {
         lang.clone(),
     );
 
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let terminal = s.cont_terminal();
     let expr5 = "(let ((trie (.lurk.trie.new))
                        (found (.lurk.trie.lookup trie 123)))
@@ -4198,7 +4394,7 @@ fn test_trie_lang() {
     let expr5 = s.read(state.clone(), expr5).unwrap();
     let res5 = s.comm(Fr::zero());
     nova_test_full_aux2::<_, TrieCoproc<_>>(
-        s,
+        &s,
         expr5,
         Some(res5),
         None,
@@ -4217,7 +4413,7 @@ fn test_trie_lang() {
     let expr6 = s.read(state.clone(), expr6).unwrap();
     let res6 = s.comm(Fr::from(456));
     nova_test_full_aux2::<_, TrieCoproc<_>>(
-        s,
+        &s,
         expr6,
         Some(res6),
         None,
@@ -4227,18 +4423,18 @@ fn test_trie_lang() {
         DEFAULT_REDUCTION_COUNT,
         false,
         None,
-        lang.clone(),
+        lang,
     );
 }
 
 // This is related to issue #426
 #[test]
 fn test_prove_lambda_body_nil() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.intern_nil();
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "((lambda (x) nil) 0)",
         Some(expected),
         None,
@@ -4252,11 +4448,11 @@ fn test_prove_lambda_body_nil() {
 // The following 3 tests are related to issue #424
 #[test]
 fn test_letrec_let_nesting() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(2);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(letrec ((x (let ((z 0)) 1))) 2)",
         Some(expected),
         None,
@@ -4268,11 +4464,11 @@ fn test_letrec_let_nesting() {
 }
 #[test]
 fn test_let_sequencing() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(1);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(let ((x 0) (y x)) 1)",
         Some(expected),
         None,
@@ -4284,11 +4480,11 @@ fn test_let_sequencing() {
 }
 #[test]
 fn test_letrec_sequencing() {
-    let s = &Store::<Fr>::default();
+    let s = Arc::new(Store::<Fr>::default());
     let expected = s.num_u64(3);
     let terminal = s.cont_terminal();
     test_aux::<_, Coproc<_>>(
-        s,
+        &s,
         "(letrec ((x 0) (y (letrec ((inner 1)) 2))) 3)",
         Some(expected),
         None,

--- a/src/proof/tests/stream.rs
+++ b/src/proof/tests/stream.rs
@@ -35,7 +35,7 @@ fn test_continued_proof() {
             (let ((counter (+ counter x)))
             (cons counter (add counter))))))
         (add 0))";
-    let store = Store::<Fr>::default();
+    let store = Arc::new(Store::<Fr>::default());
     let callable = get_callable(callable_str, &store);
     let expected_iterations = &expect!["14"];
 

--- a/src/proof/tests/supernova_tests.rs
+++ b/src/proof/tests/supernova_tests.rs
@@ -23,7 +23,7 @@ fn test_nil_nil_lang() {
     let lurk_step = make_eval_step_from_config(&eval_config);
     let cprocs = make_cprocs_funcs_from_lang(&lang);
 
-    let store = Store::default();
+    let store = Arc::new(Store::default());
     let expr = store.read_with_default_state("(nil-nil)").unwrap();
     let frames = evaluate(
         Some((&lurk_step, &cprocs, &lang)),

--- a/src/public_parameters/instance.rs
+++ b/src/public_parameters/instance.rs
@@ -138,7 +138,7 @@ impl<F: CurveCycleEquipped, C: Coprocessor<F>> Instance<F, C> {
     /// Returns an `Instance` for Nova public parameters with the prover's
     /// reduction count and lang
     #[inline]
-    pub fn new_nova(prover: &NovaProver<'_, F, C>, abomonated: bool) -> Self {
+    pub fn new_nova(prover: &NovaProver<F, C>, abomonated: bool) -> Self {
         Self::new(
             prover.reduction_count(),
             prover.lang().clone(),
@@ -150,7 +150,7 @@ impl<F: CurveCycleEquipped, C: Coprocessor<F>> Instance<F, C> {
     /// Returns an `Instance` for SuperNova public parameters with the prover's
     /// reduction count and lang
     #[inline]
-    pub fn new_supernova(prover: &SuperNovaProver<'_, F, C>, abomonated: bool) -> Self {
+    pub fn new_supernova(prover: &SuperNovaProver<F, C>, abomonated: bool) -> Self {
         Self::new(
             prover.reduction_count(),
             prover.lang().clone(),


### PR DESCRIPTION
## What's in this PR?

This removes the assumption that `prove_recursively` has access to the whole set of multiframes, by :
- removing lifetime semantics on store references, in favor of the simpler use of `Arc`,
- making `prove_recursively` operate on an `Iterator` of `MultiFrame`, opening the way for that iterator to eventually be lazy,
- making `prove_recursively`'s witness caching only run ahead of proving by at most a fixed number of frames (set to 1000),

> [!NOTE]
> This PR is split in commits matching the above bullet points, the *Commits*  view will let you inspect them separatedly.

## Next Steps

Transferring the above memory-sparse semantics to `prove_from_frames`,`evaluate_and_prove` and other transitive consumers of `prove_recursively`. In other words, evaluation should, as much as is possible, produce an iterator of frames.