### PR TITLE
refactor: move prove_from_frames into Prover trait

### DIFF
--- a/benches/end2end.rs
+++ b/benches/end2end.rs
@@ -13,7 +13,7 @@ use lurk::{
         pointers::Ptr,
         store::Store,
     },
-    proof::{nova::NovaProver, RecursiveSNARKTrait},
+    proof::{nova::NovaProver, Prover, RecursiveSNARKTrait},
     public_parameters::{
         self,
         instance::{Instance, Kind},

--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -11,6 +11,7 @@ use lurk::{
     lang::{Coproc, Lang},
     lem::{eval::evaluate, store::Store},
     proof::nova::NovaProver,
+    proof::Prover,
     public_parameters::{
         instance::{Instance, Kind},
         public_params,

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -23,7 +23,7 @@ use lurk::{
         pointers::Ptr,
         store::Store,
     },
-    proof::{nova::NovaProver, supernova::SuperNovaProver, RecursiveSNARKTrait},
+    proof::{nova::NovaProver, supernova::SuperNovaProver, Prover, RecursiveSNARKTrait},
     public_parameters::{
         instance::{Instance, Kind},
         public_params, supernova_public_params,

--- a/examples/tp_table.rs
+++ b/examples/tp_table.rs
@@ -7,6 +7,7 @@ use lurk::{
     lang::{Coproc, Lang},
     lem::{eval::evaluate, store::Store},
     proof::nova::{public_params, NovaProver, PublicParams},
+    proof::Prover,
 };
 use num_traits::ToPrimitive;
 use statrs::statistics::Statistics;

--- a/src/cli/repl/mod.rs
+++ b/src/cli/repl/mod.rs
@@ -38,7 +38,7 @@ use crate::{
     proof::{
         nova::{CurveCycleEquipped, Dual, NovaProver},
         supernova::SuperNovaProver,
-        RecursiveSNARKTrait,
+        Prover, RecursiveSNARKTrait,
     },
     public_parameters::{instance::Instance, public_params, supernova_public_params},
     state::{State, StateRcCell},

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -392,30 +392,9 @@ impl<F: CurveCycleEquipped, C: Coprocessor<F>> NovaProver<F, C> {
             folding_mode: FoldingMode::IVC,
         }
     }
-
-    /// Generate a proof from a sequence of frames
-    pub fn prove_from_frames(
-        &self,
-        pp: &PublicParams<F>,
-        frames: &[Frame],
-        store: &Arc<Store<F>>,
-        init: Option<RecursiveSNARK<E1<F>>>,
-    ) -> Result<(Proof<F, C1LEM<F, C>>, Vec<F>, Vec<F>, usize), ProofError> {
-        let folding_config = self
-            .folding_mode()
-            .folding_config(self.lang().clone(), self.reduction_count());
-        let steps = C1LEM::<F, C>::from_frames(frames, store, &folding_config.into());
-        self.prove(pp, steps, store, init)
-    }
-
-    #[inline]
-    /// Returns the `Lang` wrapped with `Arc` for cheap cloning
-    pub fn lang(&self) -> &Arc<Lang<F, C>> {
-        &self.lang
-    }
 }
 
-impl<F: CurveCycleEquipped, C: Coprocessor<F>> Prover<F> for NovaProver<F, C> {
+impl<F: CurveCycleEquipped, C: Coprocessor<F>> Prover<F, C> for NovaProver<F, C> {
     type Frame = C1LEM<F, C>;
     type PublicParams = PublicParams<F>;
     type RecursiveSNARK = Proof<F, C1LEM<F, C>>;
@@ -443,5 +422,18 @@ impl<F: CurveCycleEquipped, C: Coprocessor<F>> Prover<F> for NovaProver<F, C> {
         let frames =
             C1LEM::<F, C>::build_frames(expr, env, store, limit, &eval_config, ch_terminal)?;
         self.prove_from_frames(pp, &frames, store, None)
+    }
+
+    fn from_frames(
+        frames: &[Frame],
+        store: &Arc<Store<F>>,
+        folding_config: &Arc<FoldingConfig<F, C>>,
+    ) -> Vec<Self::Frame> {
+        C1LEM::<F, C>::from_frames(frames, store, folding_config)
+    }
+
+    #[inline]
+    fn lang(&self) -> &Arc<Lang<F, C>> {
+        &self.lang
     }
 }

--- a/src/proof/supernova.rs
+++ b/src/proof/supernova.rs
@@ -195,12 +195,6 @@ impl<F: CurveCycleEquipped, C: Coprocessor<F>> SuperNovaProver<F, C> {
         let steps = C1LEM::<F, C>::from_frames(frames, store, &folding_config.into());
         self.prove(pp, steps, store, init)
     }
-
-    #[inline]
-    /// Returns the `Lang` wrapped with `Arc` for cheap cloning
-    pub fn lang(&self) -> &Arc<Lang<F, C>> {
-        &self.lang
-    }
 }
 
 impl<F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<F, C1LEM<F, C>>
@@ -323,7 +317,7 @@ impl<F: CurveCycleEquipped, C: Coprocessor<F>> RecursiveSNARKTrait<F, C1LEM<F, C
     }
 }
 
-impl<F: CurveCycleEquipped, C: Coprocessor<F>> Prover<F> for SuperNovaProver<F, C> {
+impl<F: CurveCycleEquipped, C: Coprocessor<F>> Prover<F, C> for SuperNovaProver<F, C> {
     type Frame = C1LEM<F, C>;
     type PublicParams = PublicParams<F>;
     type RecursiveSNARK = Proof<F, C1LEM<F, C>>;
@@ -351,6 +345,19 @@ impl<F: CurveCycleEquipped, C: Coprocessor<F>> Prover<F> for SuperNovaProver<F, 
         let frames =
             C1LEM::<F, C>::build_frames(expr, env, store, limit, &eval_config, ch_terminal)?;
         self.prove_from_frames(pp, &frames, store, None)
+    }
+
+    fn from_frames(
+        frames: &[Frame],
+        store: &Arc<Store<F>>,
+        folding_config: &Arc<FoldingConfig<F, C>>,
+    ) -> Vec<Self::Frame> {
+        C1LEM::<F, C>::from_frames(frames, store, folding_config)
+    }
+
+    #[inline]
+    fn lang(&self) -> &Arc<Lang<F, C>> {
+        &self.lang
     }
 }
 


### PR DESCRIPTION
Closes #1217.

- Adds `lang()` method to the `Prover` trait
- Adds `prove_from_frames()` method to the `Prover` trait with the default implementation extracted from both `Nova` and `SuperNova`
- Adds a new `from_frames()` method to the `Prover` trait to assist the `prove_from_frames()` method
  - Better name suggestions welcome here