### PR TITLE
chore: factor out `StoreCore`

### DIFF
--- a/benches/common/fib.rs
+++ b/benches/common/fib.rs
@@ -38,7 +38,7 @@ pub(crate) fn fib_limit(n: usize, rc: usize) -> usize {
     rc * (frame / rc + usize::from(frame % rc != 0))
 }
 
-fn lurk_fib<F: LurkField>(store: &Store<F>, n: usize) -> Ptr {
+fn lurk_fib<F: LurkField>(store: &Store<F>, n: usize) -> &Ptr {
     let frame_idx = fib_frame(n);
     let limit = frame_idx;
     let fib_expr = fib_expr(store);
@@ -59,7 +59,7 @@ fn lurk_fib<F: LurkField>(store: &Store<F>, n: usize) -> Ptr {
     //               body: (.lurk.user.fib), continuation: Outermost }
 
     let [_, _, rest_bindings] = store.pop_binding(target_env).unwrap();
-    let [_, val, _] = store.pop_binding(&rest_bindings).unwrap();
+    let [_, val, _] = store.pop_binding(rest_bindings).unwrap();
     val
 }
 
@@ -109,7 +109,7 @@ pub(crate) fn test_fib_io_matches() {
     let fib_9 = store.num_u64(34);
     let fib_10 = store.num_u64(55);
     let fib_11 = store.num_u64(89);
-    assert_eq!(fib_9, lurk_fib(&store, 9));
-    assert_eq!(fib_10, lurk_fib(&store, 10));
-    assert_eq!(fib_11, lurk_fib(&store, 11));
+    assert_eq!(&fib_9, lurk_fib(&store, 9));
+    assert_eq!(&fib_10, lurk_fib(&store, 10));
+    assert_eq!(&fib_11, lurk_fib(&store, 11));
 }

--- a/chain-server/src/server.rs
+++ b/chain-server/src/server.rs
@@ -173,8 +173,8 @@ where
 
                 // produce the data for the response
                 let chain_response_data = ser(ChainResponseData::new(
-                    &result,
-                    &next_callable,
+                    result,
+                    next_callable,
                     &self.store,
                     compressed_proof,
                 ))
@@ -182,13 +182,13 @@ where
 
                 // save the session
                 if let Some(session) = &self.session {
-                    let session_data = SessionData::pack_standalone(self, &next_callable);
+                    let session_data = SessionData::pack_standalone(self, next_callable);
                     dump(session_data, session).map_err(|e| Status::internal(e.to_string()))?;
                 }
 
                 // now it's safe to set the new callable state since no error
                 // has occurred so far
-                *callable_state = next_callable;
+                *callable_state = *next_callable;
 
                 Ok(Response::new(ChainResponse {
                     chain_response_data,
@@ -371,8 +371,8 @@ where
 
                 // produce the data for the response
                 let chain_response_data = ser(ChainResponseData::new(
-                    &result,
-                    &next_callable,
+                    result,
+                    next_callable,
                     &self.store,
                     compressed_proof,
                 ))
@@ -382,16 +382,16 @@ where
                 if let Some(session) = &self.session {
                     let session_data = SessionData::pack_stream(
                         self,
-                        &next_callable,
-                        Some((&result, recursive_proof.clone())),
+                        next_callable,
+                        Some((result, recursive_proof.clone())),
                     );
                     dump(session_data, session).map_err(|e| Status::internal(e.to_string()))?;
                 }
 
                 // now it's safe to set the new state since no error has occurred so far
                 *state = StreamState {
-                    callable: next_callable,
-                    result_and_proof: Some((result, recursive_proof)),
+                    callable: *next_callable,
+                    result_and_proof: Some((*result, recursive_proof)),
                 };
 
                 Ok(Response::new(ChainResponse {
@@ -643,7 +643,7 @@ fn get_service_and_address<
             let callable = if init_args.comm {
                 let hash_ptr = store.read_with_default_state(&init_args.callable)?;
                 let hash = store
-                    .fetch_f(&hash_ptr)
+                    .fetch_f_by_val(hash_ptr.val())
                     .ok_or("Failed to parse callable hash")?;
                 fetch_comm(hash, &store)?;
                 hash_ptr.cast(Tag::Expr(lurk::tag::ExprTag::Comm))

--- a/examples/keccak.rs
+++ b/examples/keccak.rs
@@ -309,7 +309,7 @@ impl<F: LurkField> CircomGadget<F> for CircomKeccak<F> {
         let bytes_to_hash = bits_to_bytes(
             &z_bits
                 .iter()
-                .map(|ptr| ptr.value() != &F::ZERO)
+                .map(|ptr| ptr.hash() != &F::ZERO)
                 .collect::<Vec<_>>(),
         );
 
@@ -371,7 +371,7 @@ fn main() {
             .unwrap()
             .0
             .iter()
-            .map(|ptr| ptr.raw().get_atom().unwrap() == 1)
+            .map(|ptr| ptr.val().get_atom_idx().unwrap() == 1)
             .collect::<Vec<_>>(),
     );
 

--- a/foil/src/coil.rs
+++ b/foil/src/coil.rs
@@ -85,8 +85,8 @@ fn lookup_vertex_id<F: LurkField>(store: &Store<F>, env: &Ptr, var: &Ptr) -> Res
         return Ok(None);
     };
 
-    if *var == bound_var {
-        match store.fetch_num(&id) {
+    if var == bound_var {
+        match store.fetch_num(id) {
             Some(f) => Ok(f.to_u64().map(|u| {
                 let n = u as Id;
                 info!("found {n}");
@@ -97,7 +97,7 @@ fn lookup_vertex_id<F: LurkField>(store: &Store<F>, env: &Ptr, var: &Ptr) -> Res
             }
         }
     } else {
-        lookup_vertex_id(store, &rest_env, var)
+        lookup_vertex_id(store, rest_env, var)
     }
 }
 
@@ -127,9 +127,9 @@ impl Context {
         let [_var, id, rest_env] = store
             .pop_binding(&self.env)
             .ok_or(anyhow!("failed to pop binding"))?;
-        self.env = rest_env;
+        self.env = *rest_env;
 
-        Ok(match store.fetch_num(&id) {
+        Ok(match store.fetch_num(id) {
             Some(f) => f
                 .to_u64()
                 .map(|u| u as Id)

--- a/src/cli/repl/mod.rs
+++ b/src/cli/repl/mod.rs
@@ -29,7 +29,7 @@ use crate::{
             make_eval_step_from_config, EvalConfig,
         },
         interpreter::Frame,
-        pointers::{Ptr, RawPtr},
+        pointers::{IVal, Ptr},
         store::Store,
         tag::Tag,
         Func,
@@ -322,7 +322,10 @@ where
             &self.store,
             (input[0], output[0]),
             (input[1], output[1]),
-            (cont.parts(), cont_out.parts()),
+            (
+                (cont.tag_field(), *cont.hash()),
+                (cont_out.tag_field(), *cont_out.hash()),
+            ),
         );
 
         let claim_comm = Commitment::new(None, claim, &self.store);
@@ -555,8 +558,7 @@ where
     /// Errors when `hash_expr` doesn't reduce to a Num or Comm pointer
     fn get_comm_hash(&mut self, hash_expr: Ptr) -> Result<&F> {
         let io = self.eval_expr(hash_expr)?;
-        let (Tag::Expr(ExprTag::Num | ExprTag::Comm), RawPtr::Atom(hash_idx)) = io[0].parts()
-        else {
+        let (Tag::Expr(ExprTag::Num | ExprTag::Comm), IVal::Atom(hash_idx)) = io[0].parts() else {
             bail!("Commitment hash expression must reduce to a Num or Comm pointer")
         };
         Ok(self.store.expect_f(*hash_idx))

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -120,7 +120,7 @@ pub(crate) mod test {
 
     use super::*;
     use crate::circuit::gadgets::constraints::{alloc_equal, mul};
-    use crate::lem::{pointers::RawPtr, tag::Tag as LEMTag};
+    use crate::lem::{pointers::IVal, tag::Tag as LEMTag};
     use crate::tag::{ExprTag, Tag};
     use std::marker::PhantomData;
 
@@ -214,11 +214,11 @@ pub(crate) mod test {
         }
 
         fn evaluate(&self, s: &Store<F>, args: &[Ptr], env: &Ptr, cont: &Ptr) -> Vec<Ptr> {
-            let (LEMTag::Expr(ExprTag::Num), RawPtr::Atom(a)) = args[0].parts() else {
+            let (LEMTag::Expr(ExprTag::Num), IVal::Atom(a)) = args[0].parts() else {
                 return vec![args[0], *env, s.cont_error()];
             };
             let a = s.expect_f(*a);
-            let (LEMTag::Expr(ExprTag::Num), RawPtr::Atom(b)) = args[1].parts() else {
+            let (LEMTag::Expr(ExprTag::Num), IVal::Atom(b)) = args[1].parts() else {
                 return vec![args[1], *env, s.cont_error()];
             };
             let b = s.expect_f(*b);

--- a/src/coprocessor/sha256.rs
+++ b/src/coprocessor/sha256.rs
@@ -9,9 +9,11 @@ use crate::{
     self as lurk,
     circuit::gadgets::pointer::AllocatedPtr,
     field::LurkField,
-    lem::{pointers::Ptr, store::Store},
+    lem::{
+        pointers::{Ptr, ZPtr},
+        store::Store,
+    },
     tag::{ExprTag, Tag},
-    z_ptr::ZPtr,
 };
 
 use super::{CoCircuit, Coprocessor};
@@ -61,14 +63,14 @@ fn synthesize_sha256<F: LurkField, CS: ConstraintSystem<F>>(
     )
 }
 
-fn compute_sha256<F: LurkField, T: Tag>(n: usize, z_ptrs: &[ZPtr<T, F>]) -> F {
+fn compute_sha256<F: LurkField>(n: usize, z_ptrs: &[ZPtr<F>]) -> F {
     let mut hasher = Sha256::new();
 
     let mut input = vec![0u8; 64 * n];
 
     for (i, z_ptr) in z_ptrs.iter().enumerate() {
         let tag_zptr: F = z_ptr.tag().to_field();
-        let hash_zptr = z_ptr.value();
+        let hash_zptr = z_ptr.hash();
         input[(64 * i)..(64 * i + 32)].copy_from_slice(&tag_zptr.to_bytes());
         input[(64 * i + 32)..(64 * (i + 1))].copy_from_slice(&hash_zptr.to_bytes());
     }

--- a/src/coroutine/memoset/demo.rs
+++ b/src/coroutine/memoset/demo.rs
@@ -32,7 +32,7 @@ impl<F: LurkField> Query<F> for DemoQuery<F> {
         match self {
             Self::Factorial(n) => {
                 let n_zptr = scope.store.hash_ptr(n);
-                let n = n_zptr.value();
+                let n = n_zptr.hash();
 
                 if *n == F::ZERO {
                     scope.store.num(F::ONE)
@@ -40,7 +40,7 @@ impl<F: LurkField> Query<F> for DemoQuery<F> {
                     let sub_query = Self::Factorial(scope.store.num(*n - F::ONE));
                     let m_ptr = self.recursive_eval(scope, sub_query);
                     let m_zptr = scope.store.hash_ptr(&m_ptr);
-                    let m = m_zptr.value();
+                    let m = m_zptr.hash();
 
                     scope.store.num(*n * m)
                 }

--- a/src/coroutine/memoset/env.rs
+++ b/src/coroutine/memoset/env.rs
@@ -34,11 +34,11 @@ impl<F: LurkField> Query<F> for EnvQuery<F> {
         match self {
             Self::Lookup(var, env) => {
                 if let Some([v, val, new_env]) = s.pop_binding(env) {
-                    if s.ptr_eq(var, &v) {
+                    if s.ptr_eq(var, v) {
                         let t = s.intern_t();
-                        s.cons(val, t)
+                        s.cons(*val, t)
                     } else {
-                        self.recursive_eval(scope, Self::Lookup(*var, new_env))
+                        self.recursive_eval(scope, Self::Lookup(*var, *new_env))
                     }
                 } else {
                     let nil = s.intern_nil();
@@ -86,9 +86,9 @@ impl<F: LurkField> Query<F> for EnvQuery<F> {
         match self {
             EnvQuery::Lookup(var, env) => {
                 let allocated_var =
-                    AllocatedNum::alloc_infallible(ns!(cs, "var"), || *s.hash_ptr(var).value());
+                    AllocatedNum::alloc_infallible(ns!(cs, "var"), || *s.hash_ptr(var).hash());
                 let allocated_env =
-                    AllocatedNum::alloc_infallible(ns!(cs, "env"), || *s.hash_ptr(env).value());
+                    AllocatedNum::alloc_infallible(ns!(cs, "env"), || *s.hash_ptr(env).hash());
                 Self::CQ::Lookup(allocated_var, allocated_env)
             }
             _ => unreachable!(),

--- a/src/field.rs
+++ b/src/field.rs
@@ -285,6 +285,15 @@ impl LurkField for GrumpkinScalar {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FWrap<F>(pub F);
 
+impl<F> FWrap<F> {
+    /// Returns a reference to the wrapped value
+    #[inline]
+    pub fn get(&self) -> &F {
+        let Self(f) = self;
+        f
+    }
+}
+
 impl<F: LurkField> Copy for FWrap<F> {}
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/src/lem/coroutine/toplevel.rs
+++ b/src/lem/coroutine/toplevel.rs
@@ -274,7 +274,6 @@ mod test {
     use super::*;
     use crate::coroutine::memoset::prove::MemosetProver;
     use crate::coroutine::memoset::CoroutineCircuit;
-    use crate::lem::tag::Tag;
     use crate::proof::RecursiveSNARKTrait;
     use crate::{func, state::user_sym};
 
@@ -393,12 +392,12 @@ mod test {
             CoroutineCircuit::<_, _, ToplevelQuery<_>>::blank(index, 1, &s, &toplevel);
         let mut cs = BenchCS::new();
         let dummy = [
-            AllocatedPtr::alloc_infallible::<_, _, Tag>(&mut cs, || unreachable!()),
-            AllocatedPtr::alloc_infallible::<_, _, Tag>(&mut cs, || unreachable!()),
-            AllocatedPtr::alloc_infallible::<_, _, Tag>(&mut cs, || unreachable!()),
-            AllocatedPtr::alloc_infallible::<_, _, Tag>(&mut cs, || unreachable!()),
-            AllocatedPtr::alloc_infallible::<_, _, Tag>(&mut cs, || unreachable!()),
-            AllocatedPtr::alloc_infallible::<_, _, Tag>(&mut cs, || unreachable!()),
+            AllocatedPtr::alloc_infallible(&mut cs, || unreachable!()),
+            AllocatedPtr::alloc_infallible(&mut cs, || unreachable!()),
+            AllocatedPtr::alloc_infallible(&mut cs, || unreachable!()),
+            AllocatedPtr::alloc_infallible(&mut cs, || unreachable!()),
+            AllocatedPtr::alloc_infallible(&mut cs, || unreachable!()),
+            AllocatedPtr::alloc_infallible(&mut cs, || unreachable!()),
         ];
         factorial_circuit
             .supernova_synthesize(&mut cs, &dummy)
@@ -410,12 +409,12 @@ mod test {
             CoroutineCircuit::<_, _, ToplevelQuery<_>>::blank(index, 1, &s, &toplevel);
         let mut cs = BenchCS::new();
         let dummy = [
-            AllocatedPtr::alloc_infallible::<_, _, Tag>(&mut cs, || unreachable!()),
-            AllocatedPtr::alloc_infallible::<_, _, Tag>(&mut cs, || unreachable!()),
-            AllocatedPtr::alloc_infallible::<_, _, Tag>(&mut cs, || unreachable!()),
-            AllocatedPtr::alloc_infallible::<_, _, Tag>(&mut cs, || unreachable!()),
-            AllocatedPtr::alloc_infallible::<_, _, Tag>(&mut cs, || unreachable!()),
-            AllocatedPtr::alloc_infallible::<_, _, Tag>(&mut cs, || unreachable!()),
+            AllocatedPtr::alloc_infallible(&mut cs, || unreachable!()),
+            AllocatedPtr::alloc_infallible(&mut cs, || unreachable!()),
+            AllocatedPtr::alloc_infallible(&mut cs, || unreachable!()),
+            AllocatedPtr::alloc_infallible(&mut cs, || unreachable!()),
+            AllocatedPtr::alloc_infallible(&mut cs, || unreachable!()),
+            AllocatedPtr::alloc_infallible(&mut cs, || unreachable!()),
         ];
         even_circuit.supernova_synthesize(&mut cs, &dummy).unwrap();
         expect!("1772").assert_eq(&cs.num_constraints().to_string());

--- a/src/lem/eval.rs
+++ b/src/lem/eval.rs
@@ -23,8 +23,8 @@ use crate::{
 
 use super::{
     interpreter::{Frame, Hints},
-    pointers::{Ptr, RawPtr},
-    store::{fetch_ptrs, Store},
+    pointers::{IVal, Ptr},
+    store::Store,
     Ctrl, Func, Lit, LitType, Op, Tag, Var,
 };
 
@@ -43,9 +43,8 @@ fn get_pc<F: LurkField, C: Coprocessor<F>>(
     lang: &Lang<F, C>,
 ) -> usize {
     match expr.parts() {
-        (Tag::Expr(Cproc), RawPtr::Hash4(idx)) => {
-            let [cproc, _] =
-                &fetch_ptrs!(store, 2, *idx).expect("Coprocessor expression is not interned");
+        (Tag::Expr(Cproc), IVal::Tuple2(idx)) => {
+            let [cproc, _] = store.expect_tuple2(*idx);
             let cproc_sym = store
                 .fetch_symbol(cproc)
                 .expect("Coprocessor expression is not interned");

--- a/src/lem/mod.rs
+++ b/src/lem/mod.rs
@@ -68,6 +68,7 @@ pub mod multiframe;
 pub mod pointers;
 mod slot;
 pub mod store;
+pub mod store_core;
 pub mod tag;
 mod var_map;
 

--- a/src/lem/multiframe.rs
+++ b/src/lem/multiframe.rs
@@ -485,7 +485,7 @@ fn assert_eq_ptrs_aptrs<F: LurkField>(
                 return Err(SynthesisError::AssignmentMissing);
             };
             assert_eq!(alloc_ptr_tag, z_ptr.tag().to_field());
-            assert_eq!(&alloc_ptr_hash, z_ptr.value());
+            assert_eq!(&alloc_ptr_hash, z_ptr.hash());
         }
     }
     Ok(())
@@ -754,7 +754,7 @@ impl<F: LurkField, C: Coprocessor<F>> Circuit<F> for MultiFrame<F, C> {
 
                 let allocated_hash = AllocatedNum::alloc_infallible(
                     ns!(cs, format!("allocated hash for input {i}")),
-                    || *z_ptr.value(),
+                    || *z_ptr.hash(),
                 );
                 allocated_hash.inputize(ns!(cs, format!("inputized hash for input {i}")))?;
 
@@ -773,7 +773,7 @@ impl<F: LurkField, C: Coprocessor<F>> Circuit<F> for MultiFrame<F, C> {
 
                 let allocated_hash = AllocatedNum::alloc_infallible(
                     ns!(cs, format!("allocated hash for output {i}")),
-                    || *z_ptr.value(),
+                    || *z_ptr.hash(),
                 );
                 allocated_hash.inputize(ns!(cs, format!("inputized hash for output {i}")))?;
 
@@ -831,12 +831,12 @@ impl<F: LurkField, C: Coprocessor<F>> Provable<F> for MultiFrame<F, C> {
         for ptr in input {
             let z_ptr = store.hash_ptr(ptr);
             res.push(z_ptr.tag().to_field());
-            res.push(*z_ptr.value());
+            res.push(*z_ptr.hash());
         }
         for ptr in output {
             let z_ptr = store.hash_ptr(ptr);
             res.push(z_ptr.tag().to_field());
-            res.push(*z_ptr.value());
+            res.push(*z_ptr.hash());
         }
         res
     }
@@ -1085,7 +1085,7 @@ mod tests {
             let z_ptr = store.hash_ptr(ptr);
             let allocated_tag = AllocatedNum::alloc_infallible(&mut cs, || z_ptr.tag_field());
             allocated_tag.inputize(&mut cs).unwrap();
-            let allocated_hash = AllocatedNum::alloc_infallible(&mut cs, || *z_ptr.value());
+            let allocated_hash = AllocatedNum::alloc_infallible(&mut cs, || *z_ptr.hash());
             allocated_hash.inputize(&mut cs).unwrap();
             input.push(AllocatedPtr::from_parts(allocated_tag, allocated_hash));
         }

--- a/src/lem/slot.rs
+++ b/src/lem/slot.rs
@@ -106,7 +106,7 @@
 use match_opt::match_opt;
 
 use super::{
-    pointers::{Ptr, RawPtr},
+    pointers::{IVal, Ptr},
     Block, Ctrl, Op,
 };
 
@@ -246,7 +246,7 @@ impl Block {
 /// take only 0 or 1 values.
 pub enum Val {
     Pointer(Ptr),
-    Num(RawPtr),
+    Num(IVal),
     Boolean(bool),
 }
 

--- a/src/lem/store_core.rs
+++ b/src/lem/store_core.rs
@@ -1,0 +1,398 @@
+use arc_swap::ArcSwap;
+use elsa::sync::{index_set::FrozenIndexSet, FrozenMap, FrozenVec};
+use indexmap::IndexSet;
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use std::sync::Arc;
+
+use super::pointers::{GPtr, IPtr, IVal};
+
+/// Trait that teaches the `StoreCore` how to perform custom hashing operations
+pub trait StoreHasher<T, D> {
+    fn hash_ptrs(&self, ptrs: Vec<GPtr<T, D>>) -> D;
+    fn hash_compact(&self, d1: D, t2: T, d2: D, d3: D) -> D;
+    fn hash_commitment(&self, secret: D, payload: GPtr<T, D>) -> D;
+}
+
+/// A data structure used to efficiently encode data as DAGs of tagged pointers
+/// that can eventually be content-addressed by a custom hasher
+#[derive(Debug)]
+pub struct StoreCore<T, D, H: StoreHasher<T, D>> {
+    /// Holds leaf (non-compound) data
+    atom: FrozenIndexSet<Box<D>>,
+
+    /// Holds compound data with 2 children
+    tuple2: FrozenIndexSet<Box<[IPtr<T>; 2]>>,
+
+    /// Holds compound data with 3 children
+    tuple3: FrozenIndexSet<Box<[IPtr<T>; 3]>>,
+
+    /// Holds compound data with 4 children
+    tuple4: FrozenIndexSet<Box<[IPtr<T>; 4]>>,
+
+    /// `StoreHasher` implementer
+    pub hasher: H,
+
+    /// Holds the commitments performed with the store
+    pub comms: FrozenMap<D, Box<(D, IPtr<T>)>>, // digest -> (secret, payload)
+
+    /// Keeps track of data that hasn't been hashed yet for future parallel hashing
+    dehydrated: ArcSwap<FrozenVec<Box<IVal>>>,
+
+    /// Memoized hashes
+    z_cache: FrozenMap<IVal, Box<D>>,
+
+    /// Inverse hashes to enable the retrieval of the original data from their
+    /// digests
+    inverse_z_cache: FrozenMap<D, Box<IVal>>,
+}
+
+impl<
+        T: PartialEq + std::cmp::Eq + std::hash::Hash,
+        D: PartialEq + std::cmp::Eq + std::hash::Hash,
+        H: StoreHasher<T, D> + Default,
+    > Default for StoreCore<T, D, H>
+{
+    fn default() -> Self {
+        Self {
+            atom: Default::default(),
+            tuple2: Default::default(),
+            tuple3: Default::default(),
+            tuple4: Default::default(),
+            hasher: Default::default(),
+            comms: Default::default(),
+            dehydrated: Default::default(),
+            z_cache: Default::default(),
+            inverse_z_cache: Default::default(),
+        }
+    }
+}
+
+impl<
+        T: Copy + PartialEq + std::cmp::Eq + std::hash::Hash + Send + Sync,
+        D: Copy + PartialEq + std::cmp::Eq + std::hash::Hash + Send + Sync,
+        H: StoreHasher<T, D> + Sync,
+    > StoreCore<T, D, H>
+{
+    #[inline]
+    pub fn intern_digest(&self, d: D) -> (usize, bool) {
+        self.atom.insert_probe(Box::new(d))
+    }
+
+    #[inline]
+    pub fn fetch_digest(&self, idx: usize) -> Option<&D> {
+        self.atom.get_index(idx)
+    }
+
+    #[inline]
+    pub fn expect_digest(&self, idx: usize) -> &D {
+        self.fetch_digest(idx).expect("Digest wasn't interned")
+    }
+
+    pub fn intern_tuple2(&self, ptrs: [IPtr<T>; 2], tag: T, digest: Option<D>) -> IPtr<T> {
+        let (idx, inserted) = self.tuple2.insert_probe(Box::new(ptrs));
+        let ptr = IPtr::new(tag, IVal::Tuple2(idx));
+        if let Some(digest) = digest {
+            let val = *ptr.val();
+            self.z_cache.insert(val, Box::new(digest));
+            self.inverse_z_cache.insert(digest, Box::new(val));
+        } else if inserted {
+            self.dehydrated.load().push(Box::new(*ptr.val()));
+        }
+        ptr
+    }
+
+    #[inline]
+    pub fn fetch_tuple2(&self, idx: usize) -> Option<&[IPtr<T>; 2]> {
+        self.tuple2.get_index(idx)
+    }
+
+    #[inline]
+    pub fn expect_tuple2(&self, idx: usize) -> &[IPtr<T>; 2] {
+        self.fetch_tuple2(idx).expect("Tuple2 not interned")
+    }
+
+    fn intern_tuple3_common(
+        &self,
+        ptrs: [IPtr<T>; 3],
+        tag: T,
+        digest: Option<D>,
+        compact: bool,
+    ) -> IPtr<T> {
+        let (idx, inserted) = self.tuple3.insert_probe(Box::new(ptrs));
+        let ptr = if compact {
+            IPtr::new(tag, IVal::Compact(idx))
+        } else {
+            IPtr::new(tag, IVal::Tuple3(idx))
+        };
+        if let Some(digest) = digest {
+            let val = *ptr.val();
+            self.z_cache.insert(val, Box::new(digest));
+            self.inverse_z_cache.insert(digest, Box::new(val));
+        } else if inserted {
+            self.dehydrated.load().push(Box::new(*ptr.val()));
+        }
+        ptr
+    }
+
+    #[inline]
+    pub fn intern_tuple3(&self, ptrs: [IPtr<T>; 3], tag: T, digest: Option<D>) -> IPtr<T> {
+        self.intern_tuple3_common(ptrs, tag, digest, false)
+    }
+
+    #[inline]
+    pub fn fetch_tuple3(&self, idx: usize) -> Option<&[IPtr<T>; 3]> {
+        self.tuple3.get_index(idx)
+    }
+
+    #[inline]
+    pub fn expect_tuple3(&self, idx: usize) -> &[IPtr<T>; 3] {
+        self.fetch_tuple3(idx).expect("Tuple3 not interned")
+    }
+
+    pub fn intern_tuple4(&self, ptrs: [IPtr<T>; 4], tag: T, digest: Option<D>) -> IPtr<T> {
+        let (idx, inserted) = self.tuple4.insert_probe(Box::new(ptrs));
+        let ptr = IPtr::new(tag, IVal::Tuple4(idx));
+        if let Some(digest) = digest {
+            let val = *ptr.val();
+            self.z_cache.insert(val, Box::new(digest));
+            self.inverse_z_cache.insert(digest, Box::new(val));
+        } else if inserted {
+            self.dehydrated.load().push(Box::new(*ptr.val()));
+        }
+        ptr
+    }
+
+    #[inline]
+    pub fn fetch_tuple4(&self, idx: usize) -> Option<&[IPtr<T>; 4]> {
+        self.tuple4.get_index(idx)
+    }
+
+    #[inline]
+    pub fn expect_tuple4(&self, idx: usize) -> &[IPtr<T>; 4] {
+        self.fetch_tuple4(idx).expect("Tuple4 not interned")
+    }
+
+    #[inline]
+    pub fn intern_compact(&self, ptrs: [IPtr<T>; 3], tag: T, digest: Option<D>) -> IPtr<T> {
+        self.intern_tuple3_common(ptrs, tag, digest, true)
+    }
+
+    #[inline]
+    pub fn fetch_compact(&self, idx: usize) -> Option<&[IPtr<T>; 3]> {
+        self.fetch_tuple3(idx)
+    }
+
+    #[inline]
+    pub fn fetch_compact_by_val(&self, ptr_val: &IVal) -> Option<&[IPtr<T>; 3]> {
+        ptr_val
+            .get_compact_idx()
+            .and_then(|idx| self.fetch_compact(idx))
+    }
+
+    #[inline]
+    pub fn expect_compact(&self, idx: usize) -> &[IPtr<T>; 3] {
+        self.fetch_compact(idx).expect("Compact not interned")
+    }
+
+    /// Recursively hashes the children of a `IVal` in order to obtain its
+    /// corresponding digest. While traversing the tree, it consults the cache
+    /// of `IVal`s that have already been hashed and also populates this cache
+    /// for the new `IVal`s.
+    ///
+    /// Warning: without cache hits, this function might blow up Rust's recursion
+    /// depth limit. This limitation is circumvented by calling `hydrate_z_cache`
+    /// beforehand or by using `hash_ptr` instead, which might be slightly slower.
+    pub fn hash_ptr_val_unsafe(&self, ptr_val: &IVal) -> D {
+        if let Some(digest) = self.z_cache.get(ptr_val) {
+            *digest
+        } else {
+            let digest = match *ptr_val {
+                IVal::Atom(idx) => *self.fetch_digest(idx).expect("Atom not interned"),
+                IVal::Tuple2(idx) => {
+                    let [a, b] = self.expect_tuple2(idx);
+                    let a_digest = self.hash_ptr_val_unsafe(a.val());
+                    let b_digest = self.hash_ptr_val_unsafe(b.val());
+                    let a = GPtr::new(*a.tag(), a_digest);
+                    let b = GPtr::new(*b.tag(), b_digest);
+                    self.hasher.hash_ptrs(vec![a, b])
+                }
+                IVal::Tuple3(idx) => {
+                    let [a, b, c] = self.expect_tuple3(idx);
+                    let a_digest = self.hash_ptr_val_unsafe(a.val());
+                    let b_digest = self.hash_ptr_val_unsafe(b.val());
+                    let c_digest = self.hash_ptr_val_unsafe(c.val());
+                    let a = GPtr::new(*a.tag(), a_digest);
+                    let b = GPtr::new(*b.tag(), b_digest);
+                    let c = GPtr::new(*c.tag(), c_digest);
+                    self.hasher.hash_ptrs(vec![a, b, c])
+                }
+                IVal::Tuple4(idx) => {
+                    let [a, b, c, d] = self.expect_tuple4(idx);
+                    let a_digest = self.hash_ptr_val_unsafe(a.val());
+                    let b_digest = self.hash_ptr_val_unsafe(b.val());
+                    let c_digest = self.hash_ptr_val_unsafe(c.val());
+                    let d_digest = self.hash_ptr_val_unsafe(d.val());
+                    let a = GPtr::new(*a.tag(), a_digest);
+                    let b = GPtr::new(*b.tag(), b_digest);
+                    let c = GPtr::new(*c.tag(), c_digest);
+                    let d = GPtr::new(*d.tag(), d_digest);
+                    self.hasher.hash_ptrs(vec![a, b, c, d])
+                }
+                IVal::Compact(idx) => {
+                    let [a, b, c] = self.expect_compact(idx);
+                    let a_digest = self.hash_ptr_val_unsafe(a.val());
+                    let b_digest = self.hash_ptr_val_unsafe(b.val());
+                    let c_digest = self.hash_ptr_val_unsafe(c.val());
+                    self.hasher
+                        .hash_compact(a_digest, *b.tag(), b_digest, c_digest)
+                }
+            };
+            self.z_cache.insert(*ptr_val, Box::new(digest));
+            self.inverse_z_cache.insert(digest, Box::new(*ptr_val));
+            digest
+        }
+    }
+
+    /// Hashes `IVal`s in parallel, consuming chunks of length 256, which is a
+    /// reasonably safe limit. The danger of longer chunks is that the rightmost
+    /// pointers are the ones which are more likely to reach the recursion depth
+    /// limit in `hash_ptr_val_unsafe`. So we move in smaller chunks from left to
+    /// right, populating the `z_cache`, which can rescue `hash_ptr_val_unsafe`
+    /// from deep recursions
+    fn hydrate_z_cache_with_ptr_vals(&self, ptrs: &[&IVal]) {
+        ptrs.chunks(256).for_each(|chunk| {
+            chunk.par_iter().for_each(|ptr| {
+                self.hash_ptr_val_unsafe(ptr);
+            });
+        });
+    }
+
+    /// Hashes enqueued `Ptr` trees in chunks, avoiding deep recursions in
+    /// `hash_ptr_val_unsafe`. Resets the `dehydrated` queue afterwards.
+    pub fn hydrate_z_cache(&self) {
+        self.hydrate_z_cache_with_ptr_vals(&self.dehydrated.load().iter().collect::<Vec<_>>());
+        self.dehydrated.swap(Arc::new(FrozenVec::default()));
+    }
+
+    /// Whether the length of the dehydrated queue is within the safe limit.
+    /// Note: these values are experimental and may be machine dependant.
+    #[inline]
+    fn is_below_safe_threshold(&self) -> bool {
+        if cfg!(debug_assertions) {
+            // not release mode
+            self.dehydrated.load().len() < 443
+        } else {
+            // release mode
+            self.dehydrated.load().len() < 2497
+        }
+    }
+
+    /// Safe version of `hash_ptr_val_unsafe` that doesn't hit a stack overflow
+    /// by precomputing the pointers that need to be hashed in order to hash the
+    /// provided `ptr`
+    pub fn hash_ptr_val(&self, ptr_val: &IVal) -> D {
+        if self.is_below_safe_threshold() {
+            // just run `hash_ptr_val_unsafe` for extra speed when the dehydrated
+            // queue is small enough
+            return self.hash_ptr_val_unsafe(ptr_val);
+        }
+        let mut ptrs_vals: IndexSet<&IVal> = IndexSet::default();
+        let mut stack = vec![ptr_val];
+        macro_rules! feed_loop {
+            ($x:expr) => {
+                if $x.is_compound() {
+                    if self.z_cache.get($x).is_none() {
+                        if ptrs_vals.insert($x) {
+                            stack.push($x);
+                        }
+                    }
+                }
+            };
+        }
+        while let Some(ptr_val) = stack.pop() {
+            match ptr_val {
+                IVal::Atom(..) => (),
+                IVal::Tuple2(idx) => {
+                    for ptr in self.expect_tuple2(*idx) {
+                        feed_loop!(ptr.val())
+                    }
+                }
+                IVal::Tuple3(idx) | IVal::Compact(idx) => {
+                    for ptr in self.expect_tuple3(*idx) {
+                        feed_loop!(ptr.val())
+                    }
+                }
+                IVal::Tuple4(idx) => {
+                    for ptr in self.expect_tuple4(*idx) {
+                        feed_loop!(ptr.val())
+                    }
+                }
+            }
+        }
+        ptrs_vals.reverse();
+        self.hydrate_z_cache_with_ptr_vals(&ptrs_vals.into_iter().collect::<Vec<_>>());
+        // now it's okay to call `hash_ptr_val_unsafe`
+        self.hash_ptr_val_unsafe(ptr_val)
+    }
+
+    #[inline]
+    pub fn hash_ptr(&self, ptr: &IPtr<T>) -> GPtr<T, D> {
+        GPtr::new(*ptr.tag(), self.hash_ptr_val(ptr.val()))
+    }
+
+    #[inline]
+    pub fn add_comm(&self, digest: D, secret: D, payload: IPtr<T>) {
+        self.comms.insert(digest, Box::new((secret, payload)));
+    }
+
+    pub fn hide(&self, secret: D, payload: IPtr<T>) -> (D, GPtr<T, D>) {
+        let z = self.hash_ptr(&payload);
+        let digest = self.hasher.hash_commitment(secret, z);
+        self.add_comm(digest, secret, payload);
+        (digest, z)
+    }
+
+    #[inline]
+    pub fn open(&self, digest: &D) -> Option<&(D, IPtr<T>)> {
+        self.comms.get(digest)
+    }
+
+    #[inline]
+    pub fn can_open(&self, digest: &D) -> bool {
+        self.open(digest).is_some()
+    }
+
+    /// `IPtr` equality w.r.t. their content-addressed versions
+    #[inline]
+    pub fn ptr_eq(&self, a: &IPtr<T>, b: &IPtr<T>) -> bool {
+        self.hash_ptr(a) == self.hash_ptr(b)
+    }
+
+    #[inline]
+    pub fn intern_atom(&self, tag: T, d: D) -> IPtr<T> {
+        IPtr::new(tag, IVal::Atom(self.intern_digest(d).0))
+    }
+
+    /// Creates an atom pointer from a ZPtr, with its hash. Hashing
+    /// such pointer will result on the same original ZPtr
+    #[inline]
+    pub fn opaque(&self, z: GPtr<T, D>) -> IPtr<T> {
+        let (tag, value) = z.into_parts();
+        self.intern_atom(tag, value)
+    }
+
+    #[inline]
+    pub fn to_ptr_val(&self, digest: &D) -> IVal {
+        self.inverse_z_cache
+            .get(digest)
+            .cloned()
+            .unwrap_or_else(|| IVal::Atom(self.intern_digest(*digest).0))
+    }
+
+    /// Attempts to recover the `Ptr` from `inverse_z_cache`. If the mapping is
+    /// not there, returns the corresponding opaque pointer instead
+    #[inline]
+    pub fn to_ptr(&self, z: &GPtr<T, D>) -> IPtr<T> {
+        GPtr::new(*z.tag(), self.to_ptr_val(z.val()))
+    }
+}

--- a/src/lem/tests/eval_tests.rs
+++ b/src/lem/tests/eval_tests.rs
@@ -1879,7 +1879,7 @@ fn hide_opaque_open_available() {
     let (output, ..) =
         evaluate_simple::<Fr, Coproc<Fr>>(None, expr, s, 10, &dummy_terminal()).unwrap();
 
-    let c = *s.hash_ptr(&output[0]).value();
+    let c = *s.hash_ptr(&output[0]).hash();
     let comm = s.comm(c);
 
     let open = s.intern_lurk_symbol("open");
@@ -1914,7 +1914,7 @@ fn hide_opaque_open_unavailable() {
     let (output, ..) =
         evaluate_simple::<Fr, Coproc<Fr>>(None, expr, s, 10, &dummy_terminal()).unwrap();
 
-    let c = *s.hash_ptr(&output[0]).value();
+    let c = *s.hash_ptr(&output[0]).hash();
 
     let s2 = &Store::<Fr>::default();
     let comm = s.comm(c);
@@ -3433,11 +3433,11 @@ fn test_sym_hash_values() {
 
     // Symbol and keyword scalar hash values are the same as
     // those of the name string consed onto the parent symbol.
-    assert_eq!(cons_z_ptr.value(), sym_z_ptr.value());
-    assert_eq!(cons_z_ptr.value(), key_z_ptr.value());
+    assert_eq!(cons_z_ptr.hash(), sym_z_ptr.hash());
+    assert_eq!(cons_z_ptr.hash(), key_z_ptr.hash());
 
     // Toplevel symbols also have this property, and their parent symbol is the root symbol.
-    assert_eq!(consed_with_root_z_ptr.value(), toplevel_z_ptr.value());
+    assert_eq!(consed_with_root_z_ptr.hash(), toplevel_z_ptr.hash());
 
     // The tags differ though.
     use crate::tag::ExprTag::{Key, Sym};

--- a/src/lem/tests/nivc_steps.rs
+++ b/src/lem/tests/nivc_steps.rs
@@ -6,7 +6,7 @@ use crate::{
     lang::Lang,
     lem::{
         eval::{evaluate, make_cprocs_funcs_from_lang, make_eval_step_from_config, EvalConfig},
-        store::{expect_ptrs, intern_ptrs, Store},
+        store::Store,
         Tag,
     },
     state::user_sym,
@@ -89,14 +89,13 @@ fn test_nivc_steps() {
     let env = cproc_input.pop().unwrap();
     let expr = cproc_input.pop().unwrap();
 
-    let idx = expr.get_index2().unwrap();
-    let [_, args] = expect_ptrs!(store, 2, idx);
+    let idx = expr.get_tuple2_idx().unwrap();
+    let [_, args] = store.expect_tuple2(idx);
     let new_name = user_sym("cproc-dumb-not");
-    let new_expr = intern_ptrs!(
-        store,
+    let new_expr = store.intern_tuple2(
+        [store.intern_symbol(&new_name), *args],
         Tag::Expr(ExprTag::Cproc),
-        store.intern_symbol(&new_name),
-        args
+        None,
     );
 
     // `cproc` can't reduce the altered cproc input (with the wrong name)

--- a/src/lem/tests/stream.rs
+++ b/src/lem/tests/stream.rs
@@ -29,7 +29,7 @@ fn assert_start_stream(
     callable: Ptr,
     arg: Ptr,
     store: &Store<Fr>,
-    expected_result: Ptr,
+    expected_result: &Ptr,
     expected_iterations: &Expect,
 ) -> Vec<Ptr> {
     let (t1, t2) = pair_terminals();
@@ -47,7 +47,7 @@ fn assert_resume_stream(
     input: Vec<Ptr>,
     arg: Ptr,
     store: &Store<Fr>,
-    expected_result: Ptr,
+    expected_result: &Ptr,
     expected_iterations: &Expect,
 ) -> Vec<Ptr> {
     let (t1, t2) = pair_terminals();
@@ -76,21 +76,21 @@ fn test_comm_callable() {
         callable,
         store.num_u64(123),
         &store,
-        store.num_u64(123),
+        &store.num_u64(123),
         expected_iterations,
     );
     let output = assert_resume_stream(
         output,
         store.num_u64(321),
         &store,
-        store.num_u64(444),
+        &store.num_u64(444),
         expected_iterations,
     );
     assert_resume_stream(
         output,
         store.num_u64(111),
         &store,
-        store.num_u64(555),
+        &store.num_u64(555),
         expected_iterations,
     );
 }
@@ -109,21 +109,21 @@ fn test_fun_callable() {
         callable,
         store.num_u64(123),
         &store,
-        store.num_u64(123),
+        &store.num_u64(123),
         expected_iterations,
     );
     let output = assert_resume_stream(
         output,
         store.num_u64(321),
         &store,
-        store.num_u64(444),
+        &store.num_u64(444),
         expected_iterations,
     );
     assert_resume_stream(
         output,
         store.num_u64(111),
         &store,
-        store.num_u64(555),
+        &store.num_u64(555),
         expected_iterations,
     );
 }

--- a/src/proof/tests/nova_tests.rs
+++ b/src/proof/tests/nova_tests.rs
@@ -4,10 +4,7 @@ use std::sync::Arc;
 
 use crate::{
     lang::{Coproc, Lang},
-    lem::{
-        store::{intern_ptrs, Store},
-        tag::Tag,
-    },
+    lem::{store::Store, tag::Tag},
     num::Num,
     state::{user_sym, State, StateRcCell},
     tag::{ExprTag, Op, Op1, Op2},
@@ -3886,7 +3883,7 @@ fn test_prove_call_literal_fun() {
     let empty_env = s.intern_empty_env();
     let args = s.list(vec![s.intern_user_symbol("x")]);
     let body = s.read_with_default_state("(+ x 1)").unwrap();
-    let fun = intern_ptrs!(s, Tag::Expr(ExprTag::Fun), args, body, empty_env, s.dummy());
+    let fun = s.intern_fun(args, body, empty_env);
     let input = s.num_u64(9);
     let expr = s.list(vec![fun, input]);
     let res = s.num_u64(10);

--- a/src/proof/tests/stream.rs
+++ b/src/proof/tests/stream.rs
@@ -56,7 +56,7 @@ fn test_continued_proof() {
         expect_eq(frames.len(), expected_iterations);
         let output = &frames.last().unwrap().output;
         let (result, _) = store.fetch_cons(&output[0]).unwrap();
-        assert_eq!(result, store.num_u64(123));
+        assert_eq!(result, &store.num_u64(123));
 
         let (proof, ..) = prover
             .prove_from_frames(&pp, &frames, &store, None)
@@ -78,7 +78,7 @@ fn test_continued_proof() {
         expect_eq(frames.len(), expected_iterations);
         let output = &frames.last().unwrap().output;
         let (result, _) = store.fetch_cons(&output[0]).unwrap();
-        assert_eq!(result, store.num_u64(444));
+        assert_eq!(result, &store.num_u64(444));
 
         let (proof, ..) = prover
             .prove_from_frames(&pp, &frames, &store, base_snark)

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -3,7 +3,7 @@ use lurk_macros::TryFromRepr;
 use proptest_derive::Arbitrary;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::{convert::TryFrom, fmt};
-use strum::{EnumCount, EnumIter};
+use strum::EnumCount;
 
 use crate::field::LurkField;
 
@@ -30,11 +30,12 @@ pub(crate) const EXPR_TAG_INIT: u16 = 0b0000_0000_0000_0000;
     PartialEq,
     Eq,
     Hash,
+    PartialOrd,
+    Ord,
     Serialize_repr,
     Deserialize_repr,
     TryFromRepr,
     EnumCount,
-    EnumIter,
 )]
 #[cfg_attr(not(target_arch = "wasm32"), derive(Arbitrary))]
 #[repr(u16)]
@@ -118,9 +119,10 @@ pub(crate) const CONT_TAG_INIT: u16 = 0b0001_0000_0000_0000;
     PartialEq,
     Eq,
     Hash,
+    PartialOrd,
+    Ord,
     TryFromRepr,
     EnumCount,
-    EnumIter,
 )]
 #[cfg_attr(not(target_arch = "wasm32"), derive(Arbitrary))]
 #[repr(u16)]
@@ -209,14 +211,14 @@ pub(crate) const OP1_TAG_INIT: u16 = 0b0010_0000_0000_0000;
     Clone,
     Debug,
     PartialEq,
-    PartialOrd,
     Eq,
     Hash,
+    PartialOrd,
+    Ord,
     Serialize_repr,
     Deserialize_repr,
     TryFromRepr,
     EnumCount,
-    EnumIter,
 )]
 #[cfg_attr(not(target_arch = "wasm32"), derive(Arbitrary))]
 #[repr(u16)]
@@ -341,14 +343,14 @@ pub(crate) const OP2_TAG_INIT: u16 = 0b0011_0000_0000_0000;
     Clone,
     Debug,
     PartialEq,
-    PartialOrd,
     Eq,
     Hash,
+    PartialOrd,
+    Ord,
     Serialize_repr,
     Deserialize_repr,
     TryFromRepr,
     EnumCount,
-    EnumIter,
 )]
 #[cfg_attr(not(target_arch = "wasm32"), derive(Arbitrary))]
 #[repr(u16)]


### PR DESCRIPTION
`StoreCore` is a data structure that can encode data as DAGs of tagged pointers, which can be content-addressed with a custom hasher. The tag type as well as the digest type are generic.

To accomplish this, all pointer types are now unified in a single type hierarchy.