### PR TITLE
chore: Update Rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
 profile = "default"
-channel = "1.78"
+channel = "1.79"
 targets = [ "wasm32-unknown-unknown" ]
 

--- a/src/coprocessor/trie/mod.rs
+++ b/src/coprocessor/trie/mod.rs
@@ -785,8 +785,7 @@ impl<'a, F: LurkField, const ARITY: usize, const HEIGHT: usize> Trie<'a, F, ARIT
             .iter()
             .zip(preimage_path)
             .rev()
-            .enumerate()
-            .map(|(_i, (path_index, existing_preimage))| {
+            .map(|(path_index, existing_preimage)| {
                 let mut new_preimage = *existing_preimage;
                 new_preimage[*path_index] = value;
                 let new_hash = self.register_hash(new_preimage);


### PR DESCRIPTION
- Updated Rust toolchain version to `1.79` for better development environment
- Simplified logic in `coprocessor/trie/mod.rs` by eliminating redundant `enumerate()` in `zip()` method use.

Companion PR of https://github.com/lurk-lab/arecibo/pull/388
Fixes #1251