### PR TITLE
refactor: witness caching skips the 1st witness.

### DIFF
--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -304,8 +304,12 @@ impl<F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<F, C1LEM<F, C
             let (step_sender, step_receiver) = mpsc::sync_channel(MAX_BUFFERED_FRAMES);
             std::thread::scope(|s| {
                 s.spawn(move || {
-                    for mut step in steps {
-                        step.cache_witness(store).expect("witness caching failed");
+                    for (i, mut step) in steps.enumerate() {
+                        // Skip the very first circuit's witness, so `prove_step` can begin immediately.
+                        // That circuit's witness will not be cached and will just be computed on-demand.
+                        if i > 0 {
+                            step.cache_witness(store).expect("witness caching failed");
+                        }
                         if step_sender.send(step).is_err() {
                             // The main thread has dropped the receiver, so we can stop
                             return;

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -262,8 +262,12 @@ impl<F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<F, C1LEM<F, C
 
             std::thread::scope(|s| {
                 s.spawn(move || {
-                    for mut step in steps {
-                        step.cache_witness(store).expect("witness caching failed");
+                    for (i, mut step) in steps.enumerate() {
+                        // Skip the very first circuit's witness, so `prove_step` can begin immediately.
+                        // That circuit's witness will not be cached and will just be computed on-demand.
+                        if i > 0 {
+                            step.cache_witness(store).expect("witness caching failed");
+                        }
                         if step_sender.send(step).is_err() {
                             // The main thread has dropped the receiver, so we can stop
                             return;


### PR DESCRIPTION
- Optimized the `prove_recursively` function in `RecursiveSNARKTrait` for performance enhancement
- Implemented on-demand computation for first circuit's witness in `prove_step`