### PR TITLE
chore: generalize compact interning and fetching

### DIFF
--- a/src/coprocessor/gadgets.rs
+++ b/src/coprocessor/gadgets.rs
@@ -263,7 +263,7 @@ pub(crate) fn deconstruct_provenance<F: LurkField, CS: ConstraintSystem<F>>(
     let prov_ptr = s.to_ptr(&prov_zptr);
 
     let (a, b, c, d) = {
-        if let Some([q, res, deps]) = s.deconstruct_provenance(prov_ptr) {
+        if let Some([q, res, deps]) = s.deconstruct_provenance(&prov_ptr) {
             let q_zptr = s.hash_ptr(&q);
             let res_zptr = s.hash_ptr(&res);
             let deps_zptr = s.hash_ptr(&deps);

--- a/src/lem/coroutine/eval.rs
+++ b/src/lem/coroutine/eval.rs
@@ -283,8 +283,8 @@ fn run<F: LurkField>(
                     .store
                     .pop_binding(&img_ptr)
                     .context("cannot extract {img}'s binding")?;
-                for (var, ptr) in preimg.iter().zip(preimg_ptrs.iter()) {
-                    bindings.insert_ptr(var.clone(), *ptr);
+                for (var, ptr) in preimg.iter().zip(preimg_ptrs.into_iter()) {
+                    bindings.insert_ptr(var.clone(), ptr);
                 }
             }
             Op::Hide(tgt, sec, src) => {


### PR DESCRIPTION
Interning/fetching environments and provenances share the same logic, so we can unify their implementations to improve code reusability.